### PR TITLE
fix hard edges

### DIFF
--- a/lambdas/lib/actor/resources/base-resource-group.js
+++ b/lambdas/lib/actor/resources/base-resource-group.js
@@ -1,5 +1,6 @@
 import BaseResource from './base-resource.js';
 import Reconcilable from './reconcilable.js';
+import { withResourceScope } from './resource-scope.js';
 
 /**
  * @typedef BaseResourceGroupOptions
@@ -9,18 +10,49 @@ import Reconcilable from './reconcilable.js';
  * @property {Reconcilable[]} [dependsOn] - dependsOn.
  * @property {Object<string, any> & import('../typedefs.js').SharedProperties} properties - properties.
  * @property {Object<string, BaseResource | BaseResourceGroup>} [resources] - resources.
+ * @property {any} [stateDB] - Scoped state store.
+ * @property {import('node:events').EventEmitter} [emitter] - Scoped telemetry emitter.
  */
 class BaseResourceGroup extends BaseResource {
   /**
    * @param {BaseResourceGroupOptions} options - BaseResourceGroup Class Options
    */
-  constructor({ name, parent, status, dependsOn = [], properties, resources }) {
-    super({ name, parent, status, dependsOn, properties });
+  constructor({
+    name,
+    parent,
+    status,
+    dependsOn = [],
+    properties,
+    resources,
+    stateDB,
+    emitter,
+  }) {
+    super({
+      name,
+      parent,
+      status,
+      dependsOn,
+      properties,
+      stateDB,
+      emitter,
+    });
     this.resources = resources;
 
     if (!this.resources) {
       this.resources = {};
-      this.addResources(this._defineGroupResources(this.getName()));
+      this.addResources(
+        withResourceScope(
+          {
+            stateDB: this.getStateDB(),
+            emitter: this.getEmitter(),
+          },
+          () => this._defineGroupResources(this.getName()),
+        ),
+      );
+    } else {
+      Object.values(this.resources).forEach((resource) => {
+        this._inheritResourceScope(resource);
+      });
     }
   }
 
@@ -34,11 +66,79 @@ class BaseResourceGroup extends BaseResource {
 
   /**
    * @param {BaseResource | BaseResourceGroup} resource - resource.
+   * @returns {void} - Result.
+   */
+  _inheritResourceScope(resource) {
+    if (typeof resource.setStateDB === 'function') {
+      resource.setStateDB(this.getStateDB());
+    }
+
+    const previousEmitter =
+      typeof resource.getEmitter === 'function' ? resource.getEmitter() : null;
+    if (typeof resource.setEmitter === 'function') {
+      resource.setEmitter(this.getEmitter());
+    }
+
+    if (
+      previousEmitter &&
+      previousEmitter !== this.getEmitter() &&
+      typeof resource.dispatchStatusEvent === 'function'
+    ) {
+      resource.dispatchStatusEvent();
+    }
+  }
+
+  /**
+   * @param {any} stateDB - stateDB.
+   * @returns {this} - Result.
+   */
+  setStateDB(stateDB) {
+    super.setStateDB(stateDB);
+    this.getResources().forEach((resource) => {
+      if (typeof resource.setStateDB === 'function') {
+        resource.setStateDB(this.getStateDB());
+      }
+    });
+    return this;
+  }
+
+  /**
+   * @param {import('node:events').EventEmitter | undefined} emitter - emitter.
+   * @returns {this} - Result.
+   */
+  setEmitter(emitter) {
+    const previousEmitter = this.getEmitter();
+    super.setEmitter(emitter);
+    this.getResources().forEach((resource) => {
+      const childPreviousEmitter =
+        typeof resource.getEmitter === 'function'
+          ? resource.getEmitter()
+          : null;
+      if (typeof resource.setEmitter === 'function') {
+        resource.setEmitter(this.getEmitter());
+      }
+      if (
+        childPreviousEmitter &&
+        childPreviousEmitter !== this.getEmitter() &&
+        typeof resource.dispatchStatusEvent === 'function'
+      ) {
+        resource.dispatchStatusEvent();
+      }
+    });
+    if (previousEmitter !== this.getEmitter()) {
+      this.dispatchStatusEvent();
+    }
+    return this;
+  }
+
+  /**
+   * @param {BaseResource | BaseResourceGroup} resource - resource.
    */
   addResource(resource) {
     if (this.resources[resource.name]) {
       throw new Error(`Resource with name ${resource.name} already exists`);
     }
+    this._inheritResourceScope(resource);
     this.resources[resource.name] = resource;
   }
 

--- a/lambdas/lib/actor/resources/base-resource.js
+++ b/lambdas/lib/actor/resources/base-resource.js
@@ -4,6 +4,7 @@ import stateStore from '../../db/state/store.js';
 import Secret from '../lib/secret.js';
 import { isEqual } from 'es-toolkit';
 import { diff } from '../../json-diff.js';
+import { getCurrentResourceScope } from './resource-scope.js';
 
 /**
  * @typedef BaseResourceOptions
@@ -12,16 +13,44 @@ import { diff } from '../../json-diff.js';
  * @property {Reconcilable.Status} [status] - status.
  * @property {Reconcilable[]} [dependsOn] - dependsOn.
  * @property {Object<string, any> & import('../typedefs.js').SharedProperties} properties - properties.
+ * @property {StateStore} [stateDB] - Scoped state store.
+ * @property {import('node:events').EventEmitter} [emitter] - Scoped telemetry emitter.
  */
 class BaseResource extends Reconcilable {
   /**
    * @param {BaseResourceOptions} options - BaseResource Class Options
    */
-  constructor({ name, parent = '', status, dependsOn = [], properties }) {
-    super({ name, status, dependsOn });
+  constructor({
+    name,
+    parent = '',
+    status,
+    dependsOn = [],
+    properties,
+    stateDB,
+    emitter,
+  }) {
+    super({ name, status, dependsOn, emitter });
+    const resourceScope = getCurrentResourceScope();
     this.parent = parent;
     this.resourceType = this.constructor.name;
     this.properties = properties || {};
+    this.stateDB = stateDB ?? resourceScope?.stateDB ?? BaseResource.stateDB;
+  }
+
+  /**
+   * @returns {StateStore} - Result.
+   */
+  getStateDB() {
+    return this.stateDB || BaseResource.stateDB;
+  }
+
+  /**
+   * @param {StateStore | undefined} stateDB - stateDB.
+   * @returns {this} - Result.
+   */
+  setStateDB(stateDB) {
+    this.stateDB = stateDB ?? BaseResource.stateDB;
+    return this;
   }
 
   /**
@@ -212,25 +241,25 @@ class BaseResource extends Reconcilable {
   }
 
   async save() {
-    await BaseResource.stateDB.putResource(this);
+    await this.getStateDB().putResource(this);
   }
 
   /**
    * @returns {Promise<Reconcilable.Status?>} - Result.
    */
   async getStatus() {
-    return await BaseResource.stateDB.getResourceStatus(this);
+    return await this.getStateDB().getResourceStatus(this);
   }
 
   async saveStatus() {
-    await BaseResource.stateDB.putResourceStatus(this);
+    await this.getStateDB().putResourceStatus(this);
   }
 
   /**
    * @returns {Promise<import('../typedefs.js').SerializedBaseResource?>} - Result.
    */
   async fetchStoredData() {
-    return await BaseResource.stateDB.getResource(this);
+    return await this.getStateDB().getResource(this);
   }
 
   /**
@@ -243,7 +272,7 @@ class BaseResource extends Reconcilable {
   }
 
   async delete() {
-    await BaseResource.stateDB.deleteResource(this);
+    await this.getStateDB().deleteResource(this);
   }
 }
 /**

--- a/lambdas/lib/actor/resources/builds/actor-system.js
+++ b/lambdas/lib/actor/resources/builds/actor-system.js
@@ -6,6 +6,7 @@ import SeaBuild from './sea-build.js';
 import MacOSBinarySignature from './macos-binary-signature.js';
 import cli from './actor-system-cli/index.js';
 import { createActorSystemResources } from '../../runtime/resources.js';
+import { withResourceScope } from '../resource-scope.js';
 
 import path from 'node:path';
 
@@ -52,6 +53,8 @@ import path from 'node:path';
  * @property {WharfieActorSystemProperties & import('../../typedefs.js').SharedProperties} properties - properties.
  * @property {import('../reconcilable.js').default[]} [dependsOn] - dependsOn.
  * @property {Object<string, import('../base-resource.js').default | import('../base-resource-group.js').default>} [resources] - resources.
+ * @property {any} [stateDB] - Scoped state store.
+ * @property {import('node:events').EventEmitter} [emitter] - Scoped telemetry emitter.
  */
 
 class ActorSystem extends BuildResourceGroup {
@@ -66,6 +69,8 @@ class ActorSystem extends BuildResourceGroup {
     resources,
     dependsOn,
     functions = [],
+    stateDB,
+    emitter,
   }) {
     const propertiesWithDefaults = Object.assign(
       {},
@@ -79,12 +84,22 @@ class ActorSystem extends BuildResourceGroup {
       properties: propertiesWithDefaults,
       resources,
       dependsOn: [...(dependsOn ?? [])],
+      stateDB,
+      emitter,
     });
     this.functions = functions;
     /** @type {Promise<{ resources: any, close: () => Promise<void> }> | null} */
     this._runtimeResourcesPromise = null;
     // normally _defineGroupResources is used but this is a workaround to make sure this.functions is set before defining things
-    this.addResources(this.defineActorSystemResources(parent));
+    this.addResources(
+      withResourceScope(
+        {
+          stateDB: this.getStateDB(),
+          emitter: this.getEmitter(),
+        },
+        () => this.defineActorSystemResources(parent),
+      ),
+    );
     // @ts-ignore
     global[Symbol.for(`${this.getName()}`)] = this.run.bind(this);
   }
@@ -159,8 +174,10 @@ class ActorSystem extends BuildResourceGroup {
         `Unknown function '${functionName}'. Available: ${available || '(none)'}`,
       );
     }
-    const ctx = await this.createContext(context);
-    return await fn.fn(event, ctx);
+    const systemResources = await this.getRuntimeResources();
+    return await fn.fn(event, context, {
+      baseResources: systemResources,
+    });
   }
 
   /**
@@ -168,10 +185,19 @@ class ActorSystem extends BuildResourceGroup {
    * @returns {Promise<void>} - Result.
    */
   async closeRuntimeResources() {
-    if (!this._runtimeResourcesPromise) return;
-    const { close } = await this._ensureRuntimeResources();
-    await close();
-    this._runtimeResourcesPromise = null;
+    if (this._runtimeResourcesPromise) {
+      const { close } = await this._ensureRuntimeResources();
+      await close();
+      this._runtimeResourcesPromise = null;
+    }
+
+    await Promise.all(
+      this.functions.map((fn) =>
+        typeof fn.closeRuntimeResources === 'function'
+          ? fn.closeRuntimeResources()
+          : Promise.resolve(),
+      ),
+    );
   }
 
   /**

--- a/lambdas/lib/actor/resources/builds/build-resource-group.js
+++ b/lambdas/lib/actor/resources/builds/build-resource-group.js
@@ -8,14 +8,34 @@ import BaseResourceGroup from '../base-resource-group.js';
  * @property {import('../reconcilable.js').default[]} [dependsOn] - dependsOn.
  * @property {import('../../typedefs.js').SharedProperties} properties - properties.
  * @property {Object<string, import('../base-resource.js').default | BaseResourceGroup>} [resources] - resources.
+ * @property {any} [stateDB] - Scoped state store.
+ * @property {import('node:events').EventEmitter} [emitter] - Scoped telemetry emitter.
  */
 
 class BuildResource extends BaseResourceGroup {
   /**
    * @param {BuildResourceOptions} options - options.
    */
-  constructor({ name, parent, status, dependsOn, properties, resources }) {
-    super({ name, parent, status, dependsOn, properties, resources });
+  constructor({
+    name,
+    parent,
+    status,
+    dependsOn,
+    properties,
+    resources,
+    stateDB,
+    emitter,
+  }) {
+    super({
+      name,
+      parent,
+      status,
+      dependsOn,
+      properties,
+      resources,
+      stateDB,
+      emitter,
+    });
   }
 
   async initializeEnvironment() {}
@@ -30,7 +50,7 @@ class BuildResource extends BaseResourceGroup {
     ) {
       return;
     }
-    super.reconcile();
+    return await super.reconcile();
   }
 }
 

--- a/lambdas/lib/actor/resources/builds/build-resource.js
+++ b/lambdas/lib/actor/resources/builds/build-resource.js
@@ -7,14 +7,32 @@ import BaseResource from '../base-resource.js';
  * @property {import('../reconcilable.js').default.Status} [status] - status.
  * @property {import('../reconcilable.js').default[]} [dependsOn] - dependsOn.
  * @property {import('../../typedefs.js').SharedProperties} properties - properties.
+ * @property {any} [stateDB] - Scoped state store.
+ * @property {import('node:events').EventEmitter} [emitter] - Scoped telemetry emitter.
  */
 
 class BuildResource extends BaseResource {
   /**
    * @param {BuildResourceOptions} options - options.
    */
-  constructor({ name, parent, status, dependsOn, properties }) {
-    super({ name, parent, status, dependsOn, properties });
+  constructor({
+    name,
+    parent,
+    status,
+    dependsOn,
+    properties,
+    stateDB,
+    emitter,
+  }) {
+    super({
+      name,
+      parent,
+      status,
+      dependsOn,
+      properties,
+      stateDB,
+      emitter,
+    });
   }
 
   async initializeEnvironment() {}
@@ -29,7 +47,7 @@ class BuildResource extends BaseResource {
     ) {
       return;
     }
-    super.reconcile();
+    return await super.reconcile();
   }
 }
 

--- a/lambdas/lib/actor/resources/builds/function-resource.js
+++ b/lambdas/lib/actor/resources/builds/function-resource.js
@@ -5,6 +5,7 @@ import BuildResource from './build-resource.js';
 import paths from '../../../paths.js';
 import { build } from '../../../esbuild.js';
 import { installForTarget } from './lib/install-deps.js';
+import { normalizeExternalDependencies } from './lib/resolve-externals.js';
 
 import { dirname, join } from 'node:path';
 import { promises, existsSync, writeFileSync } from 'node:fs';
@@ -15,6 +16,12 @@ import { buffer as streamToBuffer } from 'node:stream/consumers';
  * @typedef ExternalDependencyDescription
  * @property {string} name - name.
  * @property {string} version - version.
+ */
+
+/**
+ * @typedef ExternalDependencyInput
+ * @property {string} name - name.
+ * @property {string} [version] - version.
  */
 
 /**
@@ -42,8 +49,9 @@ import { buffer as streamToBuffer } from 'node:stream/consumers';
  * @property {string} functionName - functionName.
  * @property {FunctionEntrypoint} entrypoint - entrypoint.
  * @property {BuildTarget | function(): BuildTarget} buildTarget - buildTarget.
- * @property {ExternalDependencyDescription[]} [external] - external.
+ * @property {(string | ExternalDependencyInput)[]} [external] - external.
  * @property {Object<string,string>} [environmentVariables] - environmentVariables.
+ * @property {Record<string, any>} [resources] - Function-scoped runtime resource specs.
  * @property {Object<string,string> | function(): Object<string,string>} [assets] - assets.
  */
 
@@ -66,6 +74,15 @@ class FunctionResource extends BuildResource {
       FunctionResource.DefaultProperties,
       properties,
     );
+    const normalizedExternal = normalizeExternalDependencies(
+      propertiesWithDefaults.external,
+      propertiesWithDefaults.entrypoint?.path,
+    );
+    if (normalizedExternal) {
+      propertiesWithDefaults.external = normalizedExternal;
+    } else {
+      delete propertiesWithDefaults.external;
+    }
     super({
       name,
       parent,
@@ -83,7 +100,6 @@ class FunctionResource extends BuildResource {
    * @returns {Promise<string>} - Result.
    */
   async esbuild() {
-    console.log('HELLO');
     const entryCode = `
       import { ${
         this.get('entrypoint').export || 'default'
@@ -100,6 +116,7 @@ class FunctionResource extends BuildResource {
       write: false,
       bundle: true,
       platform: 'node',
+      format: 'cjs',
       minify: true,
       keepNames: false,
       sourcemap: 'inline',
@@ -116,6 +133,8 @@ class FunctionResource extends BuildResource {
         : FunctionResource.REQUIRED_UNUSED_EXTERNALS,
       define: {
         __WILLEM_BUILD_RECONCILE_TERMINATOR: '1', // injects this variable definition into the global scope
+        'import.meta.url': '__filename',
+        'import.meta.dirname': '__dirname',
       },
     });
 
@@ -172,6 +191,7 @@ class FunctionResource extends BuildResource {
     const assetDescription = JSON.stringify({
       codeBundle,
       externalsTar,
+      resourceSpecs: this.get('resources', {}),
     });
     const singleExecutableAssetPath = join(
       FunctionResource.TEMP_ASSET_PATH,
@@ -191,6 +211,7 @@ class FunctionResource extends BuildResource {
 
 FunctionResource.DefaultProperties = {
   environmentVariables: {},
+  resources: {},
   assets: {},
 };
 FunctionResource.BUILD_DIR = join(paths.temp, 'builds');

--- a/lambdas/lib/actor/resources/builds/function.js
+++ b/lambdas/lib/actor/resources/builds/function.js
@@ -1,8 +1,10 @@
 import { getAsset } from 'node:sea';
-import worker from '../../../code-execution/worker.js';
+import path from 'node:path';
 import { brotliDecompressSync } from 'node:zlib';
 
-import path from 'node:path';
+import worker from '../../../code-execution/worker.js';
+import { createActorSystemResources } from '../../runtime/resources.js';
+import { normalizeExternalDependencies } from './lib/resolve-externals.js';
 
 /**
  * @typedef ExternalDependencyDescription
@@ -11,9 +13,16 @@ import path from 'node:path';
  */
 
 /**
+ * @typedef ExternalDependencyInput
+ * @property {string} name - name.
+ * @property {string} [version] - version.
+ */
+
+/**
  * @typedef FunctionProperties
- * @property {ExternalDependencyDescription[]} [external] - external.
+ * @property {(string | ExternalDependencyInput)[]} [external] - external.
  * @property {Object<string,string>} [environmentVariables] - environmentVariables.
+ * @property {Record<string, any>} [resources] - Function-scoped runtime resources or specs.
  */
 
 /**
@@ -35,11 +44,24 @@ import path from 'node:path';
  */
 
 /**
+ * @typedef FunctionInvokeOptions
+ * @property {Record<string, any>} [baseResources] - Base resources to merge beneath function-scoped resources.
+ */
+
+/**
  * @param {any} v - v.
  * @returns {boolean} - Result.
  */
 function isObject(v) {
   return !!v && typeof v === 'object';
+}
+
+/**
+ * @param {Record<string, any> | null | undefined} resources - resources.
+ * @returns {boolean} - Result.
+ */
+function hasAnyResources(resources) {
+  return !!resources && Object.keys(resources).length > 0;
 }
 
 /**
@@ -92,12 +114,96 @@ class Function {
     if (!name) {
       throw new Error('Function expects a name as an argument');
     }
-    const { external, environmentVariables } = properties;
+    const { external, environmentVariables, resources } = properties;
+    const normalizedExternal = normalizeExternalDependencies(
+      external,
+      entrypoint?.path,
+    );
     this.name = name;
     this.entrypoint = entrypoint;
     this.properties = {
-      external,
-      environmentVariables,
+      ...(normalizedExternal ? { external: normalizedExternal } : {}),
+      ...(environmentVariables ? { environmentVariables } : {}),
+      ...(resources ? { resources } : {}),
+    };
+    /** @type {Promise<{ resources: Record<string, any>, close: () => Promise<void> }> | null} */
+    this._runtimeResourcesPromise = null;
+  }
+
+  /**
+   * Lazily create and cache runtime resources from `properties.resources`.
+   * @returns {Promise<{ resources: Record<string, any>, close: () => Promise<void> }>} - Result.
+   */
+  async _ensureRuntimeResources() {
+    if (this._runtimeResourcesPromise) return this._runtimeResourcesPromise;
+
+    const specs = isObject(this.properties?.resources)
+      ? this.properties.resources
+      : {};
+
+    if (!hasAnyResources(specs)) {
+      this._runtimeResourcesPromise = Promise.resolve({
+        resources: {},
+        close: async () => {},
+      });
+      return this._runtimeResourcesPromise;
+    }
+
+    this._runtimeResourcesPromise = createActorSystemResources(specs);
+    return this._runtimeResourcesPromise;
+  }
+
+  /**
+   * Get the instantiated runtime resources for this Function.
+   * @returns {Promise<Record<string, any>>} - Result.
+   */
+  async getRuntimeResources() {
+    const { resources } = await this._ensureRuntimeResources();
+    return resources;
+  }
+
+  /**
+   * Close all cached runtime resources (best-effort).
+   * @returns {Promise<void>} - Result.
+   */
+  async closeRuntimeResources() {
+    if (!this._runtimeResourcesPromise) return;
+    const { close } = await this._ensureRuntimeResources();
+    await close();
+    this._runtimeResourcesPromise = null;
+  }
+
+  /**
+   * Build a context object for function invocation.
+   *
+   * Precedence is: base resources < function resources < caller-provided resources.
+   * @param {any} [context] - context.
+   * @param {Record<string, any>} [baseResources] - baseResources.
+   * @returns {Promise<any>} - Result.
+   */
+  async createContext(context = {}, baseResources = {}) {
+    const functionResources = await this.getRuntimeResources();
+    const overrideResources = isObject(context?.resources)
+      ? context.resources
+      : {};
+    const mergedResources = {
+      ...(baseResources || {}),
+      ...(functionResources || {}),
+      ...(overrideResources || {}),
+    };
+
+    const shouldAttachResources =
+      hasAnyResources(mergedResources) ||
+      (isObject(context) &&
+        Object.prototype.hasOwnProperty.call(context, 'resources'));
+
+    if (!shouldAttachResources) {
+      return context;
+    }
+
+    return {
+      ...context,
+      resources: mergedResources,
     };
   }
 
@@ -107,6 +213,9 @@ class Function {
    * If `options.resources` (or `context.resources.{db,queue,objectStorage}`) contains
    * in-process resource client instances, they are exposed to the worker via an RPC
    * bridge, and the worker sees them as `context.resources.*` proxies.
+   *
+   * Bundled functions can also embed `resourceSpecs`; Wharfie will instantiate those
+   * resources per invocation and merge them between host resources and caller overrides.
    * @param {string} name - name.
    * @param {any} event - event.
    * @param {any} context - context.
@@ -127,33 +236,49 @@ class Function {
         ? Buffer.from(externalsTarB64, 'base64')
         : null;
 
-    let rpcResources = options?.resources || null;
-    let safeContext = context;
+    const split = splitContextForWorker(context);
+    const safeContext = split.safeContext;
+    const contextRpcResources = split.rpcResources || {};
 
-    if (rpcResources && Object.keys(rpcResources).length > 0) {
-      // Ensure we don't try to structured-clone the client instances inside context.
-      if (isObject(safeContext) && isObject(safeContext.resources)) {
-        const safeRes = { ...safeContext.resources };
-        for (const k of Object.keys(rpcResources)) delete safeRes[k];
-        safeContext = { ...safeContext, resources: safeRes };
+    /** @type {{ resources: Record<string, any>, close: () => Promise<void> } | null} */
+    let scopedResources = null;
+    const bundledResourceSpecs = isObject(assetDescription.resourceSpecs)
+      ? assetDescription.resourceSpecs
+      : null;
+
+    try {
+      if (bundledResourceSpecs && hasAnyResources(bundledResourceSpecs)) {
+        scopedResources =
+          await createActorSystemResources(bundledResourceSpecs);
       }
-    } else {
-      const split = splitContextForWorker(context);
-      safeContext = split.safeContext;
-      rpcResources = split.rpcResources;
+
+      const rpcResources = {
+        ...((options?.resources && isObject(options.resources)
+          ? options.resources
+          : {}) || {}),
+        ...(scopedResources?.resources || {} || {}),
+        ...(contextRpcResources || {}),
+      };
+
+      console.time('WORKER time');
+      await worker.runInSandbox(
+        name,
+        functionCodeString,
+        [event, safeContext],
+        {
+          ...(externalsTar && externalsTar.length > 0 ? { externalsTar } : {}),
+          rpc: hasAnyResources(rpcResources)
+            ? { resources: rpcResources, contextIndex: 1 }
+            : undefined,
+        },
+      );
+      console.timeEnd('WORKER time');
+    } finally {
+      if (scopedResources) {
+        await scopedResources.close();
+      }
+      await worker._destroyWorker();
     }
-
-    console.time('WORKER time');
-    await worker.runInSandbox(name, functionCodeString, [event, safeContext], {
-      ...(externalsTar && externalsTar.length > 0 ? { externalsTar } : {}),
-      rpc:
-        rpcResources && Object.keys(rpcResources).length > 0
-          ? { resources: rpcResources, contextIndex: 1 }
-          : undefined,
-    });
-    console.timeEnd('WORKER time');
-
-    await worker._destroyWorker();
   }
 
   /**
@@ -162,12 +287,17 @@ class Function {
    * This is primarily used by the (single-process) ActorSystem runtime.
    * @param {any} [event] - event.
    * @param {any} [context] - context.
+   * @param {FunctionInvokeOptions} [options] - options.
    * @returns {Promise<any>} - Result.
    */
-  async fn(event = {}, context = {}) {
+  async fn(event = {}, context = {}, options = {}) {
     const entryPath = path.isAbsolute(this.entrypoint.path)
       ? this.entrypoint.path
       : path.resolve(this.entrypoint.path);
+    const invocationContext = await this.createContext(
+      context,
+      options.baseResources || {},
+    );
 
     // CJS: require() exists. ESM: use dynamic import().
     const handler =
@@ -190,7 +320,7 @@ class Function {
     }
 
     // Support both sync and async handlers.
-    const result = candidate(event, context);
+    const result = candidate(event, invocationContext);
     if (result && typeof result.then === 'function') {
       return await result;
     }

--- a/lambdas/lib/actor/resources/builds/lib/resolve-externals.js
+++ b/lambdas/lib/actor/resources/builds/lib/resolve-externals.js
@@ -1,0 +1,174 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+/**
+ * @typedef ExternalDependencyInputObject
+ * @property {string} name - name.
+ * @property {string} [version] - version.
+ */
+
+/**
+ * @typedef ExternalDependencyDescription
+ * @property {string} name - name.
+ * @property {string} version - version.
+ */
+
+/**
+ * @param {string | ExternalDependencyInputObject} external - external.
+ * @returns {ExternalDependencyInputObject} - Result.
+ */
+function normalizeExternalInput(external) {
+  if (typeof external === 'string') {
+    const trimmed = external.trim();
+    if (!trimmed) {
+      throw new TypeError('External dependency spec must not be empty');
+    }
+
+    const versionSeparator = trimmed.lastIndexOf('@');
+    if (versionSeparator > 0) {
+      const name = trimmed.slice(0, versionSeparator).trim();
+      const version = trimmed.slice(versionSeparator + 1).trim();
+      if (name && version) {
+        return { name, version };
+      }
+    }
+
+    return { name: trimmed };
+  }
+
+  if (external && typeof external === 'object') {
+    const name = typeof external.name === 'string' ? external.name.trim() : '';
+    const version =
+      typeof external.version === 'string' ? external.version.trim() : '';
+
+    if (!name) {
+      throw new TypeError('External dependency objects require a name');
+    }
+
+    return version ? { name, version } : { name };
+  }
+
+  throw new TypeError(
+    'External dependencies must be package names or { name, version? } objects',
+  );
+}
+
+/**
+ * @param {string | undefined} basePath - basePath.
+ * @returns {any[]} - Result.
+ */
+function createResolvers(basePath) {
+  const candidates = [
+    basePath ? path.resolve(basePath) : null,
+    path.join(process.cwd(), 'package.json'),
+  ];
+
+  /** @type {string[]} */
+  const resolvedCandidates = [];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate) {
+      resolvedCandidates.push(candidate);
+    }
+  }
+
+  return Array.from(new Set(resolvedCandidates)).map((candidate) =>
+    createRequire(candidate),
+  );
+}
+
+/**
+ * @param {string} packageName - packageName.
+ * @param {any[]} resolvers - resolvers.
+ * @returns {ExternalDependencyDescription} - Result.
+ */
+function resolveInstalledExternal(packageName, resolvers) {
+  /** @type {string[]} */
+  const errors = [];
+
+  for (const resolver of resolvers) {
+    try {
+      const packageJsonPath = resolver.resolve(`${packageName}/package.json`);
+      /** @type {{ version?: string, name?: string }} */
+      const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+      if (typeof manifest.version === 'string' && manifest.version) {
+        return { name: packageName, version: manifest.version };
+      }
+    } catch {
+      // Fall back to resolving the package entrypoint and walking upward.
+    }
+
+    let resolvedEntry;
+    try {
+      resolvedEntry = resolver.resolve(packageName);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(message);
+      continue;
+    }
+
+    let currentDir = path.dirname(resolvedEntry);
+    while (true) {
+      const packageJsonPath = path.join(currentDir, 'package.json');
+      if (existsSync(packageJsonPath)) {
+        /** @type {{ version?: string, name?: string }} */
+        const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+        if (
+          manifest?.name === packageName &&
+          typeof manifest.version === 'string' &&
+          manifest.version
+        ) {
+          return { name: packageName, version: manifest.version };
+        }
+      }
+
+      const parentDir = path.dirname(currentDir);
+      if (parentDir === currentDir) {
+        break;
+      }
+      currentDir = parentDir;
+    }
+  }
+
+  throw new Error(
+    `Could not resolve installed external dependency '${packageName}': ${errors.join(' | ')}`,
+  );
+}
+
+/**
+ * Normalize user-authored external dependency specs into exact `{ name, version }`
+ * descriptors.
+ *
+ * Supported input forms:
+ * - 'lmdb'
+ * - 'sharp@0.34.4'
+ * - { name: 'lmdb' }
+ * - { name: 'sharp', version: '0.34.4' }
+ *
+ * Bare package names are resolved against the installed dependency tree closest to
+ * the function entrypoint, with a fallback to the current Wharfie working tree.
+ * @param {(string | ExternalDependencyInputObject)[] | undefined} externals - externals.
+ * @param {string | undefined} entrypointPath - entrypointPath.
+ * @returns {ExternalDependencyDescription[] | undefined} - Result.
+ */
+export function normalizeExternalDependencies(externals, entrypointPath) {
+  if (!Array.isArray(externals) || externals.length === 0) {
+    return undefined;
+  }
+
+  const resolvers = createResolvers(entrypointPath);
+  return externals.map((external) => {
+    const normalized = normalizeExternalInput(external);
+    if (normalized.version) {
+      return {
+        name: normalized.name,
+        version: normalized.version,
+      };
+    }
+    return resolveInstalledExternal(normalized.name, resolvers);
+  });
+}
+
+export default {
+  normalizeExternalDependencies,
+};

--- a/lambdas/lib/actor/resources/reconcilable.js
+++ b/lambdas/lib/actor/resources/reconcilable.js
@@ -1,4 +1,6 @@
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
+
+import { getCurrentResourceScope } from './resource-scope.js';
 
 class ReconcilableEmitter extends EventEmitter {}
 
@@ -37,13 +39,19 @@ const Events = {
  * @property {string} name - name.
  * @property {StatusEnum} [status] - status.
  * @property {Reconcilable[]} [dependsOn] - dependsOn.
+ * @property {import('node:events').EventEmitter} [emitter] - Scoped telemetry emitter.
  */
 
 class Reconcilable {
   /**
    * @param {ReconcilableOptions} options - Reconcilable Class Options
    */
-  constructor({ name, status = Status.UNPROVISIONED, dependsOn = [] }) {
+  constructor({
+    name,
+    status = Status.UNPROVISIONED,
+    dependsOn = [],
+    emitter,
+  }) {
     if (!name) {
       throw new Error(`${this.constructor.name} requires a name`);
     }
@@ -51,6 +59,8 @@ class Reconcilable {
     this.dependsOn = dependsOn;
     this._MAX_RETRIES = 10;
     this._MAX_RETRY_TIMEOUT_SECONDS = 10;
+    const resourceScope = getCurrentResourceScope();
+    this.emitter = emitter ?? resourceScope?.emitter ?? Reconcilable.Emitter;
     /**
      * @type {Error[]}
      */
@@ -91,6 +101,22 @@ class Reconcilable {
   }
 
   /**
+   * @returns {import('node:events').EventEmitter} - Result.
+   */
+  getEmitter() {
+    return this.emitter || Reconcilable.Emitter;
+  }
+
+  /**
+   * @param {import('node:events').EventEmitter | undefined} emitter - emitter.
+   * @returns {this} - Result.
+   */
+  setEmitter(emitter) {
+    this.emitter = emitter ?? Reconcilable.Emitter;
+    return this;
+  }
+
+  /**
    * @param {StatusEnum} status - status.
    */
   setStatus(status) {
@@ -99,7 +125,7 @@ class Reconcilable {
   }
 
   dispatchStatusEvent() {
-    Reconcilable.Emitter.emit(Events.WHARFIE_STATUS, this.asEvent());
+    this.getEmitter().emit(Events.WHARFIE_STATUS, this.asEvent());
   }
 
   /**
@@ -146,7 +172,7 @@ class Reconcilable {
         break;
       } catch (error) {
         console.trace(error);
-        Reconcilable.Emitter.emit(Events.WHARFIE_ERROR, {
+        this.getEmitter().emit(Events.WHARFIE_ERROR, {
           name: this.name,
           constructor: this.constructor.name,
           error,
@@ -171,7 +197,7 @@ class Reconcilable {
     }
 
     if (!this.isStable()) throw last_error;
-    this._post_reconcile();
+    await this._post_reconcile();
   }
 
   async _destroy() {
@@ -196,7 +222,7 @@ class Reconcilable {
         break;
       } catch (error) {
         // console.trace(error);
-        Reconcilable.Emitter.emit(Events.WHARFIE_ERROR, {
+        this.getEmitter().emit(Events.WHARFIE_ERROR, {
           name: this.name,
           constructor: this.constructor.name,
           error,

--- a/lambdas/lib/actor/resources/resource-scope.js
+++ b/lambdas/lib/actor/resources/resource-scope.js
@@ -1,0 +1,39 @@
+/**
+ * @typedef ResourceScope
+ * @property {any} [stateDB] - Scoped state store.
+ * @property {import('node:events').EventEmitter} [emitter] - Scoped telemetry emitter.
+ */
+
+/** @type {ResourceScope[]} */
+const scopeStack = [];
+
+/**
+ * Run a synchronous callback with a temporary resource scope.
+ *
+ * Child resources created inside the callback inherit the scoped `stateDB`
+ * and `emitter` unless they are configured explicitly.
+ * @template T
+ * @param {ResourceScope} scope - scope.
+ * @param {() => T} fn - fn.
+ * @returns {T} - Result.
+ */
+export function withResourceScope(scope, fn) {
+  scopeStack.push(scope);
+  try {
+    return fn();
+  } finally {
+    scopeStack.pop();
+  }
+}
+
+/**
+ * @returns {ResourceScope | undefined} - Result.
+ */
+export function getCurrentResourceScope() {
+  return scopeStack.length > 0 ? scopeStack[scopeStack.length - 1] : undefined;
+}
+
+export default {
+  withResourceScope,
+  getCurrentResourceScope,
+};

--- a/scratch/test.js
+++ b/scratch/test.js
@@ -1,4 +1,7 @@
-import BaseResource from '../lambdas/lib/actor/resources/base-resource.js';
+// @ts-nocheck
+import { EventEmitter } from 'node:events';
+import path from 'node:path';
+
 import Function from '../lambdas/lib/actor/resources/builds/function.js';
 import ActorSystem from '../lambdas/lib/actor/resources/builds/actor-system.js';
 import Reconcilable from '../lambdas/lib/actor/resources/reconcilable.js';
@@ -10,12 +13,8 @@ import {
   getResources,
   deleteResource,
 } from '../lambdas/lib/db/state/store.js';
-import { createRequire } from 'node:module';
-import path from 'node:path';
 
-const require = createRequire(import.meta.url);
-
-BaseResource.stateDB = {
+const stateDB = {
   putResource,
   putResourceStatus,
   getResource,
@@ -23,27 +22,17 @@ BaseResource.stateDB = {
   getResources,
   deleteResource,
 };
-const lock = require('../package-lock.json');
 
-/**
- * @param {string} pkgName -
- * @returns {string} -
- */
-function getInstalledVersion(pkgName) {
-  // @ts-ignore
-  const entry = lock.packages?.[`node_modules/${pkgName}`];
-  if (!entry || !entry.version)
-    throw new Error(`Could not find ${pkgName} in package-lock.json`);
-  return entry.version;
-}
+const emitter = new EventEmitter();
+
 /**
  *
  */
 async function main() {
-  Reconcilable.Emitter.on(Reconcilable.Events.WHARFIE_STATUS, (event) => {
+  emitter.on(Reconcilable.Events.WHARFIE_STATUS, (event) => {
     // console.log(event)
   });
-  Reconcilable.Emitter.on(Reconcilable.Events.WHARFIE_ERROR, (event) => {
+  emitter.on(Reconcilable.Events.WHARFIE_ERROR, (event) => {
     // console.error(event)
   });
   const __dirname = import.meta.dirname;
@@ -55,15 +44,12 @@ async function main() {
     },
     properties: {
       external: [
-        // --- existing ---
-        { name: 'lmdb', version: getInstalledVersion('lmdb') },
-        { name: 'sharp', version: '0.34.4' },
-        { name: 'sodium-native', version: '5.0.9' },
-        {
-          name: '@duckdb/node-api',
-          version: getInstalledVersion('@duckdb/node-api'),
-        },
-        { name: 'usb', version: '2.13.0' },
+        // Wharfie now resolves installed versions automatically for bare package names.
+        'lmdb',
+        'sharp@0.34.4',
+        'sodium-native@5.0.9',
+        '@duckdb/node-api',
+        'usb@2.13.0',
       ],
       resources: {
         db: {
@@ -85,6 +71,8 @@ async function main() {
   const main = new ActorSystem({
     name: 'main',
     functions: [start],
+    stateDB,
+    emitter,
     properties: {
       targets: [
         {

--- a/test/runtime/resources/build-resource-reconcile.test.js
+++ b/test/runtime/resources/build-resource-reconcile.test.js
@@ -1,0 +1,62 @@
+/* eslint-env jest */
+/* eslint-disable jsdoc/require-jsdoc */
+
+import { describe, expect, it } from '@jest/globals';
+
+import BuildResource from '../../../lambdas/lib/actor/resources/builds/build-resource.js';
+import BuildResourceGroup from '../../../lambdas/lib/actor/resources/builds/build-resource-group.js';
+import Reconcilable from '../../../lambdas/lib/actor/resources/reconcilable.js';
+
+class DelayedBuildResource extends BuildResource {
+  constructor() {
+    super({
+      name: 'delayed-build-resource',
+      properties: {},
+    });
+    this.finished = false;
+  }
+
+  async _reconcile() {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    this.finished = true;
+  }
+
+  async _destroy() {}
+}
+
+class DelayedBuildResourceGroup extends BuildResourceGroup {
+  constructor() {
+    super({
+      name: 'delayed-build-group',
+      properties: {},
+    });
+    this.finished = false;
+  }
+
+  async _reconcile() {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    this.finished = true;
+  }
+
+  async _destroy() {}
+}
+
+describe('build resource reconcile lifecycle', () => {
+  it('awaits BuildResource.reconcile until the resource is stable', async () => {
+    const resource = new DelayedBuildResource();
+
+    await resource.reconcile();
+
+    expect(resource.finished).toBe(true);
+    expect(resource.status).toBe(Reconcilable.Status.STABLE);
+  });
+
+  it('awaits BuildResourceGroup.reconcile until the resource is stable', async () => {
+    const resource = new DelayedBuildResourceGroup();
+
+    await resource.reconcile();
+
+    expect(resource.finished).toBe(true);
+    expect(resource.status).toBe(Reconcilable.Status.STABLE);
+  });
+});

--- a/test/runtime/resources/function-config.test.js
+++ b/test/runtime/resources/function-config.test.js
@@ -1,0 +1,132 @@
+/* eslint-env jest */
+/* eslint-disable jsdoc/require-jsdoc */
+
+import { describe, expect, it } from '@jest/globals';
+import { promises as fsp, existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Function from '../../../lambdas/lib/actor/resources/builds/function.js';
+import FunctionResource from '../../../lambdas/lib/actor/resources/builds/function-resource.js';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * @param {string} packageName - packageName.
+ * @returns {string} - Result.
+ */
+function readInstalledVersion(packageName) {
+  const entryPath = require.resolve(packageName);
+  let currentDir = path.dirname(entryPath);
+
+  while (true) {
+    const packageJsonPath = path.join(currentDir, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+      if (manifest?.name === packageName && manifest?.version) {
+        return manifest.version;
+      }
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
+  }
+
+  throw new Error(`Could not resolve installed version for ${packageName}`);
+}
+
+describe('Function configuration hard edges', () => {
+  it('supports function-scoped resources and auto-resolves bare externals', async () => {
+    const tmp = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'wharfie-function-config-'),
+    );
+    const actorPath = fileURLToPath(
+      new URL('../../fixtures/actors/hello-resources.js', import.meta.url),
+    );
+
+    const fn = new Function({
+      name: 'hello-resources',
+      entrypoint: { path: actorPath, export: 'helloResources' },
+      properties: {
+        external: ['lmdb', { name: '@duckdb/node-api' }],
+        resources: {
+          db: { adapter: 'vanilla', options: { path: tmp } },
+          queue: { adapter: 'vanilla', options: { path: tmp } },
+          objectStorage: { adapter: 'vanilla', options: { path: tmp } },
+        },
+      },
+    });
+
+    expect(fn.properties.external).toEqual([
+      {
+        name: 'lmdb',
+        version: readInstalledVersion('lmdb'),
+      },
+      {
+        name: '@duckdb/node-api',
+        version: readInstalledVersion('@duckdb/node-api'),
+      },
+    ]);
+
+    const result = await fn.fn({ who: 'function-scope' });
+
+    expect(result.who).toBe('function-scope');
+    expect(result.dbRecord?.message).toBe('hello function-scope');
+    expect(result.queueBody).toBe(JSON.stringify({ hello: 'function-scope' }));
+    expect(result.objectBody).toBe('hello function-scope');
+
+    const r1 = await fn.getRuntimeResources();
+    const r2 = await fn.getRuntimeResources();
+
+    expect(r1.db).toBe(r2.db);
+    expect(r1.queue).toBe(r2.queue);
+    expect(r1.objectStorage).toBe(r2.objectStorage);
+
+    await fn.closeRuntimeResources();
+  });
+
+  it('normalizes bare external dependencies for FunctionResource builds too', async () => {
+    const tmp = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'wharfie-function-resource-config-'),
+    );
+    const entryPath = path.join(tmp, 'handler.js');
+
+    await fsp.writeFile(
+      entryPath,
+      ['export function handler() {', "  return 'ok';", '}'].join('\n'),
+      'utf8',
+    );
+
+    const resource = new FunctionResource({
+      name: 'resource-config',
+      properties: {
+        functionName: 'resource-config',
+        entrypoint: { path: entryPath, export: 'handler' },
+        buildTarget: {
+          nodeVersion: process.versions.node.split('.')[0],
+          platform: process.platform,
+          architecture: process.arch,
+        },
+        external: ['lmdb', '@duckdb/node-api'],
+      },
+    });
+
+    expect(resource.get('external')).toEqual([
+      {
+        name: 'lmdb',
+        version: readInstalledVersion('lmdb'),
+      },
+      {
+        name: '@duckdb/node-api',
+        version: readInstalledVersion('@duckdb/node-api'),
+      },
+    ]);
+
+    await fsp.rm(tmp, { recursive: true, force: true });
+  });
+});

--- a/test/runtime/resources/function-run-bundled-resources.test.js
+++ b/test/runtime/resources/function-run-bundled-resources.test.js
@@ -1,0 +1,93 @@
+/* eslint-env jest */
+/* eslint-disable jsdoc/require-jsdoc */
+
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { promises as fsp } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { brotliCompressSync } from 'node:zlib';
+
+import { createActorSystemResources } from '../../../lambdas/lib/actor/runtime/resources.js';
+import sandboxWorker from '../../../lambdas/lib/code-execution/worker.js';
+
+/** @type {Map<string, any>} */
+const seaAssets = new Map();
+
+jest.unstable_mockModule('node:sea', () => ({
+  getAsset: async (/** @type {string} */ name) => {
+    const assetDescription = seaAssets.get(name);
+    if (!assetDescription) {
+      throw new Error(`Unexpected asset request: ${name}`);
+    }
+    return Buffer.from(JSON.stringify(assetDescription), 'utf8');
+  },
+}));
+
+describe('Function.run bundled resource specs', () => {
+  beforeEach(() => {
+    seaAssets.clear();
+  });
+
+  it('instantiates bundled function resource specs when no host resources are provided', async () => {
+    const tmp = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'wharfie-function-run-bundled-'),
+    );
+    const fnName = `bundled-resource-spec-${Date.now()}-${Math.floor(
+      Math.random() * 1e9,
+    )}`;
+
+    const bundleCode = `
+      global[Symbol.for(${JSON.stringify(fnName)})] = async (event, context) => {
+        const who = event?.who || 'world';
+        await context.resources.db.put({
+          tableName: 'bundled-function',
+          keyName: 'id',
+          record: { id: 'greeting', who, message: 'hello ' + who }
+        });
+      };
+    `;
+
+    seaAssets.set(fnName, {
+      codeBundle: brotliCompressSync(Buffer.from(bundleCode, 'utf8')).toString(
+        'base64',
+      ),
+      externalsTar: '',
+      resourceSpecs: {
+        db: { adapter: 'vanilla', options: { path: tmp } },
+      },
+    });
+
+    const { default: Function } =
+      await import('../../../lambdas/lib/actor/resources/builds/function.js');
+
+    try {
+      await Function.run(fnName, { who: 'bundled' }, { requestId: 'req-1' });
+
+      const { resources, close } = await createActorSystemResources({
+        db: { adapter: 'vanilla', options: { path: tmp } },
+      });
+
+      try {
+        if (!resources.db) {
+          throw new Error('db resource not available');
+        }
+        const record = await resources.db.get({
+          tableName: 'bundled-function',
+          keyName: 'id',
+          keyValue: 'greeting',
+        });
+
+        expect(record).toEqual({
+          id: 'greeting',
+          who: 'bundled',
+          message: 'hello bundled',
+        });
+      } finally {
+        await close();
+      }
+    } finally {
+      await sandboxWorker._destroyWorker();
+      sandboxWorker._clearSandboxCache();
+    }
+  });
+});

--- a/test/runtime/resources/resource-scope.test.js
+++ b/test/runtime/resources/resource-scope.test.js
@@ -1,0 +1,149 @@
+/* eslint-env jest */
+/* eslint-disable jsdoc/require-jsdoc */
+
+import { describe, expect, it } from '@jest/globals';
+import EventEmitter from 'node:events';
+
+import BaseResource from '../../../lambdas/lib/actor/resources/base-resource.js';
+import BaseResourceGroup from '../../../lambdas/lib/actor/resources/base-resource-group.js';
+import Reconcilable from '../../../lambdas/lib/actor/resources/reconcilable.js';
+
+class TestLeaf extends BaseResource {
+  async _reconcile() {
+    this._setUNSAFE('reconciled', true);
+  }
+
+  async _destroy() {}
+}
+
+class TestGroup extends BaseResourceGroup {
+  /**
+   * @param {string} parent - parent.
+   * @returns {TestLeaf[]} - Result.
+   */
+  _defineGroupResources(parent) {
+    return [
+      new TestLeaf({
+        name: 'child',
+        parent,
+        properties: {},
+      }),
+    ];
+  }
+}
+
+/**
+ * @returns {{
+ *   calls: { putResource: string[], putResourceStatus: string[] },
+ *   putResource: (resource: BaseResource) => Promise<void>,
+ *   putResourceStatus: (resource: BaseResource) => Promise<void>,
+ *   getResource: () => Promise<undefined>,
+ *   getResourceStatus: () => Promise<undefined>,
+ *   getResources: () => Promise<never[]>,
+ *   deleteResource: () => Promise<void>,
+ * }} - Result.
+ */
+function createStateStore() {
+  const calls = {
+    putResource: /** @type {string[]} */ ([]),
+    putResourceStatus: /** @type {string[]} */ ([]),
+  };
+
+  return {
+    calls,
+    putResource: async (resource) => {
+      calls.putResource.push(resource.getName());
+    },
+    putResourceStatus: async (resource) => {
+      calls.putResourceStatus.push(resource.getName());
+    },
+    getResource: async () => undefined,
+    getResourceStatus: async () => undefined,
+    getResources: async () => [],
+    deleteResource: async () => {},
+  };
+}
+
+describe('resource scope isolation', () => {
+  it('isolates state stores and telemetry emitters per resource tree', async () => {
+    const storeA = createStateStore();
+    const storeB = createStateStore();
+    const emitterA = new EventEmitter();
+    const emitterB = new EventEmitter();
+    /** @type {string[]} */
+    const eventsA = [];
+    /** @type {string[]} */
+    const eventsB = [];
+
+    emitterA.on(Reconcilable.Events.WHARFIE_STATUS, (event) => {
+      eventsA.push(`${event.constructor}:${event.name}:${event.status}`);
+    });
+    emitterB.on(Reconcilable.Events.WHARFIE_STATUS, (event) => {
+      eventsB.push(`${event.constructor}:${event.name}:${event.status}`);
+    });
+
+    const groupA = new TestGroup({
+      name: 'group-a',
+      properties: {},
+      stateDB: storeA,
+      emitter: emitterA,
+    });
+    const groupB = new TestGroup({
+      name: 'group-b',
+      properties: {},
+      stateDB: storeB,
+      emitter: emitterB,
+    });
+
+    const childA = groupA.getResource('child');
+    const childB = groupB.getResource('child');
+
+    expect(groupA.getStateDB()).toBe(storeA);
+    expect(childA.getStateDB()).toBe(storeA);
+    expect(groupB.getStateDB()).toBe(storeB);
+    expect(childB.getStateDB()).toBe(storeB);
+
+    expect(groupA.getEmitter()).toBe(emitterA);
+    expect(childA.getEmitter()).toBe(emitterA);
+    expect(groupB.getEmitter()).toBe(emitterB);
+    expect(childB.getEmitter()).toBe(emitterB);
+
+    await groupA.reconcile();
+    await groupB.reconcile();
+
+    expect(storeA.calls.putResourceStatus).toEqual(
+      expect.arrayContaining(['group-a', 'group-a#child']),
+    );
+    expect(storeA.calls.putResource).toEqual(
+      expect.arrayContaining(['group-a', 'group-a#child']),
+    );
+    expect(storeB.calls.putResourceStatus).toEqual(
+      expect.arrayContaining(['group-b', 'group-b#child']),
+    );
+    expect(storeB.calls.putResource).toEqual(
+      expect.arrayContaining(['group-b', 'group-b#child']),
+    );
+
+    expect(storeA.calls.putResourceStatus.join('|')).not.toContain('group-b');
+    expect(storeA.calls.putResource.join('|')).not.toContain('group-b');
+    expect(storeB.calls.putResourceStatus.join('|')).not.toContain('group-a');
+    expect(storeB.calls.putResource.join('|')).not.toContain('group-a');
+
+    expect(eventsA).toEqual(
+      expect.arrayContaining([
+        'TestGroup:group-a:UNPROVISIONED',
+        'TestLeaf:child:UNPROVISIONED',
+        'TestGroup:group-a:STABLE',
+        'TestLeaf:child:STABLE',
+      ]),
+    );
+    expect(eventsB).toEqual(
+      expect.arrayContaining([
+        'TestGroup:group-b:UNPROVISIONED',
+        'TestLeaf:child:UNPROVISIONED',
+        'TestGroup:group-b:STABLE',
+        'TestLeaf:child:STABLE',
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
- Added scoped resource context so stateDB and telemetry emitter can be injected per resource tree / actor system instead of only mutating global defaults.
- Preserved and instantiated Function.properties.resources, and bundled resourceSpecs into SEA assets so packaged functions can create their own runtime resources.
- Fixed BuildResource.reconcile() and BuildResourceGroup.reconcile() so await reconcile() does not return early.
- Added Wharfie-owned external dependency normalization/version resolution for bare specs like 'lmdb' and '@duckdb/node-api'.
- Updated scratch/test.js to use the new ergonomics and added focused Jest coverage for the new behavior.