### PR TITLE
INVOKE_FUNCTION graph runner

### DIFF
--- a/cli/cmds/ops_cmds/run.js
+++ b/cli/cmds/ops_cmds/run.js
@@ -1,6 +1,8 @@
 import { Command } from 'commander';
 
+import { loadApp } from '../../app/load-app.js';
 import { withOperationsStore } from '../operations-store.js';
+import Action from '../../../lambdas/lib/graph/action.js';
 import { runOperation } from '../../../lambdas/lib/graph/runner.js';
 import {
   displayFailure,
@@ -8,26 +10,131 @@ import {
   displaySuccess,
 } from '../../output/basic.js';
 
+/**
+ * @param {any} appExport - appExport.
+ * @returns {void}
+ */
+function assertRunnableApp(appExport) {
+  if (!appExport || typeof appExport.invoke !== 'function') {
+    throw new Error(
+      'App is not runnable. Expected a default export with invoke(functionName, event, context).',
+    );
+  }
+}
+
+/**
+ * @param {Record<string, any> | undefined} placement - placement.
+ * @returns {string} - Result.
+ */
+function getPlacementMode(placement) {
+  const mode = placement?.mode;
+  if (typeof mode !== 'string' || !mode.trim()) return 'local';
+  return mode.trim().toLowerCase();
+}
+
+/**
+ * @param {import('../../../lambdas/lib/graph/operation.js').default | undefined} operation - operation.
+ * @param {Record<string, string>} fallbackStatuses - fallbackStatuses.
+ * @returns {Array<Record<string, any>>} - Result.
+ */
+function formatActionRows(operation, fallbackStatuses) {
+  if (!operation) {
+    return Object.entries(fallbackStatuses).map(([action_id, status]) => ({
+      action_id,
+      status,
+    }));
+  }
+
+  return operation.getSequentialActionOrder().map((action) => ({
+    action_id: action.id,
+    type: action.type,
+    function_name: action.function_name || '',
+    status: action.status,
+    attempt_count: action.attempt_count || 0,
+  }));
+}
+
 const runCommand = new Command('run')
-  .description(
-    'Execute an operation DAG in-process (placeholder executor: marks actions completed)',
-  )
+  .description('Execute an operation DAG locally against wharfie.app.js')
   .argument('<resource_id>', 'Wharfie resource ID')
   .argument('<operation_id>', 'Operation ID')
-  .action(async (resource_id, operation_id) => {
+  .option('--dir <dir>', 'Directory containing wharfie.app.js', process.cwd())
+  .action(async (resource_id, operation_id, options) => {
+    /** @type {any | undefined} */
+    let appExport;
+
     try {
       await withOperationsStore(async (store) => {
         displayInfo(`Running operation: ${resource_id}#${operation_id}`);
 
         /**
+         * @returns {Promise<any>} - Result.
+         */
+        const ensureRunnableApp = async () => {
+          if (appExport) return appExport;
+          const loaded = await loadApp({ dir: options.dir || process.cwd() });
+          assertRunnableApp(loaded.appExport);
+          appExport = loaded.appExport;
+          return appExport;
+        };
+
+        /**
          * @param {import('../../../lambdas/lib/graph/action.js').default} action - action.
-         * @returns {Promise<boolean>} - Result.
+         * @returns {Promise<{ ok: boolean, outputs?: any }>} - Result.
          */
         const executeAction = async (action) => {
-          // Placeholder executor used for DAG inspection/testing.
-          // The runner will handle status transitions; we just return success.
-          displayInfo(`- ${action.id} (${action.type})`);
-          return true;
+          if (
+            action.type === Action.Type.START ||
+            action.type === Action.Type.FINISH
+          ) {
+            displayInfo(`- ${action.id} (${action.type})`);
+            return { ok: true };
+          }
+
+          if (action.type !== Action.Type.INVOKE_FUNCTION) {
+            throw new Error(
+              `Unsupported action type '${action.type}' for ops run. Only START, FINISH, and INVOKE_FUNCTION are currently executable.`,
+            );
+          }
+
+          if (!action.function_name || !String(action.function_name).trim()) {
+            throw new Error(
+              `INVOKE_FUNCTION action '${action.id}' is missing function_name.`,
+            );
+          }
+
+          const placementMode = getPlacementMode(action.placement);
+          if (placementMode !== 'local' && placementMode !== 'in_process') {
+            throw new Error(
+              `INVOKE_FUNCTION action '${action.id}' requested unsupported placement mode '${placementMode}'. Local execution currently supports only 'local' or 'in_process'.`,
+            );
+          }
+
+          const app = await ensureRunnableApp();
+          const attemptCount = Number(action.attempt_count || 0) + 1;
+          displayInfo(
+            `- ${action.id} (${action.type}:${action.function_name} attempt=${attemptCount})`,
+          );
+
+          const outputs = await app.invoke(
+            action.function_name,
+            action.inputs ?? {},
+            {
+              workflow: {
+                resourceId: action.resource_id,
+                operationId: action.operation_id,
+                actionId: action.id,
+                actionType: action.type,
+                attemptCount,
+                placement: action.placement,
+              },
+            },
+          );
+
+          return {
+            ok: true,
+            outputs,
+          };
         };
 
         const result = await runOperation({
@@ -36,6 +143,15 @@ const runCommand = new Command('run')
           operationId: operation_id,
           executeAction,
         });
+
+        const finalRecords = await store.getRecords(resource_id, operation_id);
+        const finalOperation = finalRecords.operations.find(
+          (operation) => operation.id === operation_id,
+        );
+
+        console.table(
+          formatActionRows(finalOperation, result.finalStatusByActionId),
+        );
 
         if (result.status !== 'COMPLETED') {
           const details = [];
@@ -53,18 +169,14 @@ const runCommand = new Command('run')
         }
 
         displaySuccess(`Executed ${result.executedActionIds.length} actions.`);
-        console.table(
-          Object.entries(result.finalStatusByActionId).map(
-            ([action_id, status]) => ({
-              action_id,
-              status,
-            }),
-          ),
-        );
       });
     } catch (err) {
       displayFailure(err);
       process.exitCode = 1;
+    } finally {
+      if (typeof appExport?.closeRuntimeResources === 'function') {
+        await appExport.closeRuntimeResources();
+      }
     }
   });
 

--- a/lambdas/lib/db/tables/operations.js
+++ b/lambdas/lib/db/tables/operations.js
@@ -95,12 +95,15 @@ const chunk = (arr, size) => {
 };
 
 /**
- * The adapter stores action.status redundantly at the top-level for some backends.
+ * The adapter stores selected status fields redundantly at the top-level for some backends.
  * @param {Record<string, any>} record - record.
  * @returns {Record<string, any>} - Result.
  */
 const normalizeRecord = (record) => {
-  if (record?.data?.record_type === Action.RecordType) {
+  if (
+    record?.data?.record_type === Action.RecordType ||
+    record?.data?.record_type === Operation.RecordType
+  ) {
     return { ...record, status: record.data.status };
   }
   return record;
@@ -121,11 +124,12 @@ const normalizeRecord = (record) => {
  * @property {(resource_id: string, operation_id: string, action_id: string) => Promise<Action | null>} getAction - getAction.
  * @property {(action: { toRecords: () => Record<string, any>[] }) => Promise<void>} putAction -
  * @property {(action: Action, new_status: string, overrideTableName?: string) => Promise<boolean>} updateActionStatus - updateActionStatus.
+ * @property {(operation: Operation, new_status: import('../../graph/operation.js').WharfieOperationStatusEnum, overrideTableName?: string) => Promise<boolean>} updateOperationStatus - updateOperationStatus.
  * @property {(query: { toRecord: () => any }) => Promise<void>} putQuery -
  * @property {(queries: Array<{ toRecord: () => any }>) => Promise<void>} putQueries -
  * @property {(resource_id: string, operation_id: string, action_id: string, query_id: string) => Promise<Query | null>} getQuery - getQuery.
  * @property {(resource_id: string, operation_id: string, action_id: string) => Promise<Query[]>} getQueries - getQueries.
- * @property {(operation: Operation, action_type: import('../../graph/action.js').WharfieActionTypeEnum) => Promise<boolean>} checkActionPrerequisites - checkActionPrerequisites.
+ * @property {(operation: Operation, action_identifier: string) => Promise<boolean>} checkActionPrerequisites - checkActionPrerequisites.
  * @property {(resource_id: string, operation_id?: string) => Promise<{ operations: Operation[]; actions: Action[]; queries: Query[] }>} getRecords -
  */
 
@@ -309,6 +313,75 @@ export function createOperationsTable({ db, tableName } = {}) {
   }
 
   /**
+   * Optimistic status transition for an operation record.
+   * @param {Operation} operation - operation.
+   * @param {import('../../graph/operation.js').WharfieOperationStatusEnum} new_status - new_status.
+   * @param {string} [overrideTableName] - overrideTableName.
+   * @returns {Promise<boolean>} - Result.
+   */
+  async function updateOperationStatus(
+    operation,
+    new_status,
+    overrideTableName = _tableName,
+  ) {
+    const key = `${operation.resource_id}#${operation.id}`;
+
+    const current = await dbClient.get({
+      tableName: overrideTableName,
+      keyName: KEY_NAME,
+      keyValue: operation.resource_id,
+      sortKeyName: SORT_KEY_NAME,
+      sortKeyValue: key,
+      consistentRead: true,
+    });
+
+    if (!current) return false;
+
+    const storedStatus = current.status ?? current?.data?.status;
+    if (storedStatus !== operation.status) return false;
+
+    const nextUpdatedAt = Date.now();
+
+    try {
+      await dbClient.update({
+        tableName: overrideTableName,
+        keyName: KEY_NAME,
+        keyValue: operation.resource_id,
+        sortKeyName: SORT_KEY_NAME,
+        sortKeyValue: key,
+        updates: [
+          { property: ['data', 'status'], propertyValue: new_status },
+          {
+            property: ['data', 'last_updated_at'],
+            propertyValue: nextUpdatedAt,
+          },
+          { property: ['status'], propertyValue: new_status },
+        ],
+        conditions:
+          current.status !== undefined ? [eq('status', storedStatus)] : [],
+      });
+    } catch (error) {
+      if (isConditionalCheckFailed(error)) return false;
+      throw error;
+    }
+
+    const after = await dbClient.get({
+      tableName: overrideTableName,
+      keyName: KEY_NAME,
+      keyValue: operation.resource_id,
+      sortKeyName: SORT_KEY_NAME,
+      sortKeyValue: key,
+      consistentRead: true,
+    });
+
+    const afterStatus = after?.status ?? after?.data?.status;
+    return (
+      afterStatus === new_status &&
+      after?.data?.last_updated_at === nextUpdatedAt
+    );
+  }
+
+  /**
    * @param {Operation} operation - operation.
    * @returns {Promise<void>} - Result.
    */
@@ -445,6 +518,8 @@ export function createOperationsTable({ db, tableName } = {}) {
     const storedStatus = current.status ?? current?.data?.status;
     if (storedStatus !== action.status) return false;
 
+    const nextUpdatedAt = Date.now();
+
     try {
       await dbClient.update({
         tableName: overrideTableName,
@@ -454,6 +529,10 @@ export function createOperationsTable({ db, tableName } = {}) {
         sortKeyValue: key,
         updates: [
           { property: ['data', 'status'], propertyValue: new_status },
+          {
+            property: ['data', 'last_updated_at'],
+            propertyValue: nextUpdatedAt,
+          },
           { property: ['status'], propertyValue: new_status },
         ],
         conditions:
@@ -474,7 +553,10 @@ export function createOperationsTable({ db, tableName } = {}) {
     });
 
     const afterStatus = after?.status ?? after?.data?.status;
-    return afterStatus === new_status;
+    return (
+      afterStatus === new_status &&
+      after?.data?.last_updated_at === nextUpdatedAt
+    );
   }
 
   /**
@@ -552,20 +634,27 @@ export function createOperationsTable({ db, tableName } = {}) {
   }
 
   /**
-   * Check whether prerequisite actions for a given action type have completed.
+   * Check whether prerequisite actions for a given action have completed.
    *
-   * The operation graph stores edges keyed by action *ids*; most call-sites refer
-   * to actions by their *type*.
+   * The operation graph stores edges keyed by action ids. Older call-sites may
+   * still pass an action type, so this helper accepts either an id or a type and
+   * prefers exact id matches when available.
    * @param {Operation} operation - operation.
-   * @param {import('../../graph/action.js').WharfieActionTypeEnum} action_type - action_type.
+   * @param {string} action_identifier - action identifier.
    * @returns {Promise<boolean>} - Result.
    */
-  async function checkActionPrerequisites(operation, action_type) {
-    let actionId;
-    try {
-      actionId = operation.getActionIdByType(action_type);
-    } catch {
-      return false;
+  async function checkActionPrerequisites(operation, action_identifier) {
+    let actionId = action_identifier;
+    if (!operation.actions.has(actionId)) {
+      try {
+        actionId = operation.getActionIdByType(
+          /** @type {import('../../graph/action.js').WharfieActionTypeEnum} */ (
+            action_identifier
+          ),
+        );
+      } catch {
+        return false;
+      }
     }
 
     const prerequisites = operation.getUpstreamActionIds(actionId) || [];
@@ -702,6 +791,7 @@ export function createOperationsTable({ db, tableName } = {}) {
     getAction,
     putAction,
     updateActionStatus,
+    updateOperationStatus,
     putQuery,
     putQueries,
     getQuery,

--- a/lambdas/lib/graph/action.js
+++ b/lambdas/lib/graph/action.js
@@ -14,6 +14,7 @@ import { WHARFIE_VERSION } from '../version.js';
  * 'SWAP_RESOURCE'|
  * 'REGISTER_PARTITION'|
  * 'RUN_SINGLE_COMPACTION'|
+ * 'INVOKE_FUNCTION'|
  * 'FINISH'|
  * 'SIDE_EFFECT__CLOUDWATCH'|
  * 'SIDE_EFFECT__DAGSTER'|
@@ -38,6 +39,7 @@ const Type = {
   RESPOND_TO_CLOUDFORMATION: 'RESPOND_TO_CLOUDFORMATION',
   REGISTER_PARTITION: 'REGISTER_PARTITION',
   RUN_SINGLE_COMPACTION: 'RUN_SINGLE_COMPACTION',
+  INVOKE_FUNCTION: 'INVOKE_FUNCTION',
   FINISH: 'FINISH',
   SIDE_EFFECT__CLOUDWATCH: 'SIDE_EFFECT__CLOUDWATCH',
   SIDE_EFFECT__DAGSTER: 'SIDE_EFFECT__DAGSTER',
@@ -71,9 +73,15 @@ const Status = {
  * @property {WharfieActionTypeEnum} type - type.
  * @property {WharfieActionStatusEnum} [status] - status.
  * @property {import('./query.js').default[]} [queries] - queries.
- * @property {number} [started_at] - start timestamp
- * @property {number} [last_updated_at] - update_at_timestamp
+ * @property {number} [started_at] - start timestamp.
+ * @property {number} [last_updated_at] - update_at_timestamp.
  * @property {string} [wharfie_version] - wharfie_version.
+ * @property {string} [function_name] - Function name used by INVOKE_FUNCTION actions.
+ * @property {any} [inputs] - Invocation inputs for generic workflow actions.
+ * @property {Record<string, any>} [placement] - Placement hints for the action executor.
+ * @property {Record<string, any>} [retry] - Retry metadata for the action executor.
+ * @property {any} [error] - Last persisted execution error.
+ * @property {number} [attempt_count] - Number of execution attempts recorded for this action.
  * @property {any} [outputs] - outputs.
  */
 
@@ -91,7 +99,13 @@ class Action {
     started_at = Date.now(),
     last_updated_at = started_at,
     wharfie_version = WHARFIE_VERSION,
-    outputs = {},
+    function_name,
+    inputs,
+    placement,
+    retry,
+    error,
+    attempt_count = 0,
+    outputs,
   }) {
     this.id = id;
     this.resource_id = resource_id;
@@ -102,6 +116,12 @@ class Action {
     this.started_at = started_at;
     this.last_updated_at = last_updated_at;
     this.wharfie_version = wharfie_version;
+    this.function_name = function_name;
+    this.inputs = inputs;
+    this.placement = placement;
+    this.retry = retry;
+    this.error = error;
+    this.attempt_count = attempt_count;
     this.outputs = outputs;
   }
 
@@ -129,6 +149,12 @@ class Action {
         started_at: this.started_at,
         last_updated_at: this.last_updated_at,
         wharfie_version: this.wharfie_version,
+        function_name: this.function_name,
+        inputs: this.inputs,
+        placement: this.placement,
+        retry: this.retry,
+        error: this.error,
+        attempt_count: this.attempt_count,
         record_type: Action.RecordType,
         outputs: this.outputs,
       },
@@ -154,6 +180,12 @@ class Action {
       started_at: action_record.data.started_at,
       last_updated_at: action_record.data.last_updated_at,
       wharfie_version: action_record.data.wharfie_version,
+      function_name: action_record.data.function_name,
+      inputs: action_record.data.inputs,
+      placement: action_record.data.placement,
+      retry: action_record.data.retry,
+      error: action_record.data.error,
+      attempt_count: action_record.data.attempt_count,
       outputs: action_record.data.outputs,
     });
     for (const query_record of query_records) {
@@ -176,6 +208,12 @@ class Action {
       started_at: action_record.data.started_at,
       last_updated_at: action_record.data.last_updated_at,
       wharfie_version: action_record.data.wharfie_version,
+      function_name: action_record.data.function_name,
+      inputs: action_record.data.inputs,
+      placement: action_record.data.placement,
+      retry: action_record.data.retry,
+      error: action_record.data.error,
+      attempt_count: action_record.data.attempt_count,
       outputs: action_record.data.outputs,
     });
   }

--- a/lambdas/lib/graph/operation.js
+++ b/lambdas/lib/graph/operation.js
@@ -22,7 +22,9 @@ const Type = {
 };
 
 /**
- * @typedef {('COMPLETED'|
+ * @typedef {('BLOCKED'|
+ * 'COMPLETED'|
+ * 'FAILED'|
  * 'PENDING'|
  * 'RUNNING'
  * )} WharfieOperationStatusEnum
@@ -32,7 +34,9 @@ const Type = {
  * @type {Object<WharfieOperationStatusEnum,WharfieOperationStatusEnum>}
  */
 const Status = {
+  BLOCKED: 'BLOCKED',
   COMPLETED: 'COMPLETED',
+  FAILED: 'FAILED',
   PENDING: 'PENDING',
   RUNNING: 'RUNNING',
 };
@@ -101,6 +105,18 @@ class Operation {
    * @property {import('./action.js').WharfieActionTypeEnum} type - type.
    * @property {Action[]} [dependsOn] - dependsOn.
    * @property {string} [id] - id.
+   * @property {import('./action.js').WharfieActionStatusEnum} [status] - status.
+   * @property {import('./query.js').default[]} [queries] - queries.
+   * @property {number} [started_at] - started_at.
+   * @property {number} [last_updated_at] - last_updated_at.
+   * @property {string} [wharfie_version] - wharfie_version.
+   * @property {string} [function_name] - function_name.
+   * @property {any} [inputs] - inputs.
+   * @property {Record<string, any>} [placement] - placement.
+   * @property {Record<string, any>} [retry] - retry.
+   * @property {any} [error] - error.
+   * @property {number} [attempt_count] - attempt_count.
+   * @property {any} [outputs] - outputs.
    */
 
   /**
@@ -108,10 +124,38 @@ class Operation {
    * @param {CreateActionOptions} options - options.
    * @returns {Action} - Result.
    */
-  createAction({ type, dependsOn = [], id }) {
+  createAction({
+    type,
+    dependsOn = [],
+    id,
+    status,
+    queries,
+    started_at,
+    last_updated_at,
+    wharfie_version,
+    function_name,
+    inputs,
+    placement,
+    retry,
+    error,
+    attempt_count,
+    outputs,
+  }) {
     const action = new Action({
       type,
       id,
+      status,
+      queries,
+      started_at,
+      last_updated_at,
+      wharfie_version,
+      function_name,
+      inputs,
+      placement,
+      retry,
+      error,
+      attempt_count,
+      outputs,
       resource_id: this.resource_id,
       operation_id: this.id,
     });

--- a/lambdas/lib/graph/runner.js
+++ b/lambdas/lib/graph/runner.js
@@ -1,7 +1,9 @@
 import { Status as ActionStatus } from './action.js';
+import { Status as OperationStatus } from './operation.js';
 
 /**
  * @typedef {import('./action.js').default} ActionInstance
+ * @typedef {import('./operation.js').default} OperationInstance
  */
 
 /**
@@ -10,18 +12,82 @@ import { Status as ActionStatus } from './action.js';
  * NOTE: this intentionally matches the provider-neutral operations table client
  * (createOperationsTable / createOperationsStore).
  * @typedef {Object} OperationRunnerStore
- * @property {(resource_id: string, operation_id?: string) => Promise<{ operations: import('./operation.js').default[]; actions: ActionInstance[]; queries: import('./query.js').default[] }>} getRecords - Load operation/action/query records.
+ * @property {(resource_id: string, operation_id?: string) => Promise<{ operations: OperationInstance[]; actions: ActionInstance[]; queries: import('./query.js').default[] }>} getRecords - Load operation/action/query records.
+ * @property {(action: ActionInstance) => Promise<void>} putAction - Persist a full action snapshot.
  * @property {(action: ActionInstance, new_status: string) => Promise<boolean>} updateActionStatus - Optimistically transition an action status.
- * @property {(operation: import('./operation.js').default, action_type: import('./action.js').WharfieActionTypeEnum) => Promise<boolean>} [checkActionPrerequisites] - Check whether prerequisites have completed.
+ * @property {(operation: OperationInstance, new_status: import('./operation.js').WharfieOperationStatusEnum) => Promise<boolean>} [updateOperationStatus] - Optimistically transition an operation status.
+ * @property {(operation: OperationInstance, action_identifier: string) => Promise<boolean>} [checkActionPrerequisites] - Check whether prerequisites have completed.
  */
 
 /**
- * @typedef {Object} RunOperationParams
+ * @typedef RunOperationParams
  * @property {OperationRunnerStore} store - Operations store/table client.
  * @property {string} resourceId - Resource id.
  * @property {string} operationId - Operation id.
- * @property {(action: ActionInstance) => (boolean | Promise<boolean>)} executeAction - User-provided action executor.
+ * @property {(action: ActionInstance) => (unknown | Promise<unknown>)} executeAction - User-provided action executor. Return `true`/`false` for the legacy shorthand or `{ ok, outputs, error }` for structured results.
  */
+
+/**
+ * @param {unknown} error - error.
+ * @returns {Record<string, any>} - Result.
+ */
+function serializeError(error) {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      ...(error.stack ? { stack: error.stack } : {}),
+    };
+  }
+
+  if (typeof error === 'string') {
+    return { message: error };
+  }
+
+  return {
+    message: `Action execution failed: ${String(error)}`,
+  };
+}
+
+/**
+ * @param {unknown} result - result.
+ * @returns {{ ok: boolean, outputs?: any, error?: any }} - Result.
+ */
+function normalizeExecutionResult(result) {
+  if (typeof result === 'boolean') {
+    return result
+      ? { ok: true }
+      : { ok: false, error: { message: 'Action returned false.' } };
+  }
+
+  if (result && typeof result === 'object' && 'ok' in result) {
+    const outcome =
+      /** @type {{ ok?: unknown, outputs?: any, error?: any }} */ (result);
+    return {
+      ok: Boolean(outcome.ok),
+      outputs: outcome.outputs,
+      error: outcome.error,
+    };
+  }
+
+  return {
+    ok: true,
+    outputs: result,
+  };
+}
+
+/**
+ * @param {ActionInstance} action - action.
+ * @returns {number} - Result.
+ */
+function getMaxAttempts(action) {
+  const maxAttempts =
+    action.retry?.max_attempts ?? action.retry?.maxAttempts ?? 1;
+  const normalized = Number(maxAttempts);
+  return Number.isFinite(normalized) && normalized >= 1
+    ? Math.floor(normalized)
+    : 1;
+}
 
 /**
  * Execute a persisted operation DAG in-process.
@@ -29,11 +95,9 @@ import { Status as ActionStatus } from './action.js';
  * Algorithm:
  * - Load operation/action records
  * - Find PENDING actions whose prerequisites are satisfied
- * - Optimistically transition to RUNNING, execute, then transition to COMPLETED/FAILED
+ * - Optimistically transition to RUNNING, execute, then persist a full action snapshot
+ * - Persist operation-level RUNNING / COMPLETED / FAILED / BLOCKED transitions
  * - Repeat until no runnable actions remain
- *
- * This runner is intentionally minimal: it does not attempt concurrency, retries,
- * or operation-level status transitions.
  * @param {RunOperationParams} params - params.
  * @returns {Promise<{ status: 'COMPLETED' | 'FAILED' | 'BLOCKED'; executedActionIds: string[]; failedActionIds: string[]; blockedActionIds: string[]; finalStatusByActionId: Record<string, string> }>} - Result.
  */
@@ -46,6 +110,9 @@ export async function runOperation({
   if (!store) throw new Error('runOperation requires store');
   if (!resourceId) throw new Error('runOperation requires resourceId');
   if (!operationId) throw new Error('runOperation requires operationId');
+  if (typeof store.putAction !== 'function') {
+    throw new Error('runOperation requires store.putAction(action)');
+  }
   if (typeof executeAction !== 'function') {
     throw new Error('runOperation requires executeAction(action)');
   }
@@ -60,27 +127,55 @@ export async function runOperation({
   let status = 'COMPLETED';
 
   /**
-   * @param {import('./operation.js').default} operation - operation.
+   * @param {OperationInstance} operation - operation.
+   * @param {import('./operation.js').WharfieOperationStatusEnum} nextStatus - nextStatus.
+   * @returns {Promise<void>} - Result.
+   */
+  const persistOperationStatus = async (operation, nextStatus) => {
+    if (operation.status === nextStatus) return;
+
+    if (typeof store.updateOperationStatus === 'function') {
+      // Best-effort optimistic update. The stored operation record is the source
+      // of truth; the in-memory object is only used to issue the transition.
+      await store.updateOperationStatus(operation, nextStatus);
+    }
+
+    operation.status = nextStatus;
+    operation.last_updated_at = Date.now();
+  };
+
+  /**
+   * @param {OperationInstance} operation - operation.
    * @param {ActionInstance} action - action.
    * @returns {Promise<boolean>} - Result.
    */
   const prerequisitesSatisfied = async (operation, action) => {
     if (typeof store.checkActionPrerequisites === 'function') {
-      return store.checkActionPrerequisites(operation, action.type);
+      return store.checkActionPrerequisites(operation, action.id);
     }
 
-    // Fallback: in-memory prerequisite check.
     const upstreamIds = operation.getUpstreamActionIds(action.id) || [];
     if (!upstreamIds.length) return true;
 
     const { actions } = await store.getRecords(resourceId, operationId);
-    const byId = new Map(actions.map((a) => [a.id, a]));
+    const byId = new Map(actions.map((candidate) => [candidate.id, candidate]));
     for (const upstreamId of upstreamIds) {
       const upstream = byId.get(upstreamId);
       if (!upstream || upstream.status !== ActionStatus.COMPLETED) return false;
     }
     return true;
   };
+
+  const initialRecords = await store.getRecords(resourceId, operationId);
+  const initialOperation = initialRecords.operations.find(
+    (operation) => operation.id === operationId,
+  );
+
+  if (!initialOperation) {
+    throw new Error(`Operation not found: ${resourceId}#${operationId}`);
+  }
+
+  await persistOperationStatus(initialOperation, OperationStatus.RUNNING);
 
   // Run until no runnable PENDING actions remain.
   // Each loop reloads from the store to ensure DB-backed status is respected.
@@ -90,13 +185,17 @@ export async function runOperation({
       resourceId,
       operationId,
     );
-    const operation = operations.find((o) => o.id === operationId);
+    const operation = operations.find(
+      (candidate) => candidate.id === operationId,
+    );
 
     if (!operation) {
       throw new Error(`Operation not found: ${resourceId}#${operationId}`);
     }
 
-    const pending = actions.filter((a) => a.status === ActionStatus.PENDING);
+    const pending = actions.filter(
+      (action) => action.status === ActionStatus.PENDING,
+    );
     if (!pending.length) {
       break;
     }
@@ -105,12 +204,12 @@ export async function runOperation({
     const runnable = [];
     for (const action of pending) {
       // eslint-disable-next-line no-await-in-loop
-      if (await prerequisitesSatisfied(operation, action))
+      if (await prerequisitesSatisfied(operation, action)) {
         runnable.push(action);
+      }
     }
 
-    // Deterministic execution order for any concurrently runnable actions.
-    runnable.sort((a, b) => a.id.localeCompare(b.id));
+    runnable.sort((left, right) => left.id.localeCompare(right.id));
 
     if (!runnable.length) {
       status = 'BLOCKED';
@@ -118,7 +217,6 @@ export async function runOperation({
     }
 
     for (const action of runnable) {
-      // Optimistically claim the action.
       // eslint-disable-next-line no-await-in-loop
       const claimed = await store.updateActionStatus(
         action,
@@ -126,28 +224,57 @@ export async function runOperation({
       );
       if (!claimed) continue;
       action.status = ActionStatus.RUNNING;
+      action.last_updated_at = Date.now();
 
-      let ok = false;
+      const attemptCount = Number(action.attempt_count || 0) + 1;
+      const maxAttempts = getMaxAttempts(action);
+
+      /** @type {{ ok: boolean, outputs?: any, error?: any }} */
+      let execution = { ok: false };
       try {
         // eslint-disable-next-line no-await-in-loop
-        ok = Boolean(await executeAction(action));
-      } catch {
-        ok = false;
+        execution = normalizeExecutionResult(await executeAction(action));
+      } catch (error) {
+        execution = {
+          ok: false,
+          error: serializeError(error),
+        };
       }
 
-      const terminal = ok ? ActionStatus.COMPLETED : ActionStatus.FAILED;
-      // eslint-disable-next-line no-await-in-loop
-      await store.updateActionStatus(action, terminal);
+      const terminal = execution.ok
+        ? ActionStatus.COMPLETED
+        : attemptCount < maxAttempts
+          ? ActionStatus.PENDING
+          : ActionStatus.FAILED;
+
       action.status = terminal;
-      executedActionIds.push(action.id);
+      action.last_updated_at = Date.now();
+      action.attempt_count = attemptCount;
+      action.outputs = execution.ok ? execution.outputs : undefined;
+      action.error = execution.ok
+        ? undefined
+        : (execution.error ?? { message: 'Action execution failed.' });
+
+      // eslint-disable-next-line no-await-in-loop
+      await store.putAction(action);
+
+      if (!executedActionIds.includes(action.id)) {
+        executedActionIds.push(action.id);
+      }
       finalStatusByActionId[action.id] = terminal;
     }
   }
 
-  const { actions: finalActions } = await store.getRecords(
-    resourceId,
-    operationId,
+  const finalRecords = await store.getRecords(resourceId, operationId);
+  const finalOperation = finalRecords.operations.find(
+    (operation) => operation.id === operationId,
   );
+
+  if (!finalOperation) {
+    throw new Error(`Operation not found: ${resourceId}#${operationId}`);
+  }
+
+  const finalActions = finalRecords.actions;
   for (const action of finalActions) {
     finalStatusByActionId[action.id] = action.status;
   }
@@ -163,6 +290,14 @@ export async function runOperation({
 
   if (failedActionIds.length > 0) status = 'FAILED';
   else if (blockedActionIds.length > 0) status = 'BLOCKED';
+
+  const terminalOperationStatus =
+    status === 'FAILED'
+      ? OperationStatus.FAILED
+      : status === 'BLOCKED'
+        ? OperationStatus.BLOCKED
+        : OperationStatus.COMPLETED;
+  await persistOperationStatus(finalOperation, terminalOperationStatus);
 
   return {
     status,

--- a/lambdas/lib/graph/typedefs.js
+++ b/lambdas/lib/graph/typedefs.js
@@ -52,6 +52,13 @@
  * @property {string} id - Id of the action
  * @property {import('./action.js').WharfieActionTypeEnum} type - type of action
  * @property {import('./action.js').WharfieActionStatusEnum} status - status of the action
+ * @property {string} [function_name] - Function name used by generic invocation actions
+ * @property {any} [inputs] - Invocation inputs stored with the action
+ * @property {Record<string, any>} [placement] - Placement hints stored with the action
+ * @property {Record<string, any>} [retry] - Retry metadata stored with the action
+ * @property {any} [error] - Persisted execution error metadata
+ * @property {number} [attempt_count] - Number of execution attempts recorded for the action
+ * @property {any} [outputs] - Persisted execution outputs
  * @property {number} started_at - started_at
  * @property {number} last_updated_at - update_at_timestamp
  * @property {string} wharfie_version - version of wharfie

--- a/prompts/work
+++ b/prompts/work
@@ -107,7 +107,7 @@ Output requirements
 At the end, return all of the following:
 
 1. A downloadable zip containing every changed file as a complete drop-in replacement, preserving repo-relative paths only.
-2. A concise changelog.
+2. A concise changelog. including a copy-able git commit message.
 3. The exact commands you ran and their results.
 4. Final validation status for:
    - verify.offline.sh repo

--- a/test/cli/cmds/ops-run-command.test.js
+++ b/test/cli/cmds/ops-run-command.test.js
@@ -1,0 +1,148 @@
+/* eslint-env jest */
+/* eslint-disable jsdoc/require-jsdoc */
+
+import { describe, expect, it } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import createVanillaDB from '../../../lambdas/lib/db/adapters/vanilla.js';
+import operationsStoreFactory from '../../../lambdas/lib/graph/operations-store.js';
+import Action, {
+  Status as ActionStatus,
+} from '../../../lambdas/lib/graph/action.js';
+import Operation, {
+  Status as OperationStatus,
+  Type as OperationType,
+} from '../../../lambdas/lib/graph/operation.js';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, '../../..');
+const binPath = path.join(repoRoot, 'bin', 'wharfie');
+const helloWorldDir = path.join(
+  repoRoot,
+  'scratch',
+  'examples',
+  'actor-systems',
+  'hello-world',
+);
+
+/**
+ * @param {string[]} args - args.
+ * @param {Record<string, string | undefined>} env - env.
+ * @returns {import('node:child_process').SpawnSyncReturns<string>} - Result.
+ */
+function runCli(args, env) {
+  return /** @type {import('node:child_process').SpawnSyncReturns<string>} */ (
+    spawnSync(process.execPath, [binPath, ...args], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env,
+    })
+  );
+}
+
+describe('wharfie ops run', () => {
+  it('executes INVOKE_FUNCTION actions against a local app and persists outputs', async () => {
+    const dbPath = mkdtempSync(path.join(os.tmpdir(), 'wharfie-ops-run-'));
+    const tableName = 'operations-test';
+    const resourceId = 'resource-1';
+    /** @type {import('../../../lambdas/lib/db/base.js').DBClient | undefined} */
+    let inspectDb;
+
+    /** @type {import('../../../lambdas/lib/graph/operation.js').default} */
+    let operation;
+    /** @type {import('../../../lambdas/lib/graph/action.js').default} */
+    let invokeAction;
+
+    try {
+      const db = createVanillaDB({ path: dbPath });
+      const store = operationsStoreFactory({ db, tableName });
+
+      operation = new Operation({
+        id: 'op-1',
+        resource_id: resourceId,
+        resource_version: 1,
+        type: OperationType.PIPELINE,
+        started_at: 1,
+        last_updated_at: 1,
+      });
+
+      const startAction = operation.createAction({
+        id: 'start-1',
+        type: Action.Type.START,
+      });
+      invokeAction = operation.createAction({
+        id: 'invoke-1',
+        type: Action.Type.INVOKE_FUNCTION,
+        function_name: 'echo-event',
+        inputs: { who: 'ops-run' },
+        placement: { mode: 'local' },
+        retry: { max_attempts: 1 },
+        dependsOn: [startAction],
+      });
+      operation.createAction({
+        id: 'finish-1',
+        type: Action.Type.FINISH,
+        dependsOn: [invokeAction],
+      });
+
+      await store.putOperation(operation);
+      await db.close();
+
+      const result = runCli(
+        ['ops', 'run', resourceId, operation.id, '--dir', helloWorldDir],
+        {
+          ...process.env,
+          NODE_ENV: 'development',
+          OPERATIONS_TABLE: tableName,
+          WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
+          WHARFIE_DB_ADAPTER: 'vanilla',
+          WHARFIE_DB_PATH: dbPath,
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('invoke-1');
+      expect(result.stdout).toContain('Executed 3 actions.');
+
+      inspectDb = createVanillaDB({ path: dbPath });
+      const inspectStore = operationsStoreFactory({ db: inspectDb, tableName });
+
+      const storedAction = await inspectStore.getAction(
+        resourceId,
+        operation.id,
+        invokeAction.id,
+      );
+      const storedOperation = await inspectStore.getOperation(
+        resourceId,
+        operation.id,
+      );
+
+      expect(storedAction).not.toBeNull();
+      expect(storedOperation).not.toBeNull();
+      if (!storedAction || !storedOperation) {
+        throw new Error('Expected stored action and operation to exist');
+      }
+
+      expect(storedAction.status).toBe(ActionStatus.COMPLETED);
+      expect(storedAction.function_name).toBe('echo-event');
+      expect(storedAction.inputs).toEqual({ who: 'ops-run' });
+      expect(storedAction.attempt_count).toBe(1);
+      expect(storedAction.error).toBeUndefined();
+      expect(storedAction.outputs).toEqual({
+        ok: true,
+        who: 'ops-run',
+        message: 'hello ops-run',
+        requestId: null,
+      });
+      expect(storedOperation.status).toBe(OperationStatus.COMPLETED);
+    } finally {
+      await inspectDb?.close?.();
+      rmSync(dbPath, { recursive: true, force: true });
+    }
+  }, 15000);
+});

--- a/test/graph/runner/graph-runner.test.js
+++ b/test/graph/runner/graph-runner.test.js
@@ -13,7 +13,7 @@ import Operation from '../../../lambdas/lib/graph/operation.js';
 import { runOperation } from '../../../lambdas/lib/graph/runner.js';
 
 describe('graph runner', () => {
-  test('executes a persisted action DAG in prerequisite order', async () => {
+  test('executes a persisted action DAG in prerequisite order and persists COMPLETED', async () => {
     const tmp = mkdtempSync(join(tmpdir(), 'wharfie-runner-'));
     try {
       const db = createVanillaDB({ path: tmp });
@@ -26,6 +26,8 @@ describe('graph runner', () => {
         resource_id: resourceId,
         resource_version: 1,
         type: Operation.Type.PIPELINE,
+        started_at: 1,
+        last_updated_at: 1,
       });
 
       const actionA = operation.createAction({
@@ -65,8 +67,9 @@ describe('graph runner', () => {
             actionA.id,
           );
           expect(upstream).not.toBeNull();
-          if (!upstream)
+          if (!upstream) {
             throw new Error('Expected prerequisite action to exist');
+          }
           expect(upstream.status).toBe(Action.Status.COMPLETED);
         }
 
@@ -93,17 +96,26 @@ describe('graph runner', () => {
         operation.id,
         actionB.id,
       );
+      const storedOperation = await store.getOperation(
+        resourceId,
+        operation.id,
+      );
       expect(afterA).not.toBeNull();
       expect(afterB).not.toBeNull();
-      if (!afterA || !afterB) throw new Error('Expected actions to exist');
+      expect(storedOperation).not.toBeNull();
+      if (!afterA || !afterB || !storedOperation) {
+        throw new Error('Expected actions and operation to exist');
+      }
       expect(afterA.status).toBe(Action.Status.COMPLETED);
       expect(afterB.status).toBe(Action.Status.COMPLETED);
+      expect(storedOperation.status).toBe(Operation.Status.COMPLETED);
+      expect(storedOperation.last_updated_at).toBeGreaterThan(1);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
   });
 
-  test('returns FAILED when an upstream action fails and leaves downstream work blocked', async () => {
+  test('returns FAILED when an upstream action fails and persists FAILED', async () => {
     const tmp = mkdtempSync(join(tmpdir(), 'wharfie-runner-'));
     try {
       const db = createVanillaDB({ path: tmp });
@@ -116,6 +128,8 @@ describe('graph runner', () => {
         resource_id: resourceId,
         resource_version: 1,
         type: Operation.Type.PIPELINE,
+        started_at: 1,
+        last_updated_at: 1,
       });
 
       const actionA = operation.createAction({
@@ -156,11 +170,266 @@ describe('graph runner', () => {
         operation.id,
         actionB.id,
       );
+      const storedOperation = await store.getOperation(
+        resourceId,
+        operation.id,
+      );
       expect(afterA).not.toBeNull();
       expect(afterB).not.toBeNull();
-      if (!afterA || !afterB) throw new Error('Expected actions to exist');
+      expect(storedOperation).not.toBeNull();
+      if (!afterA || !afterB || !storedOperation) {
+        throw new Error('Expected actions and operation to exist');
+      }
       expect(afterA.status).toBe(Action.Status.FAILED);
       expect(afterB.status).toBe(Action.Status.PENDING);
+      expect(storedOperation.status).toBe(Operation.Status.FAILED);
+      expect(storedOperation.last_updated_at).toBeGreaterThan(1);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('returns BLOCKED when pending work cannot make progress and persists BLOCKED', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'wharfie-runner-'));
+    try {
+      const db = createVanillaDB({ path: tmp });
+      const tableName = 'operations-runner-test';
+      const store = createOperationsTable({ db, tableName });
+
+      const resourceId = 'r1';
+      const operation = new Operation({
+        id: 'op1',
+        resource_id: resourceId,
+        resource_version: 1,
+        type: Operation.Type.PIPELINE,
+        started_at: 1,
+        last_updated_at: 1,
+      });
+
+      const actionA = new Action({
+        id: 'a1',
+        resource_id: resourceId,
+        operation_id: operation.id,
+        type: Action.Type.START,
+        status: Action.Status.RUNNING,
+      });
+      const actionB = new Action({
+        id: 'b1',
+        resource_id: resourceId,
+        operation_id: operation.id,
+        type: Action.Type.FINISH,
+        status: Action.Status.PENDING,
+      });
+      operation.addAction({ action: actionA, dependsOn: [] });
+      operation.addAction({ action: actionB, dependsOn: [actionA] });
+
+      await store.putOperation(operation);
+
+      const result = await runOperation({
+        store,
+        resourceId,
+        operationId: operation.id,
+        executeAction: async () => true,
+      });
+
+      expect(result.status).toBe('BLOCKED');
+      expect(result.executedActionIds).toEqual([]);
+      expect(result.failedActionIds).toEqual([]);
+      expect([...result.blockedActionIds].sort()).toEqual(
+        [actionA.id, actionB.id].sort(),
+      );
+
+      const storedOperation = await store.getOperation(
+        resourceId,
+        operation.id,
+      );
+      expect(storedOperation).not.toBeNull();
+      if (!storedOperation) throw new Error('Expected operation to exist');
+      expect(storedOperation.status).toBe(Operation.Status.BLOCKED);
+      expect(storedOperation.last_updated_at).toBeGreaterThan(1);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('supports multiple INVOKE_FUNCTION actions with the same type and persists outputs', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'wharfie-runner-'));
+    try {
+      const db = createVanillaDB({ path: tmp });
+      const tableName = 'operations-runner-test';
+      const store = createOperationsTable({ db, tableName });
+
+      const resourceId = 'r1';
+      const operation = new Operation({
+        id: 'op1',
+        resource_id: resourceId,
+        resource_version: 1,
+        type: Operation.Type.PIPELINE,
+        started_at: 1,
+        last_updated_at: 1,
+      });
+
+      const actionA = operation.createAction({
+        id: 'task-a',
+        type: Action.Type.INVOKE_FUNCTION,
+        function_name: 'step-a',
+        inputs: { value: 1 },
+        placement: { mode: 'local' },
+        retry: { max_attempts: 1 },
+      });
+      const actionB = operation.createAction({
+        id: 'task-b',
+        type: Action.Type.INVOKE_FUNCTION,
+        function_name: 'step-b',
+        inputs: { value: 2 },
+        placement: { mode: 'local' },
+        retry: { max_attempts: 1 },
+        dependsOn: [actionA],
+      });
+
+      await store.putOperation(operation);
+
+      /** @type {string[]} */
+      const order = [];
+
+      const result = await runOperation({
+        store,
+        resourceId,
+        operationId: operation.id,
+        executeAction: async (action) => {
+          order.push(action.id);
+
+          if (action.id === actionB.id) {
+            const upstream = await store.getAction(
+              resourceId,
+              operation.id,
+              actionA.id,
+            );
+            expect(upstream).not.toBeNull();
+            if (!upstream) {
+              throw new Error('Expected prerequisite action to exist');
+            }
+            expect(upstream.status).toBe(Action.Status.COMPLETED);
+            expect(upstream.outputs).toEqual({ step: 'step-a', value: 1 });
+          }
+
+          return {
+            ok: true,
+            outputs: {
+              step: action.function_name,
+              value: action.inputs?.value,
+            },
+          };
+        },
+      });
+
+      expect(result.status).toBe('COMPLETED');
+      expect(order).toEqual([actionA.id, actionB.id]);
+      expect(result.executedActionIds).toEqual([actionA.id, actionB.id]);
+
+      const afterA = await store.getAction(
+        resourceId,
+        operation.id,
+        actionA.id,
+      );
+      const afterB = await store.getAction(
+        resourceId,
+        operation.id,
+        actionB.id,
+      );
+
+      expect(afterA).not.toBeNull();
+      expect(afterB).not.toBeNull();
+      if (!afterA || !afterB) {
+        throw new Error('Expected actions to exist');
+      }
+
+      expect(afterA.status).toBe(Action.Status.COMPLETED);
+      expect(afterA.function_name).toBe('step-a');
+      expect(afterA.inputs).toEqual({ value: 1 });
+      expect(afterA.outputs).toEqual({ step: 'step-a', value: 1 });
+      expect(afterA.attempt_count).toBe(1);
+
+      expect(afterB.status).toBe(Action.Status.COMPLETED);
+      expect(afterB.function_name).toBe('step-b');
+      expect(afterB.inputs).toEqual({ value: 2 });
+      expect(afterB.outputs).toEqual({ step: 'step-b', value: 2 });
+      expect(afterB.attempt_count).toBe(1);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('retries INVOKE_FUNCTION actions and persists attempt counts and errors', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'wharfie-runner-'));
+    try {
+      const db = createVanillaDB({ path: tmp });
+      const tableName = 'operations-runner-test';
+      const store = createOperationsTable({ db, tableName });
+
+      const resourceId = 'r1';
+      const operation = new Operation({
+        id: 'op1',
+        resource_id: resourceId,
+        resource_version: 1,
+        type: Operation.Type.PIPELINE,
+        started_at: 1,
+        last_updated_at: 1,
+      });
+
+      const action = operation.createAction({
+        id: 'retry-action',
+        type: Action.Type.INVOKE_FUNCTION,
+        function_name: 'unstable-step',
+        inputs: { value: 1 },
+        retry: { max_attempts: 2 },
+      });
+
+      await store.putOperation(operation);
+
+      let attempts = 0;
+      const result = await runOperation({
+        store,
+        resourceId,
+        operationId: operation.id,
+        executeAction: async () => {
+          attempts += 1;
+          throw new Error(`boom ${attempts}`);
+        },
+      });
+
+      expect(result.status).toBe('FAILED');
+      expect(result.executedActionIds).toEqual([action.id]);
+      expect(result.failedActionIds).toEqual([action.id]);
+      expect(result.blockedActionIds).toEqual([]);
+      expect(attempts).toBe(2);
+
+      const storedAction = await store.getAction(
+        resourceId,
+        operation.id,
+        action.id,
+      );
+      const storedOperation = await store.getOperation(
+        resourceId,
+        operation.id,
+      );
+
+      expect(storedAction).not.toBeNull();
+      expect(storedOperation).not.toBeNull();
+      if (!storedAction || !storedOperation) {
+        throw new Error('Expected action and operation to exist');
+      }
+
+      expect(storedAction.status).toBe(Action.Status.FAILED);
+      expect(storedAction.retry).toEqual({ max_attempts: 2 });
+      expect(storedAction.attempt_count).toBe(2);
+      expect(storedAction.outputs).toBeUndefined();
+      expect(storedAction.error).toMatchObject({
+        name: 'Error',
+        message: 'boom 2',
+      });
+      expect(storedOperation.status).toBe(Operation.Status.FAILED);
+      expect(storedOperation.last_updated_at).toBeGreaterThan(1);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION

	•	Added a generic INVOKE_FUNCTION action type and persisted workflow fields on actions:
	•	function_name
	•	inputs
	•	placement
	•	retry
	•	error
	•	attempt_count
	•	outputs
	•	Updated the graph runner to:
	•	execute structured action results
	•	persist outputs and errors
	•	track attempt counts
	•	honor retry metadata for generic actions
	•	Replaced the ops run placeholder executor with real local app execution via wharfie.app.js / app.invoke(...).
	•	Fixed prerequisite resolution so repeated actions of the same type work correctly by checking upstream completion by action id, not just action type.
	•	Added:
	•	a runner test for repeated INVOKE_FUNCTION actions and persisted outputs
	•	a runner test for retries / attempt-count persistence
	•	an end-to-end CLI test for wharfie ops run