### PR TITLE
add deployment config cmd

### DIFF
--- a/bin/wharfie
+++ b/bin/wharfie
@@ -13,7 +13,12 @@ require('yargonaut').style('cyan');
 
 const config = require('../cli/config');
 if (fs.existsSync(process.env.CONFIG_PATH)) {
-  if (process.argv[process.argv.length - 1] !== 'config') {
+  if (
+    !(
+      process.argv[process.argv.length - 1] === 'config' &&
+      process.argv[process.argv.length - 2] === 'wharfie'
+    )
+  ) {
     try {
       config.setConfig(
         JSON.parse(fs.readFileSync(process.env.CONFIG_PATH).toString())

--- a/cli/cmds/deployment.js
+++ b/cli/cmds/deployment.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.command = 'deployment <create|upgrade|delete>';
+exports.command = 'deployment <create|upgrade|delete|config>';
 exports.desc = 'manage the wharfie service deployment';
 exports.builder = function (yargs) {
   return yargs

--- a/cli/cmds/deployment_cmds/create.js
+++ b/cli/cmds/deployment_cmds/create.js
@@ -12,6 +12,7 @@ const deployment_template = require('../../../cloudformation/deployment/wharfie.
 const create = async (development) => {
   const template = deployment_template;
   const stackName = process.env.WHARFIE_DEPLOYMENT_NAME;
+  const defaultParams = [];
 
   const answers = await new Promise((resolve, reject) => {
     inquirer
@@ -21,6 +22,13 @@ const create = async (development) => {
             return acc;
           }
           const p = template.Parameters[key];
+          if (p.Default) {
+            defaultParams.push({
+              ParameterKey: key,
+              ParameterValue: String(p.Default),
+            });
+            return acc;
+          }
           let type = 'input';
           if (p.Type === 'Number') {
             type = 'number';
@@ -72,6 +80,7 @@ const create = async (development) => {
         ParameterKey: 'IsDevelopment',
         ParameterValue: String(development),
       },
+      ...defaultParams,
       ...(development
         ? []
         : [{ ParameterKey: 'GitSha', ParameterValue: version }]),

--- a/lambdas/lib/cloudformation/index.js
+++ b/lambdas/lib/cloudformation/index.js
@@ -200,7 +200,7 @@ class CloudFormation {
    * @param {import("@aws-sdk/client-cloudformation").DescribeStacksInput} params - CloudFormation getTemplate params
    * @returns {Promise<import("@aws-sdk/client-cloudformation").DescribeStacksOutput>} -
    */
-  async DescribeStacks(params) {
+  async describeStacks(params) {
     return await this.cloudformation.send(
       new AWS.DescribeStacksCommand(params)
     );

--- a/lambdas/migrations/versions/0.0.0.js
+++ b/lambdas/migrations/versions/0.0.0.js
@@ -18,7 +18,7 @@ async function up(_resource, event, context) {
   if (!resource) throw new Error('resource does not exist');
   const cloudformation = new CloudFormation({ region: process.env.AWS_REGION });
 
-  const t = await cloudformation.DescribeStacks({
+  const t = await cloudformation.describeStacks({
     StackName: resource.resource_id,
   });
   if (!t || !t.Stacks)


### PR DESCRIPTION
adds `wharfie deployment config` which allows for modifying deployment configuration options outside of a normal upgrade cycle. This also removes prompting for any of config with defaults on create/upgrade.