### PR TITLE
allow resources to occupy the root of an s3 bucket

### DIFF
--- a/cli/cmds/project_cmds/destroy.js
+++ b/cli/cmds/project_cmds/destroy.js
@@ -69,6 +69,7 @@ const destroy = async (path, environmentName) => {
     return;
   }
   process.stdout.write(ansiEscapes.cursorUp(1) + ansiEscapes.eraseLine);
+  process.stdout.write(ansiEscapes.cursorUp(1) + ansiEscapes.eraseLine);
   displayInfo(`destroying wharfie project ${project.name}...`);
 
   const multibar = monitorProjectDestroyReconcilables(projectResources);

--- a/lambdas/lib/s3.js
+++ b/lambdas/lib/s3.js
@@ -174,14 +174,14 @@ class S3 {
   parseS3Uri(uri) {
     if (typeof uri !== 'string')
       throw new TypeError(`uri (${uri}) is not a string`);
-    const match = uri.match(/^s3:\/\/([^/]+)\/(.+?)(\/*)$/);
-    if (!match) throw new Error(uri + ' is not of form s3://bucket/key');
-    const trailingSlashes = match[3];
-    const key = match[2];
+    const match = uri.match(/^s3:\/\/([^/]+)\/(.+?)*(\/*)$/);
+    if (!match)
+      throw new Error(uri + ' is not of form s3://bucket/key or s3://bucket/');
+    const parts = uri.split('//')[1].split('/');
     return {
-      bucket: match[1],
-      prefix: key + trailingSlashes,
-      arn: `arn:aws:s3:::${match[1]}/${key + trailingSlashes}`,
+      bucket: parts[0],
+      prefix: parts.slice(1).join('/'),
+      arn: `arn:aws:s3:::${parts[0]}/${parts.slice(1).join('/')}`,
     };
   }
 

--- a/test/lib/s3.test.js
+++ b/test/lib/s3.test.js
@@ -145,6 +145,27 @@ describe('tests for S3', () => {
     );
   });
 
+  it('parseS3Uri throws on unterminated bucket uri', () => {
+    expect.assertions(1);
+    const s3 = new S3({ region: 'us-east-1' });
+    expect(() =>
+      s3.parseS3Uri('s3://example-bucket')
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"s3://example-bucket is not of form s3://bucket/key or s3://bucket/"`
+    );
+  });
+
+  it('parseS3Uri works with bucket only', () => {
+    expect.assertions(1);
+    const s3 = new S3({});
+    const result = s3.parseS3Uri('s3://example-bucket/');
+    expect(result).toStrictEqual({
+      bucket: 'example-bucket',
+      prefix: '',
+      arn: 'arn:aws:s3:::example-bucket/',
+    });
+  });
+
   it('deletePath', async () => {
     expect.assertions(10);
     AWS.S3Mock.on(AWS.ListObjectsV2Command)
@@ -217,14 +238,6 @@ describe('tests for S3', () => {
           ],
         },
       }
-    );
-  });
-
-  it('parseS3Uri throws on invalid uri', () => {
-    expect.assertions(1);
-    const s3 = new S3({});
-    expect(() => s3.parseS3Uri('s3:00000')).toThrowErrorMatchingInlineSnapshot(
-      `"s3:00000 is not of form s3://bucket/key"`
     );
   });
 


### PR DESCRIPTION
some sources might use an entire s3 bucket, an example of this https://registry.opendata.aws/noaa-gsod/ which uses all of the s3://noaa-gsod-pds/ bucket