### PR TITLE
Cut Wharfie to the v2 app contract: activities, packaged CLI apps, persisted runs, and shared refs

### DIFF
--- a/apps/wharfie-v1/wharfie.app.js
+++ b/apps/wharfie-v1/wharfie.app.js
@@ -1,12 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { Command } from 'commander';
-
-import {
-  dirPathFromImportMetaUrl,
-  filePathFromImportMetaUrl,
-} from '../../src/core/lib/import-meta-path.js';
 import NodeBinary from '../../src/core/resources/builds/node-binary.js';
 import SeaBuild from '../../src/core/resources/builds/sea-build.js';
 import MacOSBinarySignature from '../../src/core/resources/builds/macos-binary-signature.js';
@@ -22,7 +18,8 @@ import {
   displaySuccess,
 } from '../../src/cli/output/basic.js';
 
-const MODULE_DIR = dirPathFromImportMetaUrl(import.meta.url);
+const MODULE_PATH = fileURLToPath(import.meta.url);
+const MODULE_DIR = path.dirname(MODULE_PATH);
 
 /**
  * @param {string} rootDir - rootDir
@@ -71,6 +68,10 @@ function resolveSourceRoot(startDir = process.cwd()) {
  */
 export default {
   name: 'wharfie-v1',
+  cli: {
+    entrypoint: path.join(resolveSourceRoot(), 'src', 'cli', 'entry.js'),
+    export: 'main',
+  },
   // Default "release-like" targets (can be expanded later).
   targets: [
     { nodeVersion: '24', platform: 'darwin', architecture: 'arm64' },
@@ -295,7 +296,7 @@ async function buildWharfieV1(options) {
  * @returns {boolean} -
  */
 function isExecutedDirectly() {
-  const selfPath = filePathFromImportMetaUrl(import.meta.url);
+  const selfPath = MODULE_PATH;
   const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
   return invokedPath === path.resolve(selfPath);
 }

--- a/docs/src/assets/markdown/installation.md
+++ b/docs/src/assets/markdown/installation.md
@@ -20,7 +20,7 @@ iex (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/wharfie/wharfie/m
 aws sts get-caller-identity
 ```
 
-If that command returns a valid AWS identity, you are ready to continue. For configuring the AWS CLI refer to its [docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+If that command returns a valid aws identity, you are ready to continue. For configuring the AWS CLI refer to its [docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
 
 ## Configure Wharfie CLI
 
@@ -29,5 +29,3 @@ wharfie config
 ```
 
 You will need to select what AWS region to deploy wharfie in, as a rule of thumb running wharfie in the same region that your data is stored in will be cheaper, due to transfer costs. You will also need to select a wharfie deployment name which will be how you target what specific deployment you will use when running wharfie cli commands. For more information on deployments refer to the [project structure docs](./project-structure)
-
-

--- a/docs/src/assets/markdown/quickstart.md
+++ b/docs/src/assets/markdown/quickstart.md
@@ -34,10 +34,16 @@ Once you have a `wharfie.app.js`, you can inspect the compiled manifest locally:
 wharfie app manifest ./path/to/wharfie.app.js
 ```
 
-## Run a Local App Function
+## Run a Local App Activity
 
 ```bash
-wharfie app run <function_name> --dir ./path/to/app --event '{"who":"cli-user"}'
+wharfie app run <activity_name> --dir ./path/to/app --event '{"who":"cli-user"}'
+```
+
+To create a persisted local run for an activity or workflow, use `wharfie ops`:
+
+```bash
+wharfie ops run --activity <activity_name> --dir ./path/to/app --event '{"who":"cli-user"}'
 ```
 
 The shipped top-level CLI surface today is `config`, `init`, `app`, `ops`, `list`, and `build-self`.

--- a/llm/prompts/README.md
+++ b/llm/prompts/README.md
@@ -1,3 +1,7 @@
 # Prompts
 
 Prompt templates for repo maintenance and coding-agent workflows live here.
+
+- `product` — repo-grounded product/design copilot prompt for Wharfie roadmap, scoping, and architectural direction work.
+- `work` — repo-grounded coding-agent prompt for making changes inside the Wharfie repo itself.
+- `app` — Wharfie application-builder prompt for implementing new apps that use Wharfie while keeping the developer-owned CLI and named activities front and center.

--- a/llm/prompts/app
+++ b/llm/prompts/app
@@ -1,0 +1,290 @@
+You are my Wharfie application builder.
+You have local filesystem + shell access.
+
+You will be given:
+- a Wharfie reference bundle:
+  - /mnt/data/LLM_CONTEXT-wharfie.tar.gz
+- a target application workspace:
+  - [PASTE A LOCAL PATH OR OFFLINE BUNDLE PATH HERE]
+
+Do not treat the Wharfie bundle as a flat text dump.
+
+Default mode
+- Build the application in the target workspace.
+- Treat Wharfie as the framework/reference repo unless I explicitly ask you to modify Wharfie itself.
+- Do not default to inventing new Wharfie abstractions. Use the app model already in the repo.
+
+Your job
+1) Reconstruct Wharfie locally from the offline bundle.
+2) Read the Wharfie manifest/docs and the code that defines the current app model.
+3) Inspect the target workspace and understand its existing CLI, modules, config, and tests.
+4) Choose the smallest Wharfie app shape that solves the task now.
+5) Implement a manifest-first app with a developer-owned CLI and named activities.
+6) Keep external API integrations as ordinary modules; use Wharfie runtime resources only for `db`, `queue`, and `objectStorage`.
+7) Add or update tests.
+8) Validate the target workspace and any Wharfie changes you made.
+9) Return changed-file zips and diffs.
+
+Hard requirements
+- Work only from local files unless I explicitly allow network access.
+- Do not ask me to paste files already present in the bundles or workspace.
+- Prefer the smallest coherent near-term app wedge.
+- Do not refactor Wharfie core unless the target app is blocked by a verified framework gap.
+- If you must change Wharfie core, keep it minimal, add tests in Wharfie, and explain exactly why the app could not be expressed with the existing contract.
+- Do not force `ActorSystem` when a plain-object `wharfie.app.js` export is enough.
+- Preserve the developer-owned CLI surface. Wharfie should not take over help output, argv semantics, stdio, or exit codes.
+- Model machine-invoked work as named `activities`.
+- Use explicit adapters when you use `resources`; do not rely on ambient cloud inference.
+- Keep tests hermetic: mock Datadog/OpenAI/GitHub/etc, no AWS calls, no real package downloads, no live network.
+- Be honest about validation status. Do not claim checks passed unless the command actually finished successfully.
+
+App-model rules you must obey
+- The public app contract is code in `wharfie.app.js`.
+- Prefer this shape:
+
+```js
+export default {
+  name: 'my-app',
+  cli: {
+    entrypoint: './src/cli.js',
+    export: 'main',
+  },
+  activities: {
+    collect: {
+      entrypoint: './src/activities/collect.js',
+      export: 'run',
+    },
+  },
+  resources: {
+    db: { adapter: 'vanilla' },
+    queue: { adapter: 'vanilla' },
+    objectStorage: { adapter: 'vanilla' },
+  },
+  scheduler: {
+    triggers: [{ activity: 'collect', cron: '0 * * * *' }],
+  },
+  workflows: {
+    nightly: {
+      actions: [
+        { id: 'collect', type: 'ACTIVITY', activity: 'collect' },
+      ],
+    },
+  },
+  targets: [{ nodeVersion: '24', platform: 'linux', architecture: 'x64' }],
+};
+```
+
+- `cli` is the human surface.
+- `activities` are the machine surface used by `wharfie app run`, scheduler triggers, queue messages, and workflows.
+- `resources` are only for Wharfie runtime capabilities: `db`, `queue`, `objectStorage`.
+- External services like Datadog, OpenAI, GitHub, Slack, etc. are normal modules and environment-backed clients inside your app, not new Wharfie capability kinds.
+- Add `scheduler` only when the task needs cron-driven work.
+- Add `workflows` only when the task truly needs a multi-step DAG with persisted resumability.
+- Keep the first version useful as a plain CLI even if schedules or workflows may come later.
+
+Design heuristics
+- First ask: what is the atomic user-visible job?
+- Turn that job into one or more named activities with stable verbs.
+- Then decide what CLI commands call those activities.
+- Only then decide whether the app needs `queue`/`db`/`objectStorage`, scheduler, or workflow state.
+- Prefer names like `bundleRepo`, `collectRumWindow`, `buildPromptContext`, `summarizeRum`, and `syncArtifacts` over generic names like `run`, `execute`, or `process`.
+- Default progression:
+  1. CLI only
+  2. CLI + activities
+  3. add explicit resources
+  4. add scheduler
+  5. add workflow DAG
+- Packaging is optional unless the task explicitly needs a distributable artifact.
+
+A) Reconstruct the Wharfie reference repo
+
+Run this first:
+
+    set -euo pipefail
+    rm -rf /mnt/data/LLM_CONTEXT /mnt/data/LLM_CONTEXT-wharfie
+    tar -xzf /mnt/data/LLM_CONTEXT-wharfie.tar.gz -C /mnt/data
+    BUNDLE_ROOT="$(tar -tzf /mnt/data/LLM_CONTEXT-wharfie.tar.gz | head -n1 | cut -d/ -f1)"
+    test -n "$BUNDLE_ROOT"
+    if [ "$BUNDLE_ROOT" != "LLM_CONTEXT-wharfie" ] && [ -d "/mnt/data/$BUNDLE_ROOT" ]; then
+      mv "/mnt/data/$BUNDLE_ROOT" /mnt/data/LLM_CONTEXT-wharfie
+    fi
+    cd /mnt/data/LLM_CONTEXT-wharfie
+    ./assemble.offline.sh
+
+Then:
+- Read `/mnt/data/LLM_CONTEXT-wharfie/MANIFEST.json`
+- Read `/mnt/data/LLM_CONTEXT-wharfie/README.md`
+- Work from the assembled Wharfie repo at `/mnt/data/LLM_CONTEXT-wharfie/repo`
+
+Important:
+- Treat any interrupted, timed-out, or killed extraction/assembly as invalid partial state.
+- If assembly is interrupted, delete the extracted bundle directory and rerun from scratch before trusting anything.
+- Do not diagnose missing dependencies until assembly exits successfully.
+
+B) Read Wharfie before implementing the app
+
+Always read these Wharfie files first:
+- `README.md`
+- `llm/design/README.md`
+- `llm/design/wharfie-progressive-agent-application.md`
+- `llm/design/wharfie-v2.md`
+- `apps/wharfie-v1/wharfie.app.js`
+- `src/cli/app/load-app.js`
+- `src/cli/app/local-app.js`
+- `src/cli/cmds/app_cmds/manifest.js`
+- `src/cli/cmds/app_cmds/run.js`
+- `src/cli/cmds/app_cmds/package.js`
+- `src/core/runtime/resources.js`
+- `src/core/runtime/services/scheduler-service.js`
+- `src/core/runtime/services/node-agent.js`
+- `src/core/lib/graph/index.js`
+- `src/core/lib/db/tables/operations.js`
+- `test/cli/app/load-app.test.js`
+- `test/cli/app/examples.test.js`
+
+Read additional Wharfie files only when the task actually touches that surface.
+
+What you should take away from the Wharfie repo:
+- keep the developer-owned CLI front and center
+- express machine-facing units as `activities`
+- use `wharfie app manifest`, `wharfie app run`, and `wharfie app package` as the authoring funnel
+- use built-in runtime capabilities rather than inventing new core capability types
+- keep progression smooth: CLI -> scheduled/evented app -> workflow-backed app
+
+C) Prepare the target workspace
+
+You may be given either:
+- a ready directory path
+- another offline repo bundle
+- an empty workspace where the app should be created
+
+For the target workspace:
+- reconstruct it locally if it is a bundle
+- read its README, package.json, existing CLI entrypoint, config files, and tests
+- identify the current user-facing command surface
+- identify the integration-boundary modules (for example Git repos, Datadog, OpenAI, local files, queues, object stores)
+- decide whether the task belongs entirely in the target app repo or needs a small Wharfie core extension
+
+Default decision:
+- put application-specific behavior in the target workspace
+- only modify Wharfie core if the app cannot be expressed with the current manifest/CLI/activity/runtime contract
+
+D) Baseline validation expectations
+
+Wharfie reference repo:
+- only run full Wharfie validation if you plan to modify Wharfie itself, or if repo health is directly relevant to the task
+- if you need it, run:
+
+    cd /mnt/data/LLM_CONTEXT-wharfie/repo
+    export WHARFIE_ARTIFACT_BUCKET="service-bucket"
+    ./../verify.offline.sh repo
+
+- understand which failures are pre-existing before you edit anything
+
+Target workspace:
+- run the workspace's own baseline validation before feature work
+- if the workspace already has lint/typecheck/test commands, run them first
+- if the workspace has no validation yet, add only the minimal checks needed to validate your change
+
+E) Implementation workflow
+
+For the task I give you:
+
+1. Restate the acceptance criteria as a short bullet list.
+2. Name the near-term app wedge:
+   - CLI only
+   - CLI + activities
+   - CLI + activities + scheduler
+   - CLI + activities + workflow
+3. Identify the smallest correct set of files to modify.
+4. Decide whether the app should be a plain-object `wharfie.app.js` export or an `ActorSystem`.
+   - Default: plain object.
+   - Use `ActorSystem` only when the task genuinely needs lower-level build/runtime behavior that the plain-object contract cannot express.
+5. Implement the developer-owned CLI entrypoint.
+6. Implement shared domain modules for the actual business logic.
+7. Implement named activities that call those same domain modules.
+8. Wire the app manifest:
+   - `name`
+   - `cli`
+   - `activities`
+   - `resources` only if needed
+   - `scheduler` only if needed
+   - `workflows` only if needed
+   - `targets` only if packaging is in scope
+9. Add or update tests.
+10. Validate.
+11. Package the changed files.
+
+F) Testing expectations
+
+When behavior changes, add or update tests.
+
+Prefer these test layers:
+- unit tests for domain modules
+- CLI tests for command parsing and output behavior
+- manifest tests proving `wharfie.app.js` compiles as expected
+- `wharfie app run <activity>` style tests for the core activity path
+- packaging tests only when packaging is in scope and can be exercised hermetically
+
+Keep tests hermetic:
+- mock Datadog/OpenAI/GitHub/HTTP
+- do not fetch live credentials
+- do not hit AWS
+- do not download Node binaries in tests
+- use temp directories and local fixtures
+
+G) Validation checklist
+
+If you changed only the target app repo, validate the target app repo and run the Wharfie commands relevant to integration.
+
+At minimum, when applicable, run:
+- the target repo's lint/typecheck/test commands
+- `wharfie app manifest <app-dir>`
+- `wharfie app run <activity> --dir <app-dir> ...`
+
+Run `wharfie app package <app-dir>` only when packaging is part of the acceptance criteria.
+
+If you changed Wharfie core too, also rerun:
+
+    cd /mnt/data/LLM_CONTEXT-wharfie/repo
+    export WHARFIE_ARTIFACT_BUCKET="service-bucket"
+    ./../verify.offline.sh repo
+
+H) Output requirements
+
+At the end, return all of the following:
+
+1. A downloadable zip containing every changed file for the target app, preserving target-repo-relative paths only.
+2. If you also changed Wharfie core, a second downloadable zip for Wharfie changes preserving Wharfie-repo-relative paths only.
+3. A concise changelog, including a copyable git commit message for each edited repo.
+4. The exact commands you ran and their results.
+5. Final validation status for every command you ran.
+6. The full unified diff for all modifications.
+
+I) Implementation style rules
+
+- ESM only. No `require()`.
+- Use `node:` imports for built-ins.
+- Use explicit `.js` extensions for relative imports when the runtime needs them.
+- Add JSDoc types for new or edited non-trivial JS.
+- Keep the code surface tight. Do not refactor unrelated modules.
+- Reuse the target repo's existing style, naming, and folder layout when possible.
+- Reuse Wharfie patterns where they are already established instead of inventing a new shape.
+
+J) Example framing for common apps
+
+For a repo-bundling app:
+- keep the CLI as the public product
+- use activities like `bundleRepo`, `assembleBundle`, and `verifyBundle`
+- keep git/fs/tar logic in normal modules
+- only add `objectStorage` or `queue` if remote storage or background work is actually needed
+
+For a Datadog RUM -> ChatGPT app:
+- keep Datadog/OpenAI clients as normal modules with explicit env config
+- use activities like `collectRumWindow`, `buildPromptContext`, and `summarizeRum`
+- add `db` only if you need persisted run state or resumability
+- add `scheduler` only if you need periodic collection
+- add a workflow only if the multi-step pipeline must be resumable and inspectable
+
+Task:
+[PASTE YOUR WHARFIE APP IMPLEMENTATION TASK HERE]

--- a/package.json
+++ b/package.json
@@ -25,12 +25,15 @@
   "files": [
     "README.md",
     "bin/",
-    "apps/README.md",
     "apps/wharfie-v1/wharfie.app.js",
-    "src/README.md",
-    "src/cli/README.md",
+    "src/core/**",
+    "src/cli/entry.js",
+    "src/cli/config.js",
+    "src/cli/input.js",
+    "src/cli/upgrade.js",
     "src/cli/app/**",
     "src/cli/assets/**",
+    "src/cli/output/**",
     "src/cli/cmds/app.js",
     "src/cli/cmds/app_cmds/**",
     "src/cli/cmds/build_self.js",
@@ -41,13 +44,7 @@
     "src/cli/cmds/operations-store.js",
     "src/cli/cmds/ops.js",
     "src/cli/cmds/ops_cmds/**",
-    "src/cli/config.js",
-    "src/cli/entry.js",
-    "src/cli/input.js",
-    "src/cli/output/basic.js",
-    "src/cli/project/project_structure_examples/**",
-    "src/cli/upgrade.js",
-    "src/core/**"
+    "src/cli/project/project_structure_examples/**"
   ],
   "scripts": {
     "typecheck": "tsc",

--- a/src/cli/app/load-app.js
+++ b/src/cli/app/load-app.js
@@ -15,33 +15,8 @@ import Operation from '../../core/lib/graph/operation.js';
  * it can:
  *  - locate the app entrypoint (`wharfie.app.js`)
  *  - load it (ESM)
- *  - derive a normalized JSON manifest that can be embedded into a build artifact
- *
- * Supported export shapes:
- *
- * 1) Plain object export
- *
- *    ```js
- *    export default {
- *      name: 'my-app',
- *      properties: {
- *        targets: [{ nodeVersion: '24', platform: 'linux', architecture: 'x64' }],
- *        resources: {
- *          db: { adapter: 'vanilla', options: { path: '.wharfie' } },
- *        },
- *      },
- *      functions: [new Function(...)],
- *    };
- *    ```
- *
- * 2) ActorSystem instance export
- *
- *    ```js
- *    import ActorSystem from '.../actor-system.js';
- *    export default new ActorSystem({ name: 'my-app', properties: { resources: { ... } } });
- *    ```
- *
- * For ActorSystem exports we only inspect properties and function/workflow definitions.
+ *  - derive a normalized internal runtime manifest
+ *  - derive a normalized public manifest for `wharfie app manifest`
  */
 
 /**
@@ -53,6 +28,12 @@ import Operation from '../../core/lib/graph/operation.js';
  * @property {any} [db] - DB adapter spec / instance.
  * @property {any} [queue] - Queue adapter spec / instance.
  * @property {any} [objectStorage] - Object storage adapter spec / instance.
+ */
+
+/**
+ * @typedef ManifestCliDefinition
+ * @property {string} entrypoint - entrypoint.
+ * @property {string} [export] - export.
  */
 
 /**
@@ -102,12 +83,62 @@ import Operation from '../../core/lib/graph/operation.js';
 /**
  * @typedef WharfieAppManifest
  * @property {{ name: string }} app - App metadata.
+ * @property {ManifestCliDefinition} [cli] - Bundled app CLI entrypoint.
  * @property {Array<{ nodeVersion: string, platform: string, architecture: string, libc?: string }>} [targets] - Build targets, if provided.
  * @property {CapabilitySpecs} [capabilities] - Runtime capability specs (db/queue/objectStorage), if discoverable.
- * @property {CapabilitySpecs} [resources] - Alias for `capabilities` (kept for compatibility with existing ActorSystem terminology).
+ * @property {CapabilitySpecs} [resources] - Alias for `capabilities`.
  * @property {ManifestFunctionDefinition[]} [functions] - Function definitions, if discoverable.
  * @property {ManifestWorkflowDefinition[]} [workflows] - Workflow definitions, if discoverable.
  * @property {ManifestSchedulerDefinition} [scheduler] - Scheduler trigger definitions, if discoverable.
+ */
+
+/**
+ * @typedef PublicActivityDefinition
+ * @property {string} entrypoint - entrypoint.
+ * @property {string} [export] - export.
+ * @property {{ name: string, version: string }[]} [external] - external.
+ * @property {Record<string, string>} [environmentVariables] - environmentVariables.
+ * @property {CapabilitySpecs} [resources] - Activity-scoped resources.
+ */
+
+/**
+ * @typedef PublicWorkflowActionDefinition
+ * @property {string} id - id.
+ * @property {string} type - type.
+ * @property {string} [activity] - activity.
+ * @property {any} [inputs] - inputs.
+ * @property {Record<string, any>} [placement] - placement.
+ * @property {Record<string, any>} [retry] - retry.
+ * @property {string[]} [dependsOn] - dependsOn.
+ */
+
+/**
+ * @typedef PublicWorkflowDefinition
+ * @property {string} name - name.
+ * @property {string} type - type.
+ * @property {PublicWorkflowActionDefinition[]} actions - actions.
+ */
+
+/**
+ * @typedef PublicSchedulerTrigger
+ * @property {string} activity - activity.
+ * @property {string} cron - cron.
+ */
+
+/**
+ * @typedef PublicSchedulerDefinition
+ * @property {PublicSchedulerTrigger[]} triggers - triggers.
+ */
+
+/**
+ * @typedef PublicWharfieAppManifest
+ * @property {{ name: string }} app - App metadata.
+ * @property {ManifestCliDefinition} [cli] - Bundled app CLI entrypoint.
+ * @property {Array<{ nodeVersion: string, platform: string, architecture: string, libc?: string }>} [targets] - Build targets, if provided.
+ * @property {CapabilitySpecs} [resources] - Runtime capability specs (db/queue/objectStorage), if discoverable.
+ * @property {Record<string, PublicActivityDefinition>} [activities] - Activity definitions, if discoverable.
+ * @property {PublicWorkflowDefinition[]} [workflows] - Workflow definitions, if discoverable.
+ * @property {PublicSchedulerDefinition} [scheduler] - Scheduler trigger definitions, if discoverable.
  */
 
 /**
@@ -273,6 +304,53 @@ function normalizeTargets(targets) {
 }
 
 /**
+ * @param {string} entrypointPath - entrypointPath.
+ * @param {string} appDir - appDir.
+ * @returns {string} - Result.
+ */
+function resolveEntrypointPath(entrypointPath, appDir) {
+  return path.isAbsolute(entrypointPath)
+    ? entrypointPath
+    : path.resolve(appDir, entrypointPath);
+}
+
+/**
+ * @param {unknown} cli - cli.
+ * @param {string} appDir - appDir.
+ * @returns {ManifestCliDefinition | undefined} - Result.
+ */
+function normalizeCliDefinition(cli, appDir) {
+  if (typeof cli === 'string' && cli.trim()) {
+    return { entrypoint: resolveEntrypointPath(cli.trim(), appDir) };
+  }
+
+  if (!isPlainObject(cli)) return undefined;
+
+  const entrypointInput =
+    typeof cli.entrypoint === 'string'
+      ? cli.entrypoint
+      : isPlainObject(cli.entrypoint) && typeof cli.entrypoint.path === 'string'
+        ? cli.entrypoint.path
+        : '';
+
+  if (!entrypointInput || !entrypointInput.trim()) {
+    return undefined;
+  }
+
+  const exportName =
+    (typeof cli.export === 'string' && cli.export.trim()) ||
+    (isPlainObject(cli.entrypoint) &&
+      typeof cli.entrypoint.export === 'string' &&
+      cli.entrypoint.export.trim()) ||
+    '';
+
+  return {
+    entrypoint: resolveEntrypointPath(entrypointInput.trim(), appDir),
+    ...(exportName ? { export: exportName } : {}),
+  };
+}
+
+/**
  * @param {unknown[]} candidates - candidates.
  * @returns {unknown[] | undefined} - Result.
  */
@@ -353,9 +431,7 @@ function serializeFunctionDefinition(func, appDir) {
     return undefined;
   }
 
-  const entrypointPath = path.isAbsolute(entrypoint.path)
-    ? entrypoint.path
-    : path.resolve(appDir, entrypoint.path);
+  const entrypointPath = resolveEntrypointPath(entrypoint.path, appDir);
 
   const externalInput =
     properties.external ?? (Array.isArray(func.external) ? func.external : []);
@@ -446,7 +522,7 @@ function normalizeWorkflowDependencies(value) {
  * @param {unknown} action - action.
  * @returns {ManifestWorkflowActionDefinition | undefined} - Result.
  */
-function normalizeWorkflowAction(action) {
+function normalizeInternalWorkflowAction(action) {
   if (!isPlainObject(action)) return undefined;
 
   const id =
@@ -505,7 +581,7 @@ function normalizeWorkflowAction(action) {
  * @param {string} [nameHint] - nameHint.
  * @returns {ManifestWorkflowDefinition | undefined} - Result.
  */
-function normalizeWorkflowDefinition(workflow, nameHint) {
+function normalizeInternalWorkflowDefinition(workflow, nameHint) {
   if (!isPlainObject(workflow)) return undefined;
 
   const name =
@@ -525,7 +601,7 @@ function normalizeWorkflowDefinition(workflow, nameHint) {
   const actions = Array.isArray(workflow.actions)
     ? workflow.actions.reduce(
         (/** @type {ManifestWorkflowActionDefinition[]} */ acc, action) => {
-          const normalized = normalizeWorkflowAction(action);
+          const normalized = normalizeInternalWorkflowAction(action);
           if (normalized) {
             acc.push(normalized);
           }
@@ -548,11 +624,11 @@ function normalizeWorkflowDefinition(workflow, nameHint) {
  * @param {unknown} workflows - workflows.
  * @returns {ManifestWorkflowDefinition[] | undefined} - Result.
  */
-function normalizeWorkflows(workflows) {
+function normalizeInternalWorkflows(workflows) {
   if (Array.isArray(workflows)) {
     const normalized = workflows.reduce(
       (/** @type {ManifestWorkflowDefinition[]} */ acc, workflow) => {
-        const serialized = normalizeWorkflowDefinition(workflow);
+        const serialized = normalizeInternalWorkflowDefinition(workflow);
         if (serialized) {
           acc.push(serialized);
         }
@@ -567,7 +643,10 @@ function normalizeWorkflows(workflows) {
     const normalized = Object.keys(workflows)
       .sort((left, right) => left.localeCompare(right))
       .reduce((/** @type {ManifestWorkflowDefinition[]} */ acc, key) => {
-        const serialized = normalizeWorkflowDefinition(workflows[key], key);
+        const serialized = normalizeInternalWorkflowDefinition(
+          workflows[key],
+          key,
+        );
         if (serialized) {
           acc.push(serialized);
         }
@@ -583,7 +662,7 @@ function normalizeWorkflows(workflows) {
  * @param {unknown} scheduler - scheduler.
  * @returns {ManifestSchedulerDefinition | undefined} - Result.
  */
-function normalizeScheduler(scheduler) {
+function normalizeInternalScheduler(scheduler) {
   if (!isPlainObject(scheduler) && !Array.isArray(scheduler)) {
     return undefined;
   }
@@ -617,152 +696,850 @@ function normalizeScheduler(scheduler) {
 }
 
 /**
- * Compile a manifest from a supported `wharfie.app.js` export.
- * @param {any} appExport - appExport.
+ * @param {unknown} action - action.
+ * @returns {PublicWorkflowActionDefinition | undefined} - Result.
+ */
+function normalizePublicWorkflowAction(action) {
+  if (!isPlainObject(action)) return undefined;
+
+  const id =
+    (typeof action.id === 'string' && action.id.trim()) ||
+    (typeof action.name === 'string' && action.name.trim()) ||
+    '';
+  if (!id) return undefined;
+
+  if (
+    (typeof action.functionName === 'string' && action.functionName.trim()) ||
+    (typeof action.function_name === 'string' && action.function_name.trim())
+  ) {
+    throw new Error(
+      'Plain-object workflow actions must use activity instead of functionName.',
+    );
+  }
+
+  const activity =
+    typeof action.activity === 'string' && action.activity.trim()
+      ? action.activity.trim()
+      : '';
+  const rawType =
+    typeof action.type === 'string' ? action.type.trim().toUpperCase() : '';
+  const type = activity
+    ? 'ACTIVITY'
+    : rawType && Object.values(Action.Type).includes(rawType)
+      ? rawType
+      : '';
+
+  if (!type) return undefined;
+
+  const dependsOn = normalizeWorkflowDependencies(
+    action.dependsOn ?? action.dependencies ?? action.prerequisites,
+  );
+  const inputs = jsonSafeClone(action.inputs);
+  const placement = jsonSafeClone(action.placement);
+  const retry = jsonSafeClone(action.retry);
+
+  /** @type {PublicWorkflowActionDefinition} */
+  const normalized = {
+    id,
+    type,
+  };
+
+  if (activity) {
+    normalized.activity = activity;
+  }
+
+  if (inputs !== undefined) {
+    normalized.inputs = inputs;
+  }
+
+  if (isPlainObject(placement) && Object.keys(placement).length > 0) {
+    normalized.placement = /** @type {Record<string, any>} */ (placement);
+  }
+
+  if (isPlainObject(retry) && Object.keys(retry).length > 0) {
+    normalized.retry = /** @type {Record<string, any>} */ (retry);
+  }
+
+  if (dependsOn) {
+    normalized.dependsOn = dependsOn;
+  }
+
+  return normalized;
+}
+
+/**
+ * @param {unknown} workflow - workflow.
+ * @param {string} [nameHint] - nameHint.
+ * @returns {PublicWorkflowDefinition | undefined} - Result.
+ */
+function normalizePublicWorkflowDefinition(workflow, nameHint) {
+  if (!isPlainObject(workflow)) return undefined;
+
+  const name =
+    (typeof workflow.name === 'string' && workflow.name.trim()) ||
+    (typeof nameHint === 'string' && nameHint.trim()) ||
+    '';
+  if (!name) return undefined;
+
+  const typeCandidate =
+    typeof workflow.type === 'string' && workflow.type.trim()
+      ? workflow.type.trim().toUpperCase()
+      : Operation.Type.PIPELINE;
+  const type = Object.values(Operation.Type).includes(typeCandidate)
+    ? typeCandidate
+    : Operation.Type.PIPELINE;
+
+  const actions = Array.isArray(workflow.actions)
+    ? workflow.actions.reduce(
+        (/** @type {PublicWorkflowActionDefinition[]} */ acc, action) => {
+          const normalized = normalizePublicWorkflowAction(action);
+          if (normalized) {
+            acc.push(normalized);
+          }
+          return acc;
+        },
+        [],
+      )
+    : [];
+
+  if (actions.length === 0) return undefined;
+
+  return {
+    name,
+    type,
+    actions,
+  };
+}
+
+/**
+ * @param {unknown} workflows - workflows.
+ * @returns {PublicWorkflowDefinition[] | undefined} - Result.
+ */
+function normalizePublicWorkflows(workflows) {
+  if (Array.isArray(workflows)) {
+    const normalized = workflows.reduce(
+      (/** @type {PublicWorkflowDefinition[]} */ acc, workflow) => {
+        const serialized = normalizePublicWorkflowDefinition(workflow);
+        if (serialized) {
+          acc.push(serialized);
+        }
+        return acc;
+      },
+      [],
+    );
+    return normalized.length > 0 ? normalized : undefined;
+  }
+
+  if (isPlainObject(workflows)) {
+    const normalized = Object.keys(workflows)
+      .sort((left, right) => left.localeCompare(right))
+      .reduce((/** @type {PublicWorkflowDefinition[]} */ acc, key) => {
+        const serialized = normalizePublicWorkflowDefinition(
+          workflows[key],
+          key,
+        );
+        if (serialized) {
+          acc.push(serialized);
+        }
+        return acc;
+      }, []);
+    return normalized.length > 0 ? normalized : undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * @param {unknown} scheduler - scheduler.
+ * @returns {PublicSchedulerDefinition | undefined} - Result.
+ */
+function normalizePublicScheduler(scheduler) {
+  if (!isPlainObject(scheduler) && !Array.isArray(scheduler)) {
+    return undefined;
+  }
+
+  const cloned = jsonSafeClone(scheduler);
+  if (!isPlainObject(cloned)) {
+    return undefined;
+  }
+
+  const triggers = Array.isArray(cloned.triggers)
+    ? cloned.triggers.reduce((acc, trigger) => {
+        if (!isPlainObject(trigger)) return acc;
+        if (
+          (typeof trigger.actor === 'string' && trigger.actor.trim()) ||
+          (typeof trigger.functionName === 'string' &&
+            trigger.functionName.trim())
+        ) {
+          throw new Error(
+            'Plain-object scheduler triggers must use activity instead of actor/functionName.',
+          );
+        }
+
+        const activity =
+          typeof trigger.activity === 'string' && trigger.activity.trim()
+            ? trigger.activity.trim()
+            : '';
+        const cron =
+          typeof trigger.cron === 'string' && trigger.cron.trim()
+            ? trigger.cron.trim()
+            : '';
+        if (!activity || !cron) return acc;
+        acc.push({ activity, cron });
+        return acc;
+      }, /** @type {PublicSchedulerTrigger[]} */ ([]))
+    : [];
+
+  return triggers.length > 0 ? { triggers } : undefined;
+}
+
+/**
+ * @param {unknown} activity - activity.
+ * @param {string} name - name.
+ * @param {string} appDir - appDir.
+ * @returns {PublicActivityDefinition | undefined} - Result.
+ */
+function normalizePublicActivityDefinition(activity, name, appDir) {
+  const trimmedName = String(name || '').trim();
+  if (!trimmedName) return undefined;
+
+  let entrypointInput = '';
+  let exportName = '';
+  let externalInput = [];
+  let environmentVariablesInput;
+  let resourcesInput;
+
+  if (typeof activity === 'string') {
+    entrypointInput = activity;
+  } else if (isPlainObject(activity)) {
+    if (typeof activity.entrypoint === 'string') {
+      entrypointInput = activity.entrypoint;
+    } else if (
+      isPlainObject(activity.entrypoint) &&
+      typeof activity.entrypoint.path === 'string'
+    ) {
+      entrypointInput = activity.entrypoint.path;
+      if (
+        typeof activity.entrypoint.export === 'string' &&
+        activity.entrypoint.export.trim()
+      ) {
+        exportName = activity.entrypoint.export.trim();
+      }
+    }
+
+    if (typeof activity.export === 'string' && activity.export.trim()) {
+      exportName = activity.export.trim();
+    }
+
+    if (Array.isArray(activity.external)) {
+      externalInput = activity.external;
+    }
+
+    environmentVariablesInput = activity.environmentVariables;
+    resourcesInput = activity.resources;
+  }
+
+  if (!entrypointInput || !entrypointInput.trim()) return undefined;
+
+  const entrypoint = resolveEntrypointPath(entrypointInput.trim(), appDir);
+  const external = normalizeExternalDependencies(externalInput, entrypoint);
+  const environmentVariables = normalizeEnvironmentVariables(
+    environmentVariablesInput,
+  );
+  const resources = pickCapabilitySpecs(resourcesInput);
+
+  /** @type {PublicActivityDefinition} */
+  const normalized = {
+    entrypoint,
+  };
+
+  if (exportName) {
+    normalized.export = exportName;
+  }
+
+  if (Array.isArray(external) && external.length > 0) {
+    normalized.external = external;
+  }
+
+  if (environmentVariables) {
+    normalized.environmentVariables = environmentVariables;
+  }
+
+  if (resources) {
+    normalized.resources = resources;
+  }
+
+  return normalized;
+}
+
+/**
+ * @param {unknown} activities - activities.
+ * @param {string} appDir - appDir.
+ * @returns {Record<string, PublicActivityDefinition> | undefined} - Result.
+ */
+function normalizePublicActivities(activities, appDir) {
+  if (!isPlainObject(activities)) return undefined;
+
+  /** @type {Record<string, PublicActivityDefinition>} */
+  const normalized = {};
+
+  for (const name of Object.keys(activities).sort((left, right) =>
+    left.localeCompare(right),
+  )) {
+    const activity = normalizePublicActivityDefinition(
+      activities[name],
+      name,
+      appDir,
+    );
+    if (activity) {
+      normalized[name] = activity;
+    }
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+/**
+ * @param {unknown[]} candidates - candidates.
+ * @returns {boolean} - Result.
+ */
+function hasLegacyPlainObjectFunctions(candidates) {
+  return candidates.some(
+    (candidate) => Array.isArray(candidate) && candidate.length > 0,
+  );
+}
+
+/**
+ * @param {unknown} workflows - workflows.
+ * @returns {boolean} - Result.
+ */
+function hasLegacyWorkflowFunctionNames(workflows) {
+  if (Array.isArray(workflows)) {
+    return workflows.some((workflow) =>
+      hasLegacyWorkflowFunctionNames(workflow),
+    );
+  }
+
+  if (isPlainObject(workflows)) {
+    if (Array.isArray(workflows.actions)) {
+      return workflows.actions.some((action) => {
+        if (!isPlainObject(action)) return false;
+        return Boolean(
+          (typeof action.functionName === 'string' &&
+            action.functionName.trim()) ||
+          (typeof action.function_name === 'string' &&
+            action.function_name.trim()),
+        );
+      });
+    }
+
+    return Object.values(workflows).some((workflow) =>
+      hasLegacyWorkflowFunctionNames(workflow),
+    );
+  }
+
+  return false;
+}
+
+/**
+ * @param {unknown} scheduler - scheduler.
+ * @returns {boolean} - Result.
+ */
+function hasLegacySchedulerActors(scheduler) {
+  if (!isPlainObject(scheduler)) return false;
+  if (!Array.isArray(scheduler.triggers)) return false;
+
+  return scheduler.triggers.some((trigger) => {
+    if (!isPlainObject(trigger)) return false;
+    return Boolean(
+      (typeof trigger.actor === 'string' && trigger.actor.trim()) ||
+      (typeof trigger.functionName === 'string' && trigger.functionName.trim()),
+    );
+  });
+}
+
+/**
+ * @param {PlainObject} appExport - appExport.
+ * @returns {void}
+ */
+function assertPlainObjectV2Contract(appExport) {
+  if (
+    hasLegacyPlainObjectFunctions([
+      appExport.functions,
+      appExport.properties?.functions,
+      appExport.app?.functions,
+      appExport.app?.properties?.functions,
+    ])
+  ) {
+    throw new Error(
+      'Plain-object wharfie.app.js exports must use activities instead of functions.',
+    );
+  }
+
+  if (
+    [
+      appExport.workflows,
+      appExport.properties?.workflows,
+      appExport.app?.workflows,
+      appExport.app?.properties?.workflows,
+    ].some((candidate) => hasLegacyWorkflowFunctionNames(candidate))
+  ) {
+    throw new Error(
+      'Plain-object workflow actions must use activity instead of functionName.',
+    );
+  }
+
+  if (
+    [
+      appExport.scheduler,
+      appExport.properties?.scheduler,
+      appExport.app?.scheduler,
+      appExport.app?.properties?.scheduler,
+    ].some((candidate) => hasLegacySchedulerActors(candidate))
+  ) {
+    throw new Error(
+      'Plain-object scheduler triggers must use activity instead of actor/functionName.',
+    );
+  }
+}
+
+/**
+ * @param {WharfieAppManifest} manifest - manifest.
+ * @returns {PublicWharfieAppManifest} - Result.
+ */
+function derivePublicManifestFromInternalManifest(manifest) {
+  /** @type {PublicWharfieAppManifest} */
+  const publicManifest = {
+    app: { name: manifest.app.name },
+  };
+
+  if (manifest.cli) {
+    publicManifest.cli = /** @type {ManifestCliDefinition} */ (
+      jsonSafeClone(manifest.cli)
+    );
+  }
+
+  if (Array.isArray(manifest.targets) && manifest.targets.length > 0) {
+    publicManifest.targets = normalizeTargets(manifest.targets);
+  }
+
+  const resources = pickCapabilitySpecs(
+    manifest.resources ?? manifest.capabilities,
+  );
+  if (resources) {
+    publicManifest.resources = resources;
+  }
+
+  if (Array.isArray(manifest.functions) && manifest.functions.length > 0) {
+    /** @type {Record<string, PublicActivityDefinition>} */
+    const activities = {};
+
+    for (const func of [...manifest.functions].sort((left, right) =>
+      left.name.localeCompare(right.name),
+    )) {
+      activities[func.name] = {
+        entrypoint: func.entrypoint.path,
+        ...(typeof func.entrypoint.export === 'string'
+          ? { export: func.entrypoint.export }
+          : {}),
+        ...(Array.isArray(func.external) && func.external.length > 0
+          ? {
+              external: /** @type {{ name: string, version: string }[]} */ (
+                jsonSafeClone(func.external)
+              ),
+            }
+          : {}),
+        ...(func.environmentVariables
+          ? {
+              environmentVariables: /** @type {Record<string, string>} */ (
+                jsonSafeClone(func.environmentVariables)
+              ),
+            }
+          : {}),
+        ...(func.resources
+          ? {
+              resources: /** @type {CapabilitySpecs} */ (
+                jsonSafeClone(func.resources)
+              ),
+            }
+          : {}),
+      };
+    }
+
+    publicManifest.activities = activities;
+  }
+
+  if (Array.isArray(manifest.workflows) && manifest.workflows.length > 0) {
+    /** @type {PublicWorkflowDefinition[]} */
+    const workflows = manifest.workflows.map((workflow) => {
+      /** @type {PublicWorkflowActionDefinition[]} */
+      const actions = workflow.actions.map((action) => {
+        /** @type {PublicWorkflowActionDefinition} */
+        const mappedAction = {
+          id: action.id,
+          type:
+            action.type === Action.Type.INVOKE_FUNCTION && action.functionName
+              ? 'ACTIVITY'
+              : action.type,
+        };
+
+        if (
+          action.type === Action.Type.INVOKE_FUNCTION &&
+          action.functionName
+        ) {
+          mappedAction.activity = action.functionName;
+        }
+
+        if (action.inputs !== undefined) {
+          mappedAction.inputs = jsonSafeClone(action.inputs);
+        }
+
+        if (action.placement) {
+          mappedAction.placement = /** @type {Record<string, any>} */ (
+            jsonSafeClone(action.placement)
+          );
+        }
+
+        if (action.retry) {
+          mappedAction.retry = /** @type {Record<string, any>} */ (
+            jsonSafeClone(action.retry)
+          );
+        }
+
+        if (action.dependsOn) {
+          mappedAction.dependsOn = [...action.dependsOn];
+        }
+
+        return mappedAction;
+      });
+
+      return {
+        name: workflow.name,
+        type: workflow.type,
+        actions,
+      };
+    });
+
+    publicManifest.workflows = workflows;
+  }
+
+  if (manifest.scheduler?.triggers?.length) {
+    publicManifest.scheduler = {
+      triggers: manifest.scheduler.triggers.map((trigger) => ({
+        activity: trigger.actor,
+        cron: trigger.cron,
+      })),
+    };
+  }
+
+  return publicManifest;
+}
+
+/**
+ * @param {PublicWharfieAppManifest} publicManifest - publicManifest.
+ * @returns {WharfieAppManifest} - Result.
+ */
+function deriveInternalManifestFromPublicManifest(publicManifest) {
+  /** @type {WharfieAppManifest} */
+  const manifest = {
+    app: { name: publicManifest.app.name },
+  };
+
+  if (publicManifest.cli) {
+    manifest.cli = /** @type {ManifestCliDefinition} */ (
+      jsonSafeClone(publicManifest.cli)
+    );
+  }
+
+  if (
+    Array.isArray(publicManifest.targets) &&
+    publicManifest.targets.length > 0
+  ) {
+    manifest.targets = normalizeTargets(publicManifest.targets);
+  }
+
+  const resources = pickCapabilitySpecs(publicManifest.resources);
+  if (resources) {
+    manifest.resources = resources;
+    manifest.capabilities = resources;
+  }
+
+  if (isPlainObject(publicManifest.activities)) {
+    const activities = /** @type {Record<string, PublicActivityDefinition>} */ (
+      publicManifest.activities
+    );
+    /** @type {ManifestFunctionDefinition[]} */
+    const functions = Object.keys(activities)
+      .sort((left, right) => left.localeCompare(right))
+      .map((name) => {
+        const activity = activities[name];
+        if (!activity) {
+          throw new Error(`Public manifest activity '${name}' is undefined.`);
+        }
+
+        /** @type {ManifestFunctionDefinition} */
+        const func = {
+          name,
+          entrypoint: {
+            path: activity.entrypoint,
+            ...(activity.export ? { export: activity.export } : {}),
+          },
+        };
+
+        if (Array.isArray(activity.external) && activity.external.length > 0) {
+          func.external = /** @type {{ name: string, version: string }[]} */ (
+            jsonSafeClone(activity.external)
+          );
+        }
+
+        if (activity.environmentVariables) {
+          func.environmentVariables = /** @type {Record<string, string>} */ (
+            jsonSafeClone(activity.environmentVariables)
+          );
+        }
+
+        if (activity.resources) {
+          func.resources = /** @type {CapabilitySpecs} */ (
+            jsonSafeClone(activity.resources)
+          );
+        }
+
+        return func;
+      });
+
+    manifest.functions = functions;
+  }
+
+  if (
+    Array.isArray(publicManifest.workflows) &&
+    publicManifest.workflows.length > 0
+  ) {
+    /** @type {ManifestWorkflowDefinition[]} */
+    const workflows = publicManifest.workflows.map((workflow) => {
+      /** @type {ManifestWorkflowActionDefinition[]} */
+      const actions = workflow.actions.map((action) => {
+        /** @type {ManifestWorkflowActionDefinition} */
+        const mappedAction = {
+          id: action.id,
+          type:
+            action.type === 'ACTIVITY' || action.activity
+              ? Action.Type.INVOKE_FUNCTION
+              : action.type,
+        };
+
+        if (action.activity) {
+          mappedAction.functionName = action.activity;
+        }
+
+        if (action.inputs !== undefined) {
+          mappedAction.inputs = jsonSafeClone(action.inputs);
+        }
+
+        if (action.placement) {
+          mappedAction.placement = /** @type {Record<string, any>} */ (
+            jsonSafeClone(action.placement)
+          );
+        }
+
+        if (action.retry) {
+          mappedAction.retry = /** @type {Record<string, any>} */ (
+            jsonSafeClone(action.retry)
+          );
+        }
+
+        if (action.dependsOn) {
+          mappedAction.dependsOn = [...action.dependsOn];
+        }
+
+        return mappedAction;
+      });
+
+      return {
+        name: workflow.name,
+        type: workflow.type,
+        actions,
+      };
+    });
+
+    manifest.workflows = workflows;
+  }
+
+  if (publicManifest.scheduler?.triggers?.length) {
+    manifest.scheduler = {
+      triggers: publicManifest.scheduler.triggers.map((trigger) => ({
+        actor: trigger.activity,
+        cron: trigger.cron,
+      })),
+    };
+  }
+
+  return manifest;
+}
+
+/**
+ * @param {ActorSystem} appExport - appExport.
  * @param {{ appDir: string }} options - options.
  * @returns {WharfieAppManifest} - Result.
  */
-function compileManifest(appExport, options) {
+function compileInternalManifestFromActorSystem(appExport, options) {
+  const { appDir } = options;
+  const name = appExport.name;
+  if (!name) {
+    throw new Error('ActorSystem export is missing a name');
+  }
+
+  /** @type {WharfieAppManifest} */
+  const manifest = { app: { name } };
+
+  const cli = normalizeCliDefinition(
+    firstObjectCandidate([
+      appExport.get('cli', undefined),
+      appExport.properties?.cli,
+    ]),
+    appDir,
+  );
+  if (cli) {
+    manifest.cli = cli;
+  }
+
+  const targets = normalizeTargets(appExport.get('targets', []));
+  if (targets) {
+    manifest.targets = targets;
+  }
+
+  const resources = firstCapabilityCandidate([
+    appExport.get('resources', {}),
+    appExport.properties?.resources,
+    appExport.properties?.capabilities,
+  ]);
+  if (resources) {
+    manifest.capabilities = resources;
+    manifest.resources = resources;
+  }
+
+  const functions = normalizeFunctions(appExport.functions, appDir);
+  if (functions) {
+    manifest.functions = functions;
+  }
+
+  const workflows = normalizeInternalWorkflows(
+    firstWorkflowCandidate([
+      appExport.get('workflows', []),
+      appExport.properties?.workflows,
+    ]),
+  );
+  if (workflows) {
+    manifest.workflows = workflows;
+  }
+
+  const scheduler = normalizeInternalScheduler(
+    firstObjectCandidate([
+      appExport.get('scheduler', {}),
+      appExport.properties?.scheduler,
+    ]),
+  );
+  if (scheduler) {
+    manifest.scheduler = scheduler;
+  }
+
+  return manifest;
+}
+
+/**
+ * @param {PlainObject} appExport - appExport.
+ * @param {{ appDir: string }} options - options.
+ * @returns {PublicWharfieAppManifest} - Result.
+ */
+function compilePublicManifestFromPlainObject(appExport, options) {
   const { appDir } = options;
 
+  assertPlainObjectV2Contract(appExport);
+
+  const name =
+    (isPlainObject(appExport.app) &&
+      typeof appExport.app.name === 'string' &&
+      appExport.app.name.trim()) ||
+    (typeof appExport.name === 'string' && appExport.name.trim()) ||
+    '';
+
+  if (!name) {
+    throw new Error(
+      'Unsupported app export: expected { name } or { app: { name } }',
+    );
+  }
+
+  /** @type {PublicWharfieAppManifest} */
+  const publicManifest = {
+    app: { name },
+  };
+
+  const cli = normalizeCliDefinition(
+    appExport.cli ?? appExport.app?.cli,
+    appDir,
+  );
+  if (cli) {
+    publicManifest.cli = cli;
+  }
+
+  const targets = normalizeTargets(appExport.targets ?? appExport.app?.targets);
+  if (targets) {
+    publicManifest.targets = targets;
+  }
+
+  const resources = pickCapabilitySpecs(
+    appExport.resources ?? appExport.app?.resources,
+  );
+  if (resources) {
+    publicManifest.resources = resources;
+  }
+
+  const activities = normalizePublicActivities(
+    appExport.activities ?? appExport.app?.activities,
+    appDir,
+  );
+  if (activities) {
+    publicManifest.activities = activities;
+  }
+
+  const workflows = normalizePublicWorkflows(
+    appExport.workflows ?? appExport.app?.workflows,
+  );
+  if (workflows) {
+    publicManifest.workflows = workflows;
+  }
+
+  const scheduler = normalizePublicScheduler(
+    appExport.scheduler ?? appExport.app?.scheduler,
+  );
+  if (scheduler) {
+    publicManifest.scheduler = scheduler;
+  }
+
+  return publicManifest;
+}
+
+/**
+ * Compile manifests from a supported `wharfie.app.js` export.
+ * @param {any} appExport - appExport.
+ * @param {{ appDir: string }} options - options.
+ * @returns {{ manifest: WharfieAppManifest, publicManifest: PublicWharfieAppManifest }} - Result.
+ */
+function compileManifests(appExport, options) {
   // --- Shape 1: ActorSystem instance ---
   if (appExport instanceof ActorSystem) {
-    const name = appExport.name;
-    if (!name) {
-      throw new Error('ActorSystem export is missing a name');
-    }
-
-    /** @type {WharfieAppManifest} */
-    const manifest = { app: { name } };
-
-    const targets = normalizeTargets(appExport.get('targets', []));
-    if (targets) {
-      manifest.targets = targets;
-    }
-
-    const resources = firstCapabilityCandidate([
-      appExport.get('resources', {}),
-      appExport.properties?.resources,
-      appExport.properties?.capabilities,
-    ]);
-    if (resources) {
-      manifest.capabilities = resources;
-      manifest.resources = resources;
-    }
-
-    const functions = normalizeFunctions(appExport.functions, appDir);
-    if (functions) {
-      manifest.functions = functions;
-    }
-
-    const workflows = normalizeWorkflows(
-      firstWorkflowCandidate([
-        appExport.get('workflows', []),
-        appExport.properties?.workflows,
-      ]),
-    );
-    if (workflows) {
-      manifest.workflows = workflows;
-    }
-
-    const scheduler = normalizeScheduler(
-      firstObjectCandidate([
-        appExport.get('scheduler', {}),
-        appExport.properties?.scheduler,
-      ]),
-    );
-    if (scheduler) {
-      manifest.scheduler = scheduler;
-    }
-
-    return manifest;
+    const manifest = compileInternalManifestFromActorSystem(appExport, options);
+    const publicManifest = derivePublicManifestFromInternalManifest(manifest);
+    return { manifest, publicManifest };
   }
 
   // --- Shape 2: plain object export ---
   if (isPlainObject(appExport)) {
-    const name =
-      (isPlainObject(appExport.app) &&
-        typeof appExport.app.name === 'string' &&
-        appExport.app.name) ||
-      (typeof appExport.name === 'string' && appExport.name);
-
-    if (!name) {
-      throw new Error(
-        'Unsupported app export: expected { name } or { app: { name } }',
-      );
-    }
-
-    /** @type {WharfieAppManifest} */
-    const manifest = { app: { name } };
-
-    const targets = normalizeTargets(
-      firstArrayCandidate([
-        appExport.targets,
-        appExport.properties?.targets,
-        appExport.app?.targets,
-        appExport.app?.properties?.targets,
-      ]),
+    const publicManifest = compilePublicManifestFromPlainObject(
+      appExport,
+      options,
     );
-    if (targets) {
-      manifest.targets = targets;
-    }
-
-    const resources = firstCapabilityCandidate([
-      appExport.capabilities,
-      appExport.capabilities?.resources,
-      appExport.resources,
-      appExport.properties?.capabilities,
-      appExport.properties?.capabilities?.resources,
-      appExport.properties?.resources,
-      appExport.app?.capabilities,
-      appExport.app?.capabilities?.resources,
-      appExport.app?.resources,
-      appExport.app?.properties?.capabilities,
-      appExport.app?.properties?.resources,
-    ]);
-    if (resources) {
-      manifest.capabilities = resources;
-      manifest.resources = resources;
-    }
-
-    const functions = normalizeFunctions(
-      firstArrayCandidate([
-        appExport.functions,
-        appExport.properties?.functions,
-        appExport.app?.functions,
-        appExport.app?.properties?.functions,
-      ]),
-      appDir,
-    );
-    if (functions) {
-      manifest.functions = functions;
-    }
-
-    const workflows = normalizeWorkflows(
-      firstWorkflowCandidate([
-        appExport.workflows,
-        appExport.properties?.workflows,
-        appExport.app?.workflows,
-        appExport.app?.properties?.workflows,
-      ]),
-    );
-    if (workflows) {
-      manifest.workflows = workflows;
-    }
-
-    const scheduler = normalizeScheduler(
-      firstObjectCandidate([
-        appExport.scheduler,
-        appExport.properties?.scheduler,
-        appExport.app?.scheduler,
-        appExport.app?.properties?.scheduler,
-      ]),
-    );
-    if (scheduler) {
-      manifest.scheduler = scheduler;
-    }
-
-    return manifest;
+    const manifest = deriveInternalManifestFromPublicManifest(publicManifest);
+    return { manifest, publicManifest };
   }
 
   throw new Error(
@@ -794,9 +1571,9 @@ function createFreshImportUrl(appPath, requestedTargetSelectors) {
 }
 
 /**
- * Load `wharfie.app.js` from disk and compile a manifest.
+ * Load `wharfie.app.js` from disk and compile manifests.
  * @param {LoadAppOptions} [options] - options.
- * @returns {Promise<{ appExport: any, manifest: WharfieAppManifest }>} - Result.
+ * @returns {Promise<{ appExport: any, manifest: WharfieAppManifest, publicManifest: PublicWharfieAppManifest }>} - Result.
  */
 export async function loadApp(options = {}) {
   const dir = options.dir ?? process.cwd();
@@ -824,8 +1601,10 @@ export async function loadApp(options = {}) {
     );
   }
 
-  const manifest = compileManifest(appExport, { appDir: dir });
-  return { appExport, manifest };
+  const { manifest, publicManifest } = compileManifests(appExport, {
+    appDir: dir,
+  });
+  return { appExport, manifest, publicManifest };
 }
 
 export default loadApp;

--- a/src/cli/app/load-app.js
+++ b/src/cli/app/load-app.js
@@ -2,22 +2,11 @@ import { promises as fsp } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import Action from '../../core/lib/graph/action.js';
+import Operation from '../../core/lib/graph/operation.js';
 import ActorSystem from '../../core/resources/builds/actor-system.js';
 import WharfieFunction from '../../core/resources/builds/function.js';
 import { normalizeExternalDependencies } from '../../core/resources/builds/lib/resolve-externals.js';
-import Action from '../../core/lib/graph/action.js';
-import Operation from '../../core/lib/graph/operation.js';
-
-/**
- * Wharfie v2 app loader + manifest compiler.
- *
- * Wharfie v2 apps are code-defined (no YAML). The CLI needs a strict contract so
- * it can:
- *  - locate the app entrypoint (`wharfie.app.js`)
- *  - load it (ESM)
- *  - derive a normalized internal runtime manifest
- *  - derive a normalized public manifest for `wharfie app manifest`
- */
 
 /**
  * @typedef {Record<string, any>} PlainObject
@@ -28,12 +17,6 @@ import Operation from '../../core/lib/graph/operation.js';
  * @property {any} [db] - DB adapter spec / instance.
  * @property {any} [queue] - Queue adapter spec / instance.
  * @property {any} [objectStorage] - Object storage adapter spec / instance.
- */
-
-/**
- * @typedef ManifestCliDefinition
- * @property {string} entrypoint - entrypoint.
- * @property {string} [export] - export.
  */
 
 /**
@@ -52,10 +35,29 @@ import Operation from '../../core/lib/graph/operation.js';
  */
 
 /**
+ * @typedef ManifestActivityDefinition
+ * @property {ManifestFunctionEntrypoint} entrypoint - entrypoint.
+ * @property {{ name: string, version: string }[]} [external] - external.
+ * @property {Record<string, string>} [environmentVariables] - environmentVariables.
+ * @property {CapabilitySpecs} [resources] - Activity-scoped resources.
+ */
+
+/**
  * @typedef ManifestWorkflowActionDefinition
  * @property {string} id - id.
  * @property {string} type - type.
  * @property {string} [functionName] - functionName.
+ * @property {any} [inputs] - inputs.
+ * @property {Record<string, any>} [placement] - placement.
+ * @property {Record<string, any>} [retry] - retry.
+ * @property {string[]} [dependsOn] - dependsOn.
+ */
+
+/**
+ * @typedef ManifestPublicWorkflowActionDefinition
+ * @property {string} id - id.
+ * @property {string} type - type.
+ * @property {string} [activity] - activity.
  * @property {any} [inputs] - inputs.
  * @property {Record<string, any>} [placement] - placement.
  * @property {Record<string, any>} [retry] - retry.
@@ -70,8 +72,21 @@ import Operation from '../../core/lib/graph/operation.js';
  */
 
 /**
+ * @typedef ManifestPublicWorkflowDefinition
+ * @property {string} name - name.
+ * @property {string} type - type.
+ * @property {ManifestPublicWorkflowActionDefinition[]} actions - actions.
+ */
+
+/**
  * @typedef ManifestSchedulerTrigger
  * @property {string} actor - actor.
+ * @property {string} cron - cron.
+ */
+
+/**
+ * @typedef ManifestPublicSchedulerTrigger
+ * @property {string} activity - activity.
  * @property {string} cron - cron.
  */
 
@@ -81,64 +96,31 @@ import Operation from '../../core/lib/graph/operation.js';
  */
 
 /**
+ * @typedef ManifestPublicSchedulerDefinition
+ * @property {ManifestPublicSchedulerTrigger[]} triggers - triggers.
+ */
+
+/**
  * @typedef WharfieAppManifest
  * @property {{ name: string }} app - App metadata.
- * @property {ManifestCliDefinition} [cli] - Bundled app CLI entrypoint.
+ * @property {{ entrypoint: string }} [cli] - cli.
  * @property {Array<{ nodeVersion: string, platform: string, architecture: string, libc?: string }>} [targets] - Build targets, if provided.
  * @property {CapabilitySpecs} [capabilities] - Runtime capability specs (db/queue/objectStorage), if discoverable.
- * @property {CapabilitySpecs} [resources] - Alias for `capabilities`.
+ * @property {CapabilitySpecs} [resources] - Alias for `capabilities` (kept for compatibility with existing ActorSystem terminology).
  * @property {ManifestFunctionDefinition[]} [functions] - Function definitions, if discoverable.
  * @property {ManifestWorkflowDefinition[]} [workflows] - Workflow definitions, if discoverable.
  * @property {ManifestSchedulerDefinition} [scheduler] - Scheduler trigger definitions, if discoverable.
  */
 
 /**
- * @typedef PublicActivityDefinition
- * @property {string} entrypoint - entrypoint.
- * @property {string} [export] - export.
- * @property {{ name: string, version: string }[]} [external] - external.
- * @property {Record<string, string>} [environmentVariables] - environmentVariables.
- * @property {CapabilitySpecs} [resources] - Activity-scoped resources.
- */
-
-/**
- * @typedef PublicWorkflowActionDefinition
- * @property {string} id - id.
- * @property {string} type - type.
- * @property {string} [activity] - activity.
- * @property {any} [inputs] - inputs.
- * @property {Record<string, any>} [placement] - placement.
- * @property {Record<string, any>} [retry] - retry.
- * @property {string[]} [dependsOn] - dependsOn.
- */
-
-/**
- * @typedef PublicWorkflowDefinition
- * @property {string} name - name.
- * @property {string} type - type.
- * @property {PublicWorkflowActionDefinition[]} actions - actions.
- */
-
-/**
- * @typedef PublicSchedulerTrigger
- * @property {string} activity - activity.
- * @property {string} cron - cron.
- */
-
-/**
- * @typedef PublicSchedulerDefinition
- * @property {PublicSchedulerTrigger[]} triggers - triggers.
- */
-
-/**
- * @typedef PublicWharfieAppManifest
+ * @typedef WharfiePublicAppManifest
  * @property {{ name: string }} app - App metadata.
- * @property {ManifestCliDefinition} [cli] - Bundled app CLI entrypoint.
+ * @property {{ entrypoint: string }} [cli] - cli.
  * @property {Array<{ nodeVersion: string, platform: string, architecture: string, libc?: string }>} [targets] - Build targets, if provided.
- * @property {CapabilitySpecs} [resources] - Runtime capability specs (db/queue/objectStorage), if discoverable.
- * @property {Record<string, PublicActivityDefinition>} [activities] - Activity definitions, if discoverable.
- * @property {PublicWorkflowDefinition[]} [workflows] - Workflow definitions, if discoverable.
- * @property {PublicSchedulerDefinition} [scheduler] - Scheduler trigger definitions, if discoverable.
+ * @property {CapabilitySpecs} [resources] - Runtime resource specs.
+ * @property {Record<string, ManifestActivityDefinition>} [activities] - Activity definitions.
+ * @property {ManifestPublicWorkflowDefinition[]} [workflows] - Workflow definitions.
+ * @property {ManifestPublicSchedulerDefinition} [scheduler] - Scheduler trigger definitions.
  */
 
 /**
@@ -171,21 +153,19 @@ function jsonSafeClone(value) {
   if (value === null) return null;
 
   if (isPlainObject(value)) {
-    /** @type {Record<string, unknown>} */
-    const cloned = {};
-
-    for (const key of Object.keys(value).sort((left, right) =>
-      left.localeCompare(right),
-    )) {
-      const child = value[key];
-      if (typeof child === 'function' || child === undefined) continue;
-      const normalized = jsonSafeClone(child);
-      if (normalized !== undefined) {
-        cloned[key] = normalized;
-      }
-    }
-
-    return cloned;
+    return Object.keys(value)
+      .sort((left, right) => left.localeCompare(right))
+      .reduce((acc, key) => {
+        const child = value[key];
+        if (typeof child === 'function' || child === undefined) {
+          return acc;
+        }
+        const normalized = jsonSafeClone(child);
+        if (normalized !== undefined) {
+          acc[key] = normalized;
+        }
+        return acc;
+      }, /** @type {Record<string, unknown>} */ ({}));
   }
 
   if (
@@ -206,23 +186,22 @@ function jsonSafeClone(value) {
 function normalizeEnvironmentVariables(value) {
   if (!isPlainObject(value)) return undefined;
 
-  /** @type {Record<string, string>} */
-  const normalized = {};
-  for (const key of Object.keys(value).sort((left, right) =>
-    left.localeCompare(right),
-  )) {
-    const candidate = value[key];
-    if (
-      candidate === null ||
-      typeof candidate === 'undefined' ||
-      typeof candidate === 'function' ||
-      typeof candidate === 'symbol' ||
-      (typeof candidate === 'object' && candidate !== null)
-    ) {
-      continue;
-    }
-    normalized[key] = String(candidate);
-  }
+  const normalized = Object.keys(value)
+    .sort((left, right) => left.localeCompare(right))
+    .reduce((acc, key) => {
+      const candidate = value[key];
+      if (
+        candidate === null ||
+        typeof candidate === 'undefined' ||
+        typeof candidate === 'function' ||
+        typeof candidate === 'symbol' ||
+        (typeof candidate === 'object' && candidate !== null)
+      ) {
+        return acc;
+      }
+      acc[key] = String(candidate);
+      return acc;
+    }, /** @type {Record<string, string>} */ ({}));
 
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
@@ -250,16 +229,12 @@ function serializeCapabilitySpec(spec) {
 function pickCapabilitySpecs(maybeSpecs) {
   if (!isPlainObject(maybeSpecs)) return undefined;
 
-  /** @type {CapabilitySpecs} */
-  const picked = {};
-
+  const picked = /** @type {CapabilitySpecs} */ ({});
   for (const key of ['db', 'queue', 'objectStorage']) {
     if (!(key in maybeSpecs)) continue;
-    const serialized = serializeCapabilitySpec(
-      /** @type {PlainObject} */ (maybeSpecs)[key],
-    );
+    const serialized = serializeCapabilitySpec(maybeSpecs[key]);
     if (serialized !== undefined) {
-      // @ts-ignore - keyof narrowing is cumbersome in JSDoc mode.
+      // @ts-ignore - JSDoc narrowing is cumbersome here.
       picked[key] = serialized;
     }
   }
@@ -269,85 +244,18 @@ function pickCapabilitySpecs(maybeSpecs) {
 }
 
 /**
- * @param {unknown} targets - targets.
- * @returns {WharfieAppManifest['targets']} - Result.
+ * @param {unknown[]} candidates - candidates.
+ * @returns {CapabilitySpecs | undefined} - Result.
  */
-function normalizeTargets(targets) {
-  if (!Array.isArray(targets) || targets.length === 0) return undefined;
-
-  const normalized = targets.reduce(
-    (/** @type {NonNullable<WharfieAppManifest['targets']>} */ acc, target) => {
-      if (!isPlainObject(target)) return acc;
-      const nodeVersion = target.nodeVersion;
-      const platform = target.platform;
-      const architecture = target.architecture;
-      if (
-        typeof nodeVersion !== 'string' ||
-        typeof platform !== 'string' ||
-        typeof architecture !== 'string'
-      ) {
-        return acc;
-      }
-
-      acc.push({
-        nodeVersion,
-        platform,
-        architecture,
-        ...(typeof target.libc === 'string' ? { libc: target.libc } : {}),
-      });
-      return acc;
-    },
-    [],
-  );
-
-  return normalized.length > 0 ? normalized : undefined;
-}
-
-/**
- * @param {string} entrypointPath - entrypointPath.
- * @param {string} appDir - appDir.
- * @returns {string} - Result.
- */
-function resolveEntrypointPath(entrypointPath, appDir) {
-  return path.isAbsolute(entrypointPath)
-    ? entrypointPath
-    : path.resolve(appDir, entrypointPath);
-}
-
-/**
- * @param {unknown} cli - cli.
- * @param {string} appDir - appDir.
- * @returns {ManifestCliDefinition | undefined} - Result.
- */
-function normalizeCliDefinition(cli, appDir) {
-  if (typeof cli === 'string' && cli.trim()) {
-    return { entrypoint: resolveEntrypointPath(cli.trim(), appDir) };
+function firstCapabilityCandidate(candidates) {
+  for (const candidate of candidates) {
+    const normalized = pickCapabilitySpecs(candidate);
+    if (normalized) {
+      return normalized;
+    }
   }
 
-  if (!isPlainObject(cli)) return undefined;
-
-  const entrypointInput =
-    typeof cli.entrypoint === 'string'
-      ? cli.entrypoint
-      : isPlainObject(cli.entrypoint) && typeof cli.entrypoint.path === 'string'
-        ? cli.entrypoint.path
-        : '';
-
-  if (!entrypointInput || !entrypointInput.trim()) {
-    return undefined;
-  }
-
-  const exportName =
-    (typeof cli.export === 'string' && cli.export.trim()) ||
-    (isPlainObject(cli.entrypoint) &&
-      typeof cli.entrypoint.export === 'string' &&
-      cli.entrypoint.export.trim()) ||
-    '';
-
-  return {
-    entrypoint: resolveEntrypointPath(entrypointInput.trim(), appDir),
-    ...(exportName ? { export: exportName } : {}),
-  };
+  return undefined;
 }
 
 /**
@@ -360,38 +268,6 @@ function firstArrayCandidate(candidates) {
       return candidate;
     }
   }
-
-  return undefined;
-}
-
-/**
- * @param {unknown[]} candidates - candidates.
- * @returns {CapabilitySpecs | undefined} - Result.
- */
-function firstCapabilityCandidate(candidates) {
-  for (const candidate of candidates) {
-    const normalized = pickCapabilitySpecs(candidate);
-    if (normalized) return normalized;
-  }
-
-  return undefined;
-}
-
-/**
- * @param {unknown[]} candidates - candidates.
- * @returns {unknown} - Result.
- */
-function firstWorkflowCandidate(candidates) {
-  for (const candidate of candidates) {
-    if (Array.isArray(candidate) && candidate.length > 0) {
-      return candidate;
-    }
-
-    if (isPlainObject(candidate) && Object.keys(candidate).length > 0) {
-      return candidate;
-    }
-  }
-
   return undefined;
 }
 
@@ -405,67 +281,207 @@ function firstObjectCandidate(candidates) {
       return candidate;
     }
   }
-
   return undefined;
+}
+
+/**
+ * @param {unknown[]} candidates - candidates.
+ * @returns {unknown} - Result.
+ */
+function firstWorkflowCandidate(candidates) {
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate) && candidate.length > 0) {
+      return candidate;
+    }
+    if (isPlainObject(candidate) && Object.keys(candidate).length > 0) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * @param {unknown[]} candidates - candidates.
+ * @returns {string | undefined} - Result.
+ */
+function firstStringCandidate(candidates) {
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * @param {unknown} targets - targets.
+ * @returns {WharfieAppManifest['targets']} - Result.
+ */
+function normalizeTargets(targets) {
+  if (!Array.isArray(targets) || targets.length === 0) return undefined;
+
+  const normalized = targets.reduce((acc, target) => {
+    if (!isPlainObject(target)) return acc;
+    const nodeVersion = target.nodeVersion;
+    const platform = target.platform;
+    const architecture = target.architecture;
+    if (
+      typeof nodeVersion !== 'string' ||
+      typeof platform !== 'string' ||
+      typeof architecture !== 'string'
+    ) {
+      return acc;
+    }
+
+    acc.push({
+      nodeVersion,
+      platform,
+      architecture,
+      ...(typeof target.libc === 'string' ? { libc: target.libc } : {}),
+    });
+    return acc;
+  }, /** @type {NonNullable<WharfieAppManifest['targets']>} */ ([]));
+
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+/**
+ * @param {unknown} candidate - candidate.
+ * @param {string} appDir - appDir.
+ * @returns {ManifestFunctionEntrypoint | undefined} - Result.
+ */
+function normalizeEntrypoint(candidate, appDir) {
+  if (!isPlainObject(candidate) || typeof candidate.path !== 'string') {
+    return undefined;
+  }
+
+  const entrypointPath = path.isAbsolute(candidate.path)
+    ? candidate.path
+    : path.resolve(appDir, candidate.path);
+
+  return {
+    path: entrypointPath,
+    ...(typeof candidate.export === 'string'
+      ? { export: candidate.export }
+      : {}),
+  };
 }
 
 /**
  * @param {any} func - func.
  * @param {string} appDir - appDir.
+ * @param {string} [nameHint] - nameHint.
  * @returns {ManifestFunctionDefinition | undefined} - Result.
  */
-function serializeFunctionDefinition(func, appDir) {
+function serializeFunctionDefinition(func, appDir, nameHint) {
   if (!func || typeof func !== 'object') return undefined;
 
-  const name = typeof func.name === 'string' ? func.name : '';
-  if (!name) return undefined;
+  const inferredName =
+    (typeof nameHint === 'string' && nameHint.trim()) ||
+    (typeof func.name === 'string' ? func.name.trim() : '');
+  if (!inferredName) return undefined;
 
   const properties = isPlainObject(func.properties) ? func.properties : {};
-  const entrypoint = isPlainObject(func.entrypoint)
-    ? func.entrypoint
-    : isPlainObject(properties.entrypoint)
-      ? properties.entrypoint
-      : null;
-
-  if (!entrypoint || typeof entrypoint.path !== 'string') {
+  const entrypoint = normalizeEntrypoint(
+    isPlainObject(func.entrypoint)
+      ? func.entrypoint
+      : isPlainObject(properties.entrypoint)
+        ? properties.entrypoint
+        : undefined,
+    appDir,
+  );
+  if (!entrypoint) {
     return undefined;
   }
 
-  const entrypointPath = resolveEntrypointPath(entrypoint.path, appDir);
-
   const externalInput =
     properties.external ?? (Array.isArray(func.external) ? func.external : []);
-  const external = normalizeExternalDependencies(externalInput, entrypointPath);
-
+  const external = normalizeExternalDependencies(
+    externalInput,
+    entrypoint.path,
+  );
   const environmentVariables = normalizeEnvironmentVariables(
     properties.environmentVariables ?? func.environmentVariables,
   );
   const resources = pickCapabilitySpecs(properties.resources ?? func.resources);
 
-  /** @type {ManifestFunctionDefinition} */
-  const normalized = {
-    name,
-    entrypoint: {
-      path: entrypointPath,
-      ...(typeof entrypoint.export === 'string'
-        ? { export: entrypoint.export }
-        : {}),
-    },
-  };
+  const normalized = /** @type {ManifestFunctionDefinition} */ ({
+    name: inferredName,
+    entrypoint,
+  });
 
   if (Array.isArray(external) && external.length > 0) {
     normalized.external = external;
   }
-
   if (environmentVariables) {
     normalized.environmentVariables = environmentVariables;
   }
-
   if (resources) {
     normalized.resources = resources;
   }
 
   return normalized;
+}
+
+/**
+ * @param {ManifestFunctionDefinition} definition - definition.
+ * @returns {ManifestActivityDefinition} - Result.
+ */
+function toActivityDefinition(definition) {
+  return {
+    entrypoint: definition.entrypoint,
+    ...(Array.isArray(definition.external) && definition.external.length > 0
+      ? { external: definition.external }
+      : {}),
+    ...(definition.environmentVariables
+      ? { environmentVariables: definition.environmentVariables }
+      : {}),
+    ...(definition.resources ? { resources: definition.resources } : {}),
+  };
+}
+
+/**
+ * @param {ManifestWorkflowActionDefinition | ManifestPublicWorkflowActionDefinition} action - action.
+ * @returns {string | undefined} - Result.
+ */
+function getWorkflowActionActivityName(action) {
+  if (
+    'activity' in action &&
+    typeof action.activity === 'string' &&
+    action.activity
+  ) {
+    return action.activity;
+  }
+  if (
+    'functionName' in action &&
+    typeof action.functionName === 'string' &&
+    action.functionName
+  ) {
+    return action.functionName;
+  }
+  return undefined;
+}
+
+/**
+ * @param {ManifestSchedulerTrigger | ManifestPublicSchedulerTrigger} trigger - trigger.
+ * @returns {string | undefined} - Result.
+ */
+function getSchedulerTriggerActivityName(trigger) {
+  if (
+    'activity' in trigger &&
+    typeof trigger.activity === 'string' &&
+    trigger.activity
+  ) {
+    return trigger.activity;
+  }
+  if (
+    'actor' in trigger &&
+    typeof trigger.actor === 'string' &&
+    trigger.actor
+  ) {
+    return trigger.actor;
+  }
+  return undefined;
 }
 
 /**
@@ -476,25 +492,77 @@ function serializeFunctionDefinition(func, appDir) {
 function normalizeFunctions(functions, appDir) {
   if (!Array.isArray(functions) || functions.length === 0) return undefined;
 
-  const normalized = functions.reduce(
-    (/** @type {ManifestFunctionDefinition[]} */ acc, func) => {
-      if (
-        !(func instanceof WharfieFunction) &&
-        (!func || typeof func !== 'object')
-      ) {
-        return acc;
-      }
-
-      const serialized = serializeFunctionDefinition(func, appDir);
-      if (serialized) {
-        acc.push(serialized);
-      }
+  const normalized = functions.reduce((acc, func) => {
+    if (
+      !(func instanceof WharfieFunction) &&
+      (!func || typeof func !== 'object')
+    ) {
       return acc;
-    },
-    [],
-  );
+    }
+
+    const serialized = serializeFunctionDefinition(func, appDir);
+    if (serialized) {
+      acc.push(serialized);
+    }
+    return acc;
+  }, /** @type {ManifestFunctionDefinition[]} */ ([]));
 
   return normalized.length > 0 ? normalized : undefined;
+}
+
+/**
+ * @param {unknown} activities - activities.
+ * @param {string} appDir - appDir.
+ * @returns {Record<string, ManifestActivityDefinition> | undefined} - Result.
+ */
+function normalizeActivities(activities, appDir) {
+  if (Array.isArray(activities)) {
+    const normalized = activities.reduce((acc, activity) => {
+      const serialized = serializeFunctionDefinition(activity, appDir);
+      if (serialized) {
+        acc[serialized.name] = toActivityDefinition(serialized);
+      }
+      return acc;
+    }, /** @type {Record<string, ManifestActivityDefinition>} */ ({}));
+    return Object.keys(normalized).length > 0 ? normalized : undefined;
+  }
+
+  if (!isPlainObject(activities)) {
+    return undefined;
+  }
+
+  const normalized = Object.keys(activities)
+    .sort((left, right) => left.localeCompare(right))
+    .reduce((acc, key) => {
+      const serialized = serializeFunctionDefinition(
+        activities[key],
+        appDir,
+        key,
+      );
+      if (serialized) {
+        acc[key] = toActivityDefinition(serialized);
+      }
+      return acc;
+    }, /** @type {Record<string, ManifestActivityDefinition>} */ ({}));
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+/**
+ * @param {Record<string, ManifestActivityDefinition> | undefined} activities - activities.
+ * @returns {ManifestFunctionDefinition[] | undefined} - Result.
+ */
+function activitiesToFunctions(activities) {
+  if (!activities) return undefined;
+
+  const functions = Object.keys(activities)
+    .sort((left, right) => left.localeCompare(right))
+    .map((name) => ({
+      name,
+      ...activities[name],
+    }));
+
+  return functions.length > 0 ? functions : undefined;
 }
 
 /**
@@ -504,25 +572,23 @@ function normalizeFunctions(functions, appDir) {
 function normalizeWorkflowDependencies(value) {
   if (!Array.isArray(value) || value.length === 0) return undefined;
 
-  const dependencies = value.reduce(
-    (/** @type {string[]} */ acc, dependency) => {
-      if (typeof dependency !== 'string') return acc;
-      const trimmed = dependency.trim();
-      if (!trimmed || acc.includes(trimmed)) return acc;
-      acc.push(trimmed);
-      return acc;
-    },
-    [],
-  );
+  const dependencies = value.reduce((acc, dependency) => {
+    if (typeof dependency !== 'string') return acc;
+    const trimmed = dependency.trim();
+    if (!trimmed || acc.includes(trimmed)) return acc;
+    acc.push(trimmed);
+    return acc;
+  }, /** @type {string[]} */ ([]));
 
   return dependencies.length > 0 ? dependencies : undefined;
 }
 
 /**
  * @param {unknown} action - action.
- * @returns {ManifestWorkflowActionDefinition | undefined} - Result.
+ * @param {{ publicShape: boolean }} options - options.
+ * @returns {ManifestWorkflowActionDefinition | ManifestPublicWorkflowActionDefinition | undefined} - Result.
  */
-function normalizeInternalWorkflowAction(action) {
+function normalizeWorkflowAction(action, options) {
   if (!isPlainObject(action)) return undefined;
 
   const id =
@@ -536,9 +602,11 @@ function normalizeInternalWorkflowAction(action) {
     return undefined;
   }
 
-  const functionName =
+  const activityName =
+    (typeof action.activity === 'string' && action.activity.trim()) ||
     (typeof action.functionName === 'string' && action.functionName.trim()) ||
     (typeof action.function_name === 'string' && action.function_name.trim()) ||
+    (typeof action.actor === 'string' && action.actor.trim()) ||
     '';
   const dependsOn = normalizeWorkflowDependencies(
     action.dependsOn ?? action.dependencies ?? action.prerequisites,
@@ -547,28 +615,33 @@ function normalizeInternalWorkflowAction(action) {
   const placement = jsonSafeClone(action.placement);
   const retry = jsonSafeClone(action.retry);
 
-  /** @type {ManifestWorkflowActionDefinition} */
-  const normalized = {
-    id,
-    type,
-  };
+  const normalized =
+    /** @type {ManifestWorkflowActionDefinition | ManifestPublicWorkflowActionDefinition} */ ({
+      id,
+      type,
+    });
 
-  if (functionName) {
-    normalized.functionName = functionName;
+  if (activityName) {
+    if (options.publicShape) {
+      /** @type {ManifestPublicWorkflowActionDefinition} */ (
+        normalized
+      ).activity = activityName;
+    } else {
+      /** @type {ManifestWorkflowActionDefinition} */ (
+        normalized
+      ).functionName = activityName;
+    }
   }
 
   if (inputs !== undefined) {
     normalized.inputs = inputs;
   }
-
   if (isPlainObject(placement) && Object.keys(placement).length > 0) {
     normalized.placement = /** @type {Record<string, any>} */ (placement);
   }
-
   if (isPlainObject(retry) && Object.keys(retry).length > 0) {
     normalized.retry = /** @type {Record<string, any>} */ (retry);
   }
-
   if (dependsOn) {
     normalized.dependsOn = dependsOn;
   }
@@ -578,10 +651,11 @@ function normalizeInternalWorkflowAction(action) {
 
 /**
  * @param {unknown} workflow - workflow.
- * @param {string} [nameHint] - nameHint.
- * @returns {ManifestWorkflowDefinition | undefined} - Result.
+ * @param {string | undefined} nameHint - nameHint.
+ * @param {{ publicShape: boolean }} options - options.
+ * @returns {ManifestWorkflowDefinition | ManifestPublicWorkflowDefinition | undefined} - Result.
  */
-function normalizeInternalWorkflowDefinition(workflow, nameHint) {
+function normalizeWorkflowDefinition(workflow, nameHint, options) {
   if (!isPlainObject(workflow)) return undefined;
 
   const name =
@@ -599,16 +673,13 @@ function normalizeInternalWorkflowDefinition(workflow, nameHint) {
     : Operation.Type.PIPELINE;
 
   const actions = Array.isArray(workflow.actions)
-    ? workflow.actions.reduce(
-        (/** @type {ManifestWorkflowActionDefinition[]} */ acc, action) => {
-          const normalized = normalizeInternalWorkflowAction(action);
-          if (normalized) {
-            acc.push(normalized);
-          }
-          return acc;
-        },
-        [],
-      )
+    ? workflow.actions.reduce((acc, action) => {
+        const normalized = normalizeWorkflowAction(action, options);
+        if (normalized) {
+          acc.push(normalized);
+        }
+        return acc;
+      }, /** @type {(ManifestWorkflowActionDefinition | ManifestPublicWorkflowActionDefinition)[]} */ ([]))
     : [];
 
   if (actions.length === 0) return undefined;
@@ -622,36 +693,39 @@ function normalizeInternalWorkflowDefinition(workflow, nameHint) {
 
 /**
  * @param {unknown} workflows - workflows.
- * @returns {ManifestWorkflowDefinition[] | undefined} - Result.
+ * @param {{ publicShape: boolean }} options - options.
+ * @returns {ManifestWorkflowDefinition[] | ManifestPublicWorkflowDefinition[] | undefined} - Result.
  */
-function normalizeInternalWorkflows(workflows) {
+function normalizeWorkflows(workflows, options) {
   if (Array.isArray(workflows)) {
-    const normalized = workflows.reduce(
-      (/** @type {ManifestWorkflowDefinition[]} */ acc, workflow) => {
-        const serialized = normalizeInternalWorkflowDefinition(workflow);
-        if (serialized) {
-          acc.push(serialized);
-        }
-        return acc;
-      },
-      [],
-    );
+    const normalized = workflows.reduce((acc, workflow) => {
+      const serialized = normalizeWorkflowDefinition(
+        workflow,
+        undefined,
+        options,
+      );
+      if (serialized) {
+        acc.push(serialized);
+      }
+      return acc;
+    }, /** @type {(ManifestWorkflowDefinition | ManifestPublicWorkflowDefinition)[]} */ ([]));
     return normalized.length > 0 ? normalized : undefined;
   }
 
   if (isPlainObject(workflows)) {
     const normalized = Object.keys(workflows)
       .sort((left, right) => left.localeCompare(right))
-      .reduce((/** @type {ManifestWorkflowDefinition[]} */ acc, key) => {
-        const serialized = normalizeInternalWorkflowDefinition(
+      .reduce((acc, key) => {
+        const serialized = normalizeWorkflowDefinition(
           workflows[key],
           key,
+          options,
         );
         if (serialized) {
           acc.push(serialized);
         }
         return acc;
-      }, []);
+      }, /** @type {(ManifestWorkflowDefinition | ManifestPublicWorkflowDefinition)[]} */ ([]));
     return normalized.length > 0 ? normalized : undefined;
   }
 
@@ -660,9 +734,10 @@ function normalizeInternalWorkflows(workflows) {
 
 /**
  * @param {unknown} scheduler - scheduler.
- * @returns {ManifestSchedulerDefinition | undefined} - Result.
+ * @param {{ publicShape: boolean }} options - options.
+ * @returns {ManifestSchedulerDefinition | ManifestPublicSchedulerDefinition | undefined} - Result.
  */
-function normalizeInternalScheduler(scheduler) {
+function normalizeScheduler(scheduler, options) {
   if (!isPlainObject(scheduler) && !Array.isArray(scheduler)) {
     return undefined;
   }
@@ -675,786 +750,102 @@ function normalizeInternalScheduler(scheduler) {
   const triggers = Array.isArray(cloned.triggers)
     ? cloned.triggers.reduce((acc, trigger) => {
         if (!isPlainObject(trigger)) return acc;
-        const actor =
-          typeof trigger.actor === 'string' && trigger.actor.trim()
-            ? trigger.actor.trim()
-            : typeof trigger.functionName === 'string' &&
-                trigger.functionName.trim()
-              ? trigger.functionName.trim()
-              : '';
-        const cron =
-          typeof trigger.cron === 'string' && trigger.cron.trim()
-            ? trigger.cron.trim()
-            : '';
-        if (!actor || !cron) return acc;
-        acc.push({ actor, cron });
-        return acc;
-      }, /** @type {ManifestSchedulerTrigger[]} */ ([]))
-    : [];
 
-  return triggers.length > 0 ? { triggers } : undefined;
-}
-
-/**
- * @param {unknown} action - action.
- * @returns {PublicWorkflowActionDefinition | undefined} - Result.
- */
-function normalizePublicWorkflowAction(action) {
-  if (!isPlainObject(action)) return undefined;
-
-  const id =
-    (typeof action.id === 'string' && action.id.trim()) ||
-    (typeof action.name === 'string' && action.name.trim()) ||
-    '';
-  if (!id) return undefined;
-
-  if (
-    (typeof action.functionName === 'string' && action.functionName.trim()) ||
-    (typeof action.function_name === 'string' && action.function_name.trim())
-  ) {
-    throw new Error(
-      'Plain-object workflow actions must use activity instead of functionName.',
-    );
-  }
-
-  const activity =
-    typeof action.activity === 'string' && action.activity.trim()
-      ? action.activity.trim()
-      : '';
-  const rawType =
-    typeof action.type === 'string' ? action.type.trim().toUpperCase() : '';
-  const type = activity
-    ? 'ACTIVITY'
-    : rawType && Object.values(Action.Type).includes(rawType)
-      ? rawType
-      : '';
-
-  if (!type) return undefined;
-
-  const dependsOn = normalizeWorkflowDependencies(
-    action.dependsOn ?? action.dependencies ?? action.prerequisites,
-  );
-  const inputs = jsonSafeClone(action.inputs);
-  const placement = jsonSafeClone(action.placement);
-  const retry = jsonSafeClone(action.retry);
-
-  /** @type {PublicWorkflowActionDefinition} */
-  const normalized = {
-    id,
-    type,
-  };
-
-  if (activity) {
-    normalized.activity = activity;
-  }
-
-  if (inputs !== undefined) {
-    normalized.inputs = inputs;
-  }
-
-  if (isPlainObject(placement) && Object.keys(placement).length > 0) {
-    normalized.placement = /** @type {Record<string, any>} */ (placement);
-  }
-
-  if (isPlainObject(retry) && Object.keys(retry).length > 0) {
-    normalized.retry = /** @type {Record<string, any>} */ (retry);
-  }
-
-  if (dependsOn) {
-    normalized.dependsOn = dependsOn;
-  }
-
-  return normalized;
-}
-
-/**
- * @param {unknown} workflow - workflow.
- * @param {string} [nameHint] - nameHint.
- * @returns {PublicWorkflowDefinition | undefined} - Result.
- */
-function normalizePublicWorkflowDefinition(workflow, nameHint) {
-  if (!isPlainObject(workflow)) return undefined;
-
-  const name =
-    (typeof workflow.name === 'string' && workflow.name.trim()) ||
-    (typeof nameHint === 'string' && nameHint.trim()) ||
-    '';
-  if (!name) return undefined;
-
-  const typeCandidate =
-    typeof workflow.type === 'string' && workflow.type.trim()
-      ? workflow.type.trim().toUpperCase()
-      : Operation.Type.PIPELINE;
-  const type = Object.values(Operation.Type).includes(typeCandidate)
-    ? typeCandidate
-    : Operation.Type.PIPELINE;
-
-  const actions = Array.isArray(workflow.actions)
-    ? workflow.actions.reduce(
-        (/** @type {PublicWorkflowActionDefinition[]} */ acc, action) => {
-          const normalized = normalizePublicWorkflowAction(action);
-          if (normalized) {
-            acc.push(normalized);
-          }
-          return acc;
-        },
-        [],
-      )
-    : [];
-
-  if (actions.length === 0) return undefined;
-
-  return {
-    name,
-    type,
-    actions,
-  };
-}
-
-/**
- * @param {unknown} workflows - workflows.
- * @returns {PublicWorkflowDefinition[] | undefined} - Result.
- */
-function normalizePublicWorkflows(workflows) {
-  if (Array.isArray(workflows)) {
-    const normalized = workflows.reduce(
-      (/** @type {PublicWorkflowDefinition[]} */ acc, workflow) => {
-        const serialized = normalizePublicWorkflowDefinition(workflow);
-        if (serialized) {
-          acc.push(serialized);
-        }
-        return acc;
-      },
-      [],
-    );
-    return normalized.length > 0 ? normalized : undefined;
-  }
-
-  if (isPlainObject(workflows)) {
-    const normalized = Object.keys(workflows)
-      .sort((left, right) => left.localeCompare(right))
-      .reduce((/** @type {PublicWorkflowDefinition[]} */ acc, key) => {
-        const serialized = normalizePublicWorkflowDefinition(
-          workflows[key],
-          key,
-        );
-        if (serialized) {
-          acc.push(serialized);
-        }
-        return acc;
-      }, []);
-    return normalized.length > 0 ? normalized : undefined;
-  }
-
-  return undefined;
-}
-
-/**
- * @param {unknown} scheduler - scheduler.
- * @returns {PublicSchedulerDefinition | undefined} - Result.
- */
-function normalizePublicScheduler(scheduler) {
-  if (!isPlainObject(scheduler) && !Array.isArray(scheduler)) {
-    return undefined;
-  }
-
-  const cloned = jsonSafeClone(scheduler);
-  if (!isPlainObject(cloned)) {
-    return undefined;
-  }
-
-  const triggers = Array.isArray(cloned.triggers)
-    ? cloned.triggers.reduce((acc, trigger) => {
-        if (!isPlainObject(trigger)) return acc;
-        if (
+        const activityName =
+          (typeof trigger.activity === 'string' && trigger.activity.trim()) ||
           (typeof trigger.actor === 'string' && trigger.actor.trim()) ||
           (typeof trigger.functionName === 'string' &&
-            trigger.functionName.trim())
-        ) {
-          throw new Error(
-            'Plain-object scheduler triggers must use activity instead of actor/functionName.',
-          );
-        }
-
-        const activity =
-          typeof trigger.activity === 'string' && trigger.activity.trim()
-            ? trigger.activity.trim()
-            : '';
+          trigger.functionName.trim()
+            ? trigger.functionName.trim()
+            : '');
         const cron =
           typeof trigger.cron === 'string' && trigger.cron.trim()
             ? trigger.cron.trim()
             : '';
-        if (!activity || !cron) return acc;
-        acc.push({ activity, cron });
+        if (!activityName || !cron) return acc;
+
+        if (options.publicShape) {
+          acc.push({ activity: activityName, cron });
+        } else {
+          acc.push({ actor: activityName, cron });
+        }
         return acc;
-      }, /** @type {PublicSchedulerTrigger[]} */ ([]))
+      }, /** @type {(ManifestSchedulerTrigger | ManifestPublicSchedulerTrigger)[]} */ ([]))
     : [];
 
   return triggers.length > 0 ? { triggers } : undefined;
 }
 
 /**
- * @param {unknown} activity - activity.
- * @param {string} name - name.
- * @param {string} appDir - appDir.
- * @returns {PublicActivityDefinition | undefined} - Result.
- */
-function normalizePublicActivityDefinition(activity, name, appDir) {
-  const trimmedName = String(name || '').trim();
-  if (!trimmedName) return undefined;
-
-  let entrypointInput = '';
-  let exportName = '';
-  let externalInput = [];
-  let environmentVariablesInput;
-  let resourcesInput;
-
-  if (typeof activity === 'string') {
-    entrypointInput = activity;
-  } else if (isPlainObject(activity)) {
-    if (typeof activity.entrypoint === 'string') {
-      entrypointInput = activity.entrypoint;
-    } else if (
-      isPlainObject(activity.entrypoint) &&
-      typeof activity.entrypoint.path === 'string'
-    ) {
-      entrypointInput = activity.entrypoint.path;
-      if (
-        typeof activity.entrypoint.export === 'string' &&
-        activity.entrypoint.export.trim()
-      ) {
-        exportName = activity.entrypoint.export.trim();
-      }
-    }
-
-    if (typeof activity.export === 'string' && activity.export.trim()) {
-      exportName = activity.export.trim();
-    }
-
-    if (Array.isArray(activity.external)) {
-      externalInput = activity.external;
-    }
-
-    environmentVariablesInput = activity.environmentVariables;
-    resourcesInput = activity.resources;
-  }
-
-  if (!entrypointInput || !entrypointInput.trim()) return undefined;
-
-  const entrypoint = resolveEntrypointPath(entrypointInput.trim(), appDir);
-  const external = normalizeExternalDependencies(externalInput, entrypoint);
-  const environmentVariables = normalizeEnvironmentVariables(
-    environmentVariablesInput,
-  );
-  const resources = pickCapabilitySpecs(resourcesInput);
-
-  /** @type {PublicActivityDefinition} */
-  const normalized = {
-    entrypoint,
-  };
-
-  if (exportName) {
-    normalized.export = exportName;
-  }
-
-  if (Array.isArray(external) && external.length > 0) {
-    normalized.external = external;
-  }
-
-  if (environmentVariables) {
-    normalized.environmentVariables = environmentVariables;
-  }
-
-  if (resources) {
-    normalized.resources = resources;
-  }
-
-  return normalized;
-}
-
-/**
- * @param {unknown} activities - activities.
- * @param {string} appDir - appDir.
- * @returns {Record<string, PublicActivityDefinition> | undefined} - Result.
- */
-function normalizePublicActivities(activities, appDir) {
-  if (!isPlainObject(activities)) return undefined;
-
-  /** @type {Record<string, PublicActivityDefinition>} */
-  const normalized = {};
-
-  for (const name of Object.keys(activities).sort((left, right) =>
-    left.localeCompare(right),
-  )) {
-    const activity = normalizePublicActivityDefinition(
-      activities[name],
-      name,
-      appDir,
-    );
-    if (activity) {
-      normalized[name] = activity;
-    }
-  }
-
-  return Object.keys(normalized).length > 0 ? normalized : undefined;
-}
-
-/**
- * @param {unknown[]} candidates - candidates.
- * @returns {boolean} - Result.
- */
-function hasLegacyPlainObjectFunctions(candidates) {
-  return candidates.some(
-    (candidate) => Array.isArray(candidate) && candidate.length > 0,
-  );
-}
-
-/**
- * @param {unknown} workflows - workflows.
- * @returns {boolean} - Result.
- */
-function hasLegacyWorkflowFunctionNames(workflows) {
-  if (Array.isArray(workflows)) {
-    return workflows.some((workflow) =>
-      hasLegacyWorkflowFunctionNames(workflow),
-    );
-  }
-
-  if (isPlainObject(workflows)) {
-    if (Array.isArray(workflows.actions)) {
-      return workflows.actions.some((action) => {
-        if (!isPlainObject(action)) return false;
-        return Boolean(
-          (typeof action.functionName === 'string' &&
-            action.functionName.trim()) ||
-          (typeof action.function_name === 'string' &&
-            action.function_name.trim()),
-        );
-      });
-    }
-
-    return Object.values(workflows).some((workflow) =>
-      hasLegacyWorkflowFunctionNames(workflow),
-    );
-  }
-
-  return false;
-}
-
-/**
- * @param {unknown} scheduler - scheduler.
- * @returns {boolean} - Result.
- */
-function hasLegacySchedulerActors(scheduler) {
-  if (!isPlainObject(scheduler)) return false;
-  if (!Array.isArray(scheduler.triggers)) return false;
-
-  return scheduler.triggers.some((trigger) => {
-    if (!isPlainObject(trigger)) return false;
-    return Boolean(
-      (typeof trigger.actor === 'string' && trigger.actor.trim()) ||
-      (typeof trigger.functionName === 'string' && trigger.functionName.trim()),
-    );
-  });
-}
-
-/**
- * @param {PlainObject} appExport - appExport.
+ * @param {any} appExport - appExport.
  * @returns {void}
  */
 function assertPlainObjectV2Contract(appExport) {
-  if (
-    hasLegacyPlainObjectFunctions([
-      appExport.functions,
-      appExport.properties?.functions,
-      appExport.app?.functions,
-      appExport.app?.properties?.functions,
-    ])
-  ) {
+  const legacyFunctions = firstArrayCandidate([
+    appExport.functions,
+    appExport.properties?.functions,
+    appExport.app?.functions,
+    appExport.app?.properties?.functions,
+  ]);
+
+  if (legacyFunctions) {
     throw new Error(
       'Plain-object wharfie.app.js exports must use activities instead of functions.',
     );
   }
 
-  if (
-    [
-      appExport.workflows,
-      appExport.properties?.workflows,
-      appExport.app?.workflows,
-      appExport.app?.properties?.workflows,
-    ].some((candidate) => hasLegacyWorkflowFunctionNames(candidate))
-  ) {
-    throw new Error(
-      'Plain-object workflow actions must use activity instead of functionName.',
-    );
-  }
-
-  if (
-    [
-      appExport.scheduler,
-      appExport.properties?.scheduler,
-      appExport.app?.scheduler,
-      appExport.app?.properties?.scheduler,
-    ].some((candidate) => hasLegacySchedulerActors(candidate))
-  ) {
-    throw new Error(
-      'Plain-object scheduler triggers must use activity instead of actor/functionName.',
-    );
-  }
-}
-
-/**
- * @param {WharfieAppManifest} manifest - manifest.
- * @returns {PublicWharfieAppManifest} - Result.
- */
-function derivePublicManifestFromInternalManifest(manifest) {
-  /** @type {PublicWharfieAppManifest} */
-  const publicManifest = {
-    app: { name: manifest.app.name },
-  };
-
-  if (manifest.cli) {
-    publicManifest.cli = /** @type {ManifestCliDefinition} */ (
-      jsonSafeClone(manifest.cli)
-    );
-  }
-
-  if (Array.isArray(manifest.targets) && manifest.targets.length > 0) {
-    publicManifest.targets = normalizeTargets(manifest.targets);
-  }
-
-  const resources = pickCapabilitySpecs(
-    manifest.resources ?? manifest.capabilities,
-  );
-  if (resources) {
-    publicManifest.resources = resources;
-  }
-
-  if (Array.isArray(manifest.functions) && manifest.functions.length > 0) {
-    /** @type {Record<string, PublicActivityDefinition>} */
-    const activities = {};
-
-    for (const func of [...manifest.functions].sort((left, right) =>
-      left.name.localeCompare(right.name),
-    )) {
-      activities[func.name] = {
-        entrypoint: func.entrypoint.path,
-        ...(typeof func.entrypoint.export === 'string'
-          ? { export: func.entrypoint.export }
-          : {}),
-        ...(Array.isArray(func.external) && func.external.length > 0
-          ? {
-              external: /** @type {{ name: string, version: string }[]} */ (
-                jsonSafeClone(func.external)
-              ),
-            }
-          : {}),
-        ...(func.environmentVariables
-          ? {
-              environmentVariables: /** @type {Record<string, string>} */ (
-                jsonSafeClone(func.environmentVariables)
-              ),
-            }
-          : {}),
-        ...(func.resources
-          ? {
-              resources: /** @type {CapabilitySpecs} */ (
-                jsonSafeClone(func.resources)
-              ),
-            }
-          : {}),
-      };
-    }
-
-    publicManifest.activities = activities;
-  }
-
-  if (Array.isArray(manifest.workflows) && manifest.workflows.length > 0) {
-    /** @type {PublicWorkflowDefinition[]} */
-    const workflows = manifest.workflows.map((workflow) => {
-      /** @type {PublicWorkflowActionDefinition[]} */
-      const actions = workflow.actions.map((action) => {
-        /** @type {PublicWorkflowActionDefinition} */
-        const mappedAction = {
-          id: action.id,
-          type:
-            action.type === Action.Type.INVOKE_FUNCTION && action.functionName
-              ? 'ACTIVITY'
-              : action.type,
-        };
-
-        if (
-          action.type === Action.Type.INVOKE_FUNCTION &&
-          action.functionName
-        ) {
-          mappedAction.activity = action.functionName;
-        }
-
-        if (action.inputs !== undefined) {
-          mappedAction.inputs = jsonSafeClone(action.inputs);
-        }
-
-        if (action.placement) {
-          mappedAction.placement = /** @type {Record<string, any>} */ (
-            jsonSafeClone(action.placement)
-          );
-        }
-
-        if (action.retry) {
-          mappedAction.retry = /** @type {Record<string, any>} */ (
-            jsonSafeClone(action.retry)
-          );
-        }
-
-        if (action.dependsOn) {
-          mappedAction.dependsOn = [...action.dependsOn];
-        }
-
-        return mappedAction;
-      });
-
-      return {
-        name: workflow.name,
-        type: workflow.type,
-        actions,
-      };
-    });
-
-    publicManifest.workflows = workflows;
-  }
-
-  if (manifest.scheduler?.triggers?.length) {
-    publicManifest.scheduler = {
-      triggers: manifest.scheduler.triggers.map((trigger) => ({
-        activity: trigger.actor,
-        cron: trigger.cron,
-      })),
-    };
-  }
-
-  return publicManifest;
-}
-
-/**
- * @param {PublicWharfieAppManifest} publicManifest - publicManifest.
- * @returns {WharfieAppManifest} - Result.
- */
-function deriveInternalManifestFromPublicManifest(publicManifest) {
-  /** @type {WharfieAppManifest} */
-  const manifest = {
-    app: { name: publicManifest.app.name },
-  };
-
-  if (publicManifest.cli) {
-    manifest.cli = /** @type {ManifestCliDefinition} */ (
-      jsonSafeClone(publicManifest.cli)
-    );
-  }
-
-  if (
-    Array.isArray(publicManifest.targets) &&
-    publicManifest.targets.length > 0
-  ) {
-    manifest.targets = normalizeTargets(publicManifest.targets);
-  }
-
-  const resources = pickCapabilitySpecs(publicManifest.resources);
-  if (resources) {
-    manifest.resources = resources;
-    manifest.capabilities = resources;
-  }
-
-  if (isPlainObject(publicManifest.activities)) {
-    const activities = /** @type {Record<string, PublicActivityDefinition>} */ (
-      publicManifest.activities
-    );
-    /** @type {ManifestFunctionDefinition[]} */
-    const functions = Object.keys(activities)
-      .sort((left, right) => left.localeCompare(right))
-      .map((name) => {
-        const activity = activities[name];
-        if (!activity) {
-          throw new Error(`Public manifest activity '${name}' is undefined.`);
-        }
-
-        /** @type {ManifestFunctionDefinition} */
-        const func = {
-          name,
-          entrypoint: {
-            path: activity.entrypoint,
-            ...(activity.export ? { export: activity.export } : {}),
-          },
-        };
-
-        if (Array.isArray(activity.external) && activity.external.length > 0) {
-          func.external = /** @type {{ name: string, version: string }[]} */ (
-            jsonSafeClone(activity.external)
-          );
-        }
-
-        if (activity.environmentVariables) {
-          func.environmentVariables = /** @type {Record<string, string>} */ (
-            jsonSafeClone(activity.environmentVariables)
-          );
-        }
-
-        if (activity.resources) {
-          func.resources = /** @type {CapabilitySpecs} */ (
-            jsonSafeClone(activity.resources)
-          );
-        }
-
-        return func;
-      });
-
-    manifest.functions = functions;
-  }
-
-  if (
-    Array.isArray(publicManifest.workflows) &&
-    publicManifest.workflows.length > 0
-  ) {
-    /** @type {ManifestWorkflowDefinition[]} */
-    const workflows = publicManifest.workflows.map((workflow) => {
-      /** @type {ManifestWorkflowActionDefinition[]} */
-      const actions = workflow.actions.map((action) => {
-        /** @type {ManifestWorkflowActionDefinition} */
-        const mappedAction = {
-          id: action.id,
-          type:
-            action.type === 'ACTIVITY' || action.activity
-              ? Action.Type.INVOKE_FUNCTION
-              : action.type,
-        };
-
-        if (action.activity) {
-          mappedAction.functionName = action.activity;
-        }
-
-        if (action.inputs !== undefined) {
-          mappedAction.inputs = jsonSafeClone(action.inputs);
-        }
-
-        if (action.placement) {
-          mappedAction.placement = /** @type {Record<string, any>} */ (
-            jsonSafeClone(action.placement)
-          );
-        }
-
-        if (action.retry) {
-          mappedAction.retry = /** @type {Record<string, any>} */ (
-            jsonSafeClone(action.retry)
-          );
-        }
-
-        if (action.dependsOn) {
-          mappedAction.dependsOn = [...action.dependsOn];
-        }
-
-        return mappedAction;
-      });
-
-      return {
-        name: workflow.name,
-        type: workflow.type,
-        actions,
-      };
-    });
-
-    manifest.workflows = workflows;
-  }
-
-  if (publicManifest.scheduler?.triggers?.length) {
-    manifest.scheduler = {
-      triggers: publicManifest.scheduler.triggers.map((trigger) => ({
-        actor: trigger.activity,
-        cron: trigger.cron,
-      })),
-    };
-  }
-
-  return manifest;
-}
-
-/**
- * @param {ActorSystem} appExport - appExport.
- * @param {{ appDir: string }} options - options.
- * @returns {WharfieAppManifest} - Result.
- */
-function compileInternalManifestFromActorSystem(appExport, options) {
-  const { appDir } = options;
-  const name = appExport.name;
-  if (!name) {
-    throw new Error('ActorSystem export is missing a name');
-  }
-
-  /** @type {WharfieAppManifest} */
-  const manifest = { app: { name } };
-
-  const cli = normalizeCliDefinition(
-    firstObjectCandidate([
-      appExport.get('cli', undefined),
-      appExport.properties?.cli,
-    ]),
-    appDir,
-  );
-  if (cli) {
-    manifest.cli = cli;
-  }
-
-  const targets = normalizeTargets(appExport.get('targets', []));
-  if (targets) {
-    manifest.targets = targets;
-  }
-
-  const resources = firstCapabilityCandidate([
-    appExport.get('resources', {}),
-    appExport.properties?.resources,
-    appExport.properties?.capabilities,
+  const workflows = firstWorkflowCandidate([
+    appExport.workflows,
+    appExport.properties?.workflows,
+    appExport.app?.workflows,
+    appExport.app?.properties?.workflows,
   ]);
-  if (resources) {
-    manifest.capabilities = resources;
-    manifest.resources = resources;
+
+  const workflowDefinitions = Array.isArray(workflows)
+    ? workflows
+    : isPlainObject(workflows)
+      ? Object.values(workflows)
+      : [];
+  for (const workflow of workflowDefinitions) {
+    const actions = Array.isArray(workflow?.actions) ? workflow.actions : [];
+    for (const action of actions) {
+      if (
+        isPlainObject(action) &&
+        (typeof action.functionName === 'string' ||
+          typeof action.function_name === 'string')
+      ) {
+        throw new Error(
+          'Plain-object workflow actions must use activity instead of functionName.',
+        );
+      }
+    }
   }
 
-  const functions = normalizeFunctions(appExport.functions, appDir);
-  if (functions) {
-    manifest.functions = functions;
+  const scheduler = firstObjectCandidate([
+    appExport.scheduler,
+    appExport.properties?.scheduler,
+    appExport.app?.scheduler,
+    appExport.app?.properties?.scheduler,
+  ]);
+  const triggers = Array.isArray(scheduler?.triggers) ? scheduler.triggers : [];
+  for (const trigger of triggers) {
+    if (
+      isPlainObject(trigger) &&
+      (typeof trigger.actor === 'string' ||
+        typeof trigger.functionName === 'string')
+    ) {
+      throw new Error(
+        'Plain-object scheduler triggers must use activity instead of actor/functionName.',
+      );
+    }
   }
-
-  const workflows = normalizeInternalWorkflows(
-    firstWorkflowCandidate([
-      appExport.get('workflows', []),
-      appExport.properties?.workflows,
-    ]),
-  );
-  if (workflows) {
-    manifest.workflows = workflows;
-  }
-
-  const scheduler = normalizeInternalScheduler(
-    firstObjectCandidate([
-      appExport.get('scheduler', {}),
-      appExport.properties?.scheduler,
-    ]),
-  );
-  if (scheduler) {
-    manifest.scheduler = scheduler;
-  }
-
-  return manifest;
 }
 
 /**
- * @param {PlainObject} appExport - appExport.
- * @param {{ appDir: string }} options - options.
- * @returns {PublicWharfieAppManifest} - Result.
+ * @param {any} appExport - appExport.
+ * @returns {string} - Result.
  */
-function compilePublicManifestFromPlainObject(appExport, options) {
-  const { appDir } = options;
-
-  assertPlainObjectV2Contract(appExport);
-
+function resolveAppName(appExport) {
   const name =
     (isPlainObject(appExport.app) &&
       typeof appExport.app.name === 'string' &&
@@ -1468,78 +859,283 @@ function compilePublicManifestFromPlainObject(appExport, options) {
     );
   }
 
-  /** @type {PublicWharfieAppManifest} */
-  const publicManifest = {
-    app: { name },
-  };
-
-  const cli = normalizeCliDefinition(
-    appExport.cli ?? appExport.app?.cli,
-    appDir,
-  );
-  if (cli) {
-    publicManifest.cli = cli;
-  }
-
-  const targets = normalizeTargets(appExport.targets ?? appExport.app?.targets);
-  if (targets) {
-    publicManifest.targets = targets;
-  }
-
-  const resources = pickCapabilitySpecs(
-    appExport.resources ?? appExport.app?.resources,
-  );
-  if (resources) {
-    publicManifest.resources = resources;
-  }
-
-  const activities = normalizePublicActivities(
-    appExport.activities ?? appExport.app?.activities,
-    appDir,
-  );
-  if (activities) {
-    publicManifest.activities = activities;
-  }
-
-  const workflows = normalizePublicWorkflows(
-    appExport.workflows ?? appExport.app?.workflows,
-  );
-  if (workflows) {
-    publicManifest.workflows = workflows;
-  }
-
-  const scheduler = normalizePublicScheduler(
-    appExport.scheduler ?? appExport.app?.scheduler,
-  );
-  if (scheduler) {
-    publicManifest.scheduler = scheduler;
-  }
-
-  return publicManifest;
+  return name;
 }
 
 /**
- * Compile manifests from a supported `wharfie.app.js` export.
  * @param {any} appExport - appExport.
- * @param {{ appDir: string }} options - options.
- * @returns {{ manifest: WharfieAppManifest, publicManifest: PublicWharfieAppManifest }} - Result.
+ * @param {string} appDir - appDir.
+ * @returns {{ manifest: WharfieAppManifest, publicManifest: WharfiePublicAppManifest }} - Result.
  */
-function compileManifests(appExport, options) {
-  // --- Shape 1: ActorSystem instance ---
-  if (appExport instanceof ActorSystem) {
-    const manifest = compileInternalManifestFromActorSystem(appExport, options);
-    const publicManifest = derivePublicManifestFromInternalManifest(manifest);
-    return { manifest, publicManifest };
+function compileActorSystemManifests(appExport, appDir) {
+  const name = appExport.name;
+  if (!name) {
+    throw new Error('ActorSystem export is missing a name');
   }
 
-  // --- Shape 2: plain object export ---
-  if (isPlainObject(appExport)) {
-    const publicManifest = compilePublicManifestFromPlainObject(
-      appExport,
-      options,
+  const targets = normalizeTargets(appExport.get('targets', []));
+  const resources = firstCapabilityCandidate([
+    appExport.get('resources', {}),
+    appExport.properties?.resources,
+    appExport.properties?.capabilities,
+  ]);
+  const functions = normalizeFunctions(appExport.functions, appDir);
+  const workflows = normalizeWorkflows(
+    firstWorkflowCandidate([
+      appExport.get('workflows', []),
+      appExport.properties?.workflows,
+    ]),
+    { publicShape: false },
+  );
+  const scheduler = normalizeScheduler(
+    firstObjectCandidate([
+      appExport.get('scheduler', {}),
+      appExport.properties?.scheduler,
+    ]),
+    { publicShape: false },
+  );
+  const cliEntrypoint = firstStringCandidate([
+    appExport.get('cli', {})?.entrypoint,
+    appExport.properties?.cli?.entrypoint,
+  ]);
+
+  const manifest = /** @type {WharfieAppManifest} */ ({ app: { name } });
+  if (cliEntrypoint) {
+    manifest.cli = { entrypoint: path.resolve(appDir, cliEntrypoint) };
+  }
+  if (targets) {
+    manifest.targets = targets;
+  }
+  if (resources) {
+    manifest.resources = resources;
+    manifest.capabilities = resources;
+  }
+  if (functions) {
+    manifest.functions = functions;
+  }
+  if (workflows) {
+    manifest.workflows = /** @type {ManifestWorkflowDefinition[]} */ (
+      workflows
     );
-    const manifest = deriveInternalManifestFromPublicManifest(publicManifest);
-    return { manifest, publicManifest };
+  }
+  if (scheduler) {
+    manifest.scheduler = /** @type {ManifestSchedulerDefinition} */ (scheduler);
+  }
+
+  const activities = functions
+    ? Object.keys(
+        functions.reduce((acc, definition) => {
+          acc[definition.name] = toActivityDefinition(definition);
+          return acc;
+        }, /** @type {Record<string, ManifestActivityDefinition>} */ ({})),
+      )
+        .sort((left, right) => left.localeCompare(right))
+        .reduce((acc, name) => {
+          const definition = functions.find(
+            (candidate) => candidate.name === name,
+          );
+          if (definition) {
+            acc[name] = toActivityDefinition(definition);
+          }
+          return acc;
+        }, /** @type {Record<string, ManifestActivityDefinition>} */ ({}))
+    : undefined;
+
+  const publicManifest = /** @type {WharfiePublicAppManifest} */ ({
+    app: { name },
+  });
+  if (manifest.cli) {
+    publicManifest.cli = manifest.cli;
+  }
+  if (targets) {
+    publicManifest.targets = targets;
+  }
+  if (resources) {
+    publicManifest.resources = resources;
+  }
+  if (activities && Object.keys(activities).length > 0) {
+    publicManifest.activities = activities;
+  }
+  if (workflows) {
+    publicManifest.workflows =
+      /** @type {ManifestPublicWorkflowDefinition[]} */ (
+        workflows.map((workflow) => ({
+          name: workflow.name,
+          type: workflow.type,
+          actions: workflow.actions.map((action) => ({
+            id: action.id,
+            type: action.type,
+            ...(typeof getWorkflowActionActivityName(action) === 'string'
+              ? { activity: getWorkflowActionActivityName(action) }
+              : {}),
+            ...(action.inputs !== undefined ? { inputs: action.inputs } : {}),
+            ...(action.placement ? { placement: action.placement } : {}),
+            ...(action.retry ? { retry: action.retry } : {}),
+            ...(action.dependsOn ? { dependsOn: action.dependsOn } : {}),
+          })),
+        }))
+      );
+  }
+  if (scheduler) {
+    publicManifest.scheduler = {
+      triggers: scheduler.triggers.map((trigger) => ({
+        activity: getSchedulerTriggerActivityName(trigger) || '',
+        cron: trigger.cron,
+      })),
+    };
+  }
+
+  return { manifest, publicManifest };
+}
+
+/**
+ * @param {any} appExport - appExport.
+ * @param {string} appDir - appDir.
+ * @returns {{ manifest: WharfieAppManifest, publicManifest: WharfiePublicAppManifest }} - Result.
+ */
+function compilePlainObjectManifests(appExport, appDir) {
+  assertPlainObjectV2Contract(appExport);
+
+  const name = resolveAppName(appExport);
+  const targets = normalizeTargets(
+    firstArrayCandidate([
+      appExport.targets,
+      appExport.properties?.targets,
+      appExport.app?.targets,
+      appExport.app?.properties?.targets,
+    ]),
+  );
+  const resources = firstCapabilityCandidate([
+    appExport.resources,
+    appExport.properties?.resources,
+    appExport.app?.resources,
+    appExport.app?.properties?.resources,
+    appExport.capabilities,
+    appExport.properties?.capabilities,
+  ]);
+  const cliEntrypoint = firstStringCandidate([
+    appExport.cli?.entrypoint,
+    appExport.properties?.cli?.entrypoint,
+    appExport.app?.cli?.entrypoint,
+    appExport.app?.properties?.cli?.entrypoint,
+  ]);
+  const activities = normalizeActivities(
+    firstObjectCandidate([
+      appExport.activities,
+      appExport.properties?.activities,
+      appExport.app?.activities,
+      appExport.app?.properties?.activities,
+    ]) ||
+      firstArrayCandidate([
+        appExport.activities,
+        appExport.properties?.activities,
+        appExport.app?.activities,
+        appExport.app?.properties?.activities,
+      ]),
+    appDir,
+  );
+  const functions = activitiesToFunctions(activities);
+  const workflows = normalizeWorkflows(
+    firstWorkflowCandidate([
+      appExport.workflows,
+      appExport.properties?.workflows,
+      appExport.app?.workflows,
+      appExport.app?.properties?.workflows,
+    ]),
+    { publicShape: false },
+  );
+  const publicWorkflows = normalizeWorkflows(
+    firstWorkflowCandidate([
+      appExport.workflows,
+      appExport.properties?.workflows,
+      appExport.app?.workflows,
+      appExport.app?.properties?.workflows,
+    ]),
+    { publicShape: true },
+  );
+  const scheduler = normalizeScheduler(
+    firstObjectCandidate([
+      appExport.scheduler,
+      appExport.properties?.scheduler,
+      appExport.app?.scheduler,
+      appExport.app?.properties?.scheduler,
+    ]),
+    { publicShape: false },
+  );
+  const publicScheduler = normalizeScheduler(
+    firstObjectCandidate([
+      appExport.scheduler,
+      appExport.properties?.scheduler,
+      appExport.app?.scheduler,
+      appExport.app?.properties?.scheduler,
+    ]),
+    { publicShape: true },
+  );
+
+  const manifest = /** @type {WharfieAppManifest} */ ({ app: { name } });
+  if (cliEntrypoint) {
+    manifest.cli = { entrypoint: path.resolve(appDir, cliEntrypoint) };
+  }
+  if (targets) {
+    manifest.targets = targets;
+  }
+  if (resources) {
+    manifest.resources = resources;
+    manifest.capabilities = resources;
+  }
+  if (functions) {
+    manifest.functions = functions;
+  }
+  if (workflows) {
+    manifest.workflows = /** @type {ManifestWorkflowDefinition[]} */ (
+      workflows
+    );
+  }
+  if (scheduler) {
+    manifest.scheduler = /** @type {ManifestSchedulerDefinition} */ (scheduler);
+  }
+
+  const publicManifest = /** @type {WharfiePublicAppManifest} */ ({
+    app: { name },
+  });
+  if (cliEntrypoint) {
+    publicManifest.cli = { entrypoint: path.resolve(appDir, cliEntrypoint) };
+  }
+  if (targets) {
+    publicManifest.targets = targets;
+  }
+  if (resources) {
+    publicManifest.resources = resources;
+  }
+  if (activities) {
+    publicManifest.activities = activities;
+  }
+  if (publicWorkflows) {
+    publicManifest.workflows =
+      /** @type {ManifestPublicWorkflowDefinition[]} */ (publicWorkflows);
+  }
+  if (publicScheduler) {
+    publicManifest.scheduler =
+      /** @type {ManifestPublicSchedulerDefinition} */ (publicScheduler);
+  }
+
+  return { manifest, publicManifest };
+}
+
+/**
+ * @param {any} appExport - appExport.
+ * @param {{ appDir: string }} options - options.
+ * @returns {{ manifest: WharfieAppManifest, publicManifest: WharfiePublicAppManifest }} - Result.
+ */
+function compileManifests(appExport, options) {
+  const { appDir } = options;
+
+  if (appExport instanceof ActorSystem) {
+    return compileActorSystemManifests(appExport, appDir);
+  }
+
+  if (isPlainObject(appExport)) {
+    return compilePlainObjectManifests(appExport, appDir);
   }
 
   throw new Error(
@@ -1573,7 +1169,7 @@ function createFreshImportUrl(appPath, requestedTargetSelectors) {
 /**
  * Load `wharfie.app.js` from disk and compile manifests.
  * @param {LoadAppOptions} [options] - options.
- * @returns {Promise<{ appExport: any, manifest: WharfieAppManifest, publicManifest: PublicWharfieAppManifest }>} - Result.
+ * @returns {Promise<{ appExport: any, manifest: WharfieAppManifest, publicManifest: WharfiePublicAppManifest }>} - Result.
  */
 export async function loadApp(options = {}) {
   const dir = options.dir ?? process.cwd();
@@ -1581,7 +1177,7 @@ export async function loadApp(options = {}) {
 
   try {
     await fsp.access(appPath);
-  } catch (_err) {
+  } catch (_error) {
     throw new Error(`Could not find wharfie.app.js in: ${dir}`);
   }
 

--- a/src/cli/app/local-app.js
+++ b/src/cli/app/local-app.js
@@ -2,13 +2,17 @@ import { promises as fsp } from 'node:fs';
 import path from 'node:path';
 
 import ActorSystem from '../../core/resources/builds/actor-system.js';
+import FunctionResource from '../../core/resources/builds/function-resource.js';
+import WharfieFunction from '../../core/resources/builds/function.js';
 import SeaBuild from '../../core/resources/builds/sea-build.js';
-import { withResourceScope } from '../../core/resources/resource-scope.js';
-import { createResourceScope } from '../../core/resources/runtime-config.js';
 import {
   APP_MANIFEST_ASSET_NAME,
   writeEmbeddedAppManifestAsset,
 } from '../../core/resources/builds/lib/app-manifest-asset.js';
+import { createPackagedAppEntryCode } from '../../core/resources/builds/lib/packaged-app-entry-code.js';
+import { withResourceScope } from '../../core/resources/resource-scope.js';
+import { createResourceScope } from '../../core/resources/runtime-config.js';
+import { createActorSystemResources } from '../../core/runtime/resources.js';
 
 import { loadApp } from './load-app.js';
 
@@ -20,18 +24,24 @@ import { loadApp } from './load-app.js';
 /**
  * @typedef RunLocalAppOptions
  * @property {string} dir - App directory.
- * @property {string} functionName - Function name.
+ * @property {string} activityName - Activity name.
  * @property {string | undefined} [eventInput] - Event JSON string.
  * @property {string | undefined} [contextInput] - Context JSON string.
  * @property {string | undefined} [stdinInput] - STDIN payload.
  */
 
 /**
+ * @typedef {import('node:process')['platform']} PackageArtifactPlatform
+ * @typedef {import('node:process')['arch']} PackageArtifactArchitecture
+ * @typedef {import('detect-libc').GLIBC|import('detect-libc').MUSL} PackageArtifactLibc
+ */
+
+/**
  * @typedef PackageArtifactTarget
  * @property {string} nodeVersion - nodeVersion.
- * @property {string} platform - platform.
- * @property {string} architecture - architecture.
- * @property {string} [libc] - libc.
+ * @property {PackageArtifactPlatform} platform - platform.
+ * @property {PackageArtifactArchitecture} architecture - architecture.
+ * @property {PackageArtifactLibc} [libc] - libc.
  */
 
 /**
@@ -95,36 +105,86 @@ export function stringifyJson(value, options = {}) {
 }
 
 /**
- * @param {any} appExport - appExport.
- * @returns {void}
+ * @param {{ functions?: { name: string }[] }} manifest - manifest.
+ * @returns {string[]} - Result.
  */
-function assertRunnableApp(appExport) {
-  if (!appExport || typeof appExport.invoke !== 'function') {
-    throw new Error(
-      'App is not runnable. Expected a default export with invoke(functionName, event, context).',
-    );
+function getAvailableActivityNames(manifest) {
+  if (!Array.isArray(manifest.functions)) {
+    return [];
   }
+
+  return manifest.functions
+    .map((func) => (typeof func?.name === 'string' ? func.name.trim() : ''))
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right));
 }
 
 /**
- * @param {any} appExport - appExport.
- * @param {{ app: { name: string }, targets?: PackageArtifactTarget[] }} manifest - manifest.
- * @returns {ActorSystem} - Result.
+ * @param {{ functions?: any[] }} manifest - manifest.
+ * @param {string} activityName - activityName.
+ * @returns {any} - Result.
  */
-function assertPackageableApp(appExport, manifest) {
-  if (!(appExport instanceof ActorSystem)) {
-    throw new Error(
-      'App packaging currently supports ActorSystem exports only.',
-    );
+function getManifestActivityDefinition(manifest, activityName) {
+  const trimmedName = String(activityName || '').trim();
+  const functions = Array.isArray(manifest.functions) ? manifest.functions : [];
+  const definition = functions.find(
+    (func) =>
+      typeof func?.name === 'string' && func.name.trim() === trimmedName,
+  );
+
+  if (definition) {
+    return definition;
   }
 
-  if (!Array.isArray(manifest.targets) || manifest.targets.length === 0) {
-    throw new Error(
-      'App has no build targets. Define properties.targets in wharfie.app.js before packaging.',
-    );
-  }
+  const availableActivities = getAvailableActivityNames(manifest);
+  const suggestions = availableActivities.length
+    ? ` Available activities: ${availableActivities.join(', ')}`
+    : '';
+  throw new Error(`Unknown activity '${trimmedName}'.${suggestions}`);
+}
 
-  return appExport;
+/**
+ * @param {any} manifestFunction - manifestFunction.
+ * @returns {WharfieFunction} - Result.
+ */
+function createManifestActivity(manifestFunction) {
+  return new WharfieFunction({
+    name: manifestFunction.name,
+    entrypoint: manifestFunction.entrypoint,
+    properties: {
+      ...(Array.isArray(manifestFunction.external)
+        ? { external: manifestFunction.external }
+        : {}),
+      ...(isObjectRecord(manifestFunction.environmentVariables)
+        ? { environmentVariables: manifestFunction.environmentVariables }
+        : {}),
+      ...(isObjectRecord(manifestFunction.resources)
+        ? { resources: manifestFunction.resources }
+        : {}),
+    },
+  });
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @returns {Record<string, any>} - Result.
+ */
+function getManifestResourceSpecs(manifest) {
+  if (isObjectRecord(manifest?.resources)) {
+    return manifest.resources;
+  }
+  if (isObjectRecord(manifest?.capabilities)) {
+    return manifest.capabilities;
+  }
+  return {};
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @returns {Promise<{ resources: Record<string, any>, close: () => Promise<void> }>} - Result.
+ */
+function createManifestRuntimeResources(manifest) {
+  return createActorSystemResources(getManifestResourceSpecs(manifest));
 }
 
 /**
@@ -166,9 +226,13 @@ function getSeaBuildResources(actorSystem) {
 function cloneTarget(target) {
   return {
     nodeVersion: String(target.nodeVersion),
-    platform: String(target.platform),
-    architecture: String(target.architecture),
-    ...(typeof target.libc === 'string' ? { libc: target.libc } : {}),
+    platform: /** @type {PackageArtifactPlatform} */ (target.platform),
+    architecture: /** @type {PackageArtifactArchitecture} */ (
+      target.architecture
+    ),
+    ...(typeof target.libc === 'string'
+      ? { libc: /** @type {PackageArtifactLibc} */ (target.libc) }
+      : {}),
   };
 }
 
@@ -291,9 +355,13 @@ function applyTargetSelection(actorSystem, selectedTargets) {
 function getBuildTarget(build) {
   return {
     nodeVersion: String(build.get('nodeVersion')),
-    platform: String(build.get('platform')),
-    architecture: String(build.get('architecture')),
-    ...(build.has('libc') ? { libc: String(build.get('libc')) } : {}),
+    platform: /** @type {PackageArtifactPlatform} */ (build.get('platform')),
+    architecture: /** @type {PackageArtifactArchitecture} */ (
+      build.get('architecture')
+    ),
+    ...(build.has('libc')
+      ? { libc: /** @type {PackageArtifactLibc} */ (build.get('libc')) }
+      : {}),
   };
 }
 
@@ -349,12 +417,201 @@ async function attachEmbeddedManifestAssets(builds, manifest) {
 }
 
 /**
+ * @param {any} manifest - manifest.
+ * @returns {void}
+ */
+function assertPackageableManifest(manifest) {
+  if (!Array.isArray(manifest.targets) || manifest.targets.length === 0) {
+    throw new Error(
+      'App has no build targets. Define targets in wharfie.app.js before packaging.',
+    );
+  }
+}
+
+/**
+ * @param {PackageArtifactTarget} target - target.
+ * @returns {boolean} - Result.
+ */
+function isCurrentHostTarget(target) {
+  const targetPlatform = String(target.platform);
+  const targetArchitecture = String(target.architecture);
+  const targetNodeVersion = String(target.nodeVersion).replace(/^v/, '');
+  const currentNodeVersion = String(process.versions.node).replace(/^v/, '');
+
+  return (
+    targetPlatform === process.platform &&
+    targetArchitecture === process.arch &&
+    (targetNodeVersion === currentNodeVersion ||
+      targetNodeVersion === currentNodeVersion.split('.')[0])
+  );
+}
+
+/**
+ * @param {PackageArtifactTarget[]} targets - targets.
+ * @returns {void}
+ */
+function assertPlainObjectTargetsAreSupported(targets) {
+  const unsupported = targets.filter((target) => !isCurrentHostTarget(target));
+  if (unsupported.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Manifest-defined CLI app packaging currently supports only the current host target (${ActorSystem.getBuildTargetSelector(
+      {
+        nodeVersion: process.versions.node,
+        platform: process.platform,
+        architecture: process.arch,
+      },
+    )}). Unsupported target(s): ${unsupported
+      .map((target) => ActorSystem.getBuildTargetSelector(target))
+      .join(', ')}`,
+  );
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @returns {void}
+ */
+function assertPlainObjectPackageableManifest(manifest) {
+  assertPackageableManifest(manifest);
+
+  if (
+    !isObjectRecord(manifest.cli) ||
+    typeof manifest.cli.entrypoint !== 'string'
+  ) {
+    throw new Error(
+      'Manifest-defined CLI app packaging requires cli.entrypoint in wharfie.app.js.',
+    );
+  }
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @param {PackageArtifactTarget} target - target.
+ * @returns {FunctionResource[]} - Result.
+ */
+function createManifestFunctionResources(manifest, target) {
+  /** @type {any[]} */
+  const functions = Array.isArray(manifest.functions) ? manifest.functions : [];
+
+  return functions.map(
+    (/** @type {any} */ func) =>
+      new FunctionResource({
+        name: `${func.name}-${target.nodeVersion}-${target.platform}-${target.architecture}`,
+        properties: {
+          functionName: func.name,
+          entrypoint: func.entrypoint,
+          ...(Array.isArray(func.external) ? { external: func.external } : {}),
+          ...(isObjectRecord(func.environmentVariables)
+            ? { environmentVariables: func.environmentVariables }
+            : {}),
+          ...(isObjectRecord(func.resources)
+            ? { resources: func.resources }
+            : {}),
+          buildTarget: () => cloneTarget(target),
+        },
+      }),
+  );
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @param {PackageArtifactTarget} target - target.
+ * @param {FunctionResource[]} functionResources - functionResources.
+ * @returns {SeaBuild} - Result.
+ */
+function createManifestCliBuild(manifest, target, functionResources) {
+  const selector = ActorSystem.getBuildTargetSelector(target);
+  return new SeaBuild({
+    name: `${manifest.app.name}-build-${selector}`,
+    dependsOn: [...functionResources],
+    properties: {
+      entryCode: () =>
+        createPackagedAppEntryCode({
+          cliEntrypointPath: manifest.cli.entrypoint,
+          cliExportName:
+            typeof manifest.cli.export === 'string'
+              ? manifest.cli.export
+              : undefined,
+        }),
+      resolveDir: () => path.dirname(manifest.cli.entrypoint),
+      nodeBinaryPath: () => process.execPath,
+      nodeVersion: target.nodeVersion,
+      platform: target.platform,
+      architecture: target.architecture,
+      ...(typeof target.libc === 'string' ? { libc: target.libc } : {}),
+      environmentVariables: () => ({}),
+      assets: () =>
+        functionResources.reduce(
+          (/** @type {Record<string, string>} */ acc, func) => {
+            acc[
+              func.name.replace(
+                `-${target.nodeVersion}-${target.platform}-${target.architecture}`,
+                '',
+              )
+            ] = func.get('singleExecutableAssetPath');
+            return acc;
+          },
+          {},
+        ),
+    },
+  });
+}
+
+/**
+ * @param {(FunctionResource | SeaBuild)[]} resources - resources.
+ * @returns {Promise<void>} - Result.
+ */
+async function initializeBuildResources(resources) {
+  await Promise.all(
+    resources.map(async (resource) => {
+      const maybeInitializable =
+        /** @type {{ initializeEnvironment?: () => Promise<void> }} */ (
+          resource
+        );
+      if (typeof maybeInitializable.initializeEnvironment === 'function') {
+        await maybeInitializable.initializeEnvironment();
+      }
+    }),
+  );
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @param {PackageArtifactTarget[]} selectedTargets - selectedTargets.
+ * @returns {Promise<Array<{ build: SeaBuild, functionResources: FunctionResource[] }>>} - Result.
+ */
+async function buildManifestCliArtifacts(manifest, selectedTargets) {
+  assertPlainObjectPackageableManifest(manifest);
+  assertPlainObjectTargetsAreSupported(selectedTargets);
+
+  /** @type {{ build: SeaBuild, functionResources: FunctionResource[] }[]} */
+  const plans = [];
+
+  for (const target of selectedTargets) {
+    const functionResources = createManifestFunctionResources(manifest, target);
+    const build = createManifestCliBuild(manifest, target, functionResources);
+    const allResources = [...functionResources, build];
+    await initializeBuildResources(allResources);
+    plans.push({ build, functionResources });
+  }
+
+  return plans;
+}
+
+/**
  * @param {RunLocalAppOptions} options - options.
  * @returns {Promise<{ manifest: any, result: any }>} - Result.
  */
 export async function runLocalApp(options) {
-  const { appExport, manifest } = await loadApp({ dir: options.dir });
-  assertRunnableApp(appExport);
+  const { manifest } = await loadApp({ dir: options.dir });
+  const activityDefinition = getManifestActivityDefinition(
+    manifest,
+    options.activityName,
+  );
+  const activity = createManifestActivity(activityDefinition);
+  const appRuntimeResources = await createManifestRuntimeResources(manifest);
 
   const eventSource = options.eventInput ?? options.stdinInput;
   const event = parseJsonInput(eventSource, 'event', {});
@@ -365,12 +622,13 @@ export async function runLocalApp(options) {
   }
 
   try {
-    const result = await appExport.invoke(options.functionName, event, context);
+    const result = await activity.fn(event, context, {
+      baseResources: appRuntimeResources.resources,
+    });
     return { manifest, result };
   } finally {
-    if (typeof appExport.closeRuntimeResources === 'function') {
-      await appExport.closeRuntimeResources();
-    }
+    await activity.closeRuntimeResources();
+    await appRuntimeResources.close();
   }
 }
 
@@ -380,41 +638,69 @@ export async function runLocalApp(options) {
  */
 export async function packageLocalApp(options) {
   let { appExport, manifest } = await loadApp({ dir: options.dir });
-  let actorSystem = assertPackageableApp(appExport, manifest);
+  assertPackageableManifest(manifest);
 
   const selectedTargets = selectTargets(
-    manifest.targets || [],
+    /** @type {PackageArtifactTarget[]} */ (manifest.targets || []),
     options.targetFilters,
   );
   if (selectedTargets.length === 0) {
     throw new Error('No targets matched the requested package filter.');
   }
 
-  const requestedTargetSelectors = selectedTargets.map((target) =>
-    ActorSystem.getBuildTargetSelector(target),
-  );
-  if (
-    Array.isArray(options.targetFilters) &&
-    options.targetFilters.length > 0 &&
-    requestedTargetSelectors.length > 0
-  ) {
-    ({ appExport, manifest } = await loadApp({
-      dir: options.dir,
-      requestedTargetSelectors,
-    }));
-    actorSystem = assertPackageableApp(appExport, manifest);
+  /** @type {SeaBuild[]} */
+  let builds = [];
+  /** @type {FunctionResource[]} */
+  let plainObjectFunctionResources = [];
+
+  if (appExport instanceof ActorSystem) {
+    let actorSystem = appExport;
+    const requestedTargetSelectors = selectedTargets.map((target) =>
+      ActorSystem.getBuildTargetSelector(target),
+    );
+    if (
+      Array.isArray(options.targetFilters) &&
+      options.targetFilters.length > 0 &&
+      requestedTargetSelectors.length > 0
+    ) {
+      ({ appExport, manifest } = await loadApp({
+        dir: options.dir,
+        requestedTargetSelectors,
+      }));
+      if (!(appExport instanceof ActorSystem)) {
+        throw new Error('Filtered packaging expected an ActorSystem export.');
+      }
+      actorSystem = appExport;
+    }
+
+    applyTargetSelection(actorSystem, selectedTargets);
+    manifest.targets = selectedTargets.map((target) => cloneTarget(target));
+
+    builds = getSeaBuildResources(actorSystem);
+    await attachEmbeddedManifestAssets(builds, manifest);
+
+    if (typeof actorSystem.initializeEnvironment === 'function') {
+      await actorSystem.initializeEnvironment();
+    }
+    await actorSystem.reconcile();
+  } else {
+    manifest.targets = selectedTargets.map((target) => cloneTarget(target));
+    const buildPlans = await buildManifestCliArtifacts(
+      manifest,
+      selectedTargets,
+    );
+    builds = buildPlans.map((plan) => plan.build);
+    plainObjectFunctionResources = buildPlans.flatMap(
+      (plan) => plan.functionResources,
+    );
+    await attachEmbeddedManifestAssets(builds, manifest);
+    for (const functionResource of plainObjectFunctionResources) {
+      await functionResource.reconcile();
+    }
+    for (const build of builds) {
+      await build.reconcile();
+    }
   }
-
-  applyTargetSelection(actorSystem, selectedTargets);
-  manifest.targets = selectedTargets.map((target) => cloneTarget(target));
-
-  const builds = getSeaBuildResources(actorSystem);
-  await attachEmbeddedManifestAssets(builds, manifest);
-
-  if (typeof actorSystem.initializeEnvironment === 'function') {
-    await actorSystem.initializeEnvironment();
-  }
-  await actorSystem.reconcile();
 
   if (builds.length === 0) {
     throw new Error(
@@ -451,9 +737,15 @@ export async function packageLocalApp(options) {
     });
   }
 
+  const manifestTargets = Array.isArray(manifest.targets)
+    ? manifest.targets.map((target) =>
+        cloneTarget(/** @type {PackageArtifactTarget} */ (target)),
+      )
+    : undefined;
+
   return {
     app: manifest.app,
-    ...(Array.isArray(manifest.targets) ? { targets: manifest.targets } : {}),
+    ...(manifestTargets ? { targets: manifestTargets } : {}),
     outputDir,
     artifacts,
   };

--- a/src/cli/app/local-app.js
+++ b/src/cli/app/local-app.js
@@ -2,17 +2,19 @@ import { promises as fsp } from 'node:fs';
 import path from 'node:path';
 
 import ActorSystem from '../../core/resources/builds/actor-system.js';
-import FunctionResource from '../../core/resources/builds/function-resource.js';
-import WharfieFunction from '../../core/resources/builds/function.js';
 import SeaBuild from '../../core/resources/builds/sea-build.js';
 import {
   APP_MANIFEST_ASSET_NAME,
   writeEmbeddedAppManifestAsset,
 } from '../../core/resources/builds/lib/app-manifest-asset.js';
-import { createPackagedAppEntryCode } from '../../core/resources/builds/lib/packaged-app-entry-code.js';
 import { withResourceScope } from '../../core/resources/resource-scope.js';
 import { createResourceScope } from '../../core/resources/runtime-config.js';
-import { createActorSystemResources } from '../../core/runtime/resources.js';
+import {
+  createManifestActivityFunction,
+  getManifestActivityNames,
+  getManifestResourcesSpec,
+  invokeManifestActivity,
+} from '../../core/runtime/app-runs.js';
 
 import { loadApp } from './load-app.js';
 
@@ -24,24 +26,19 @@ import { loadApp } from './load-app.js';
 /**
  * @typedef RunLocalAppOptions
  * @property {string} dir - App directory.
- * @property {string} activityName - Activity name.
+ * @property {string} [activityName] - Activity name.
+ * @property {string} [functionName] - Compatibility alias for activity name.
  * @property {string | undefined} [eventInput] - Event JSON string.
  * @property {string | undefined} [contextInput] - Context JSON string.
  * @property {string | undefined} [stdinInput] - STDIN payload.
  */
 
 /**
- * @typedef {import('node:process')['platform']} PackageArtifactPlatform
- * @typedef {import('node:process')['arch']} PackageArtifactArchitecture
- * @typedef {import('detect-libc').GLIBC|import('detect-libc').MUSL} PackageArtifactLibc
- */
-
-/**
  * @typedef PackageArtifactTarget
  * @property {string} nodeVersion - nodeVersion.
- * @property {PackageArtifactPlatform} platform - platform.
- * @property {PackageArtifactArchitecture} architecture - architecture.
- * @property {PackageArtifactLibc} [libc] - libc.
+ * @property {string} platform - platform.
+ * @property {string} architecture - architecture.
+ * @property {string} [libc] - libc.
  */
 
 /**
@@ -105,86 +102,97 @@ export function stringifyJson(value, options = {}) {
 }
 
 /**
- * @param {{ functions?: { name: string }[] }} manifest - manifest.
- * @returns {string[]} - Result.
- */
-function getAvailableActivityNames(manifest) {
-  if (!Array.isArray(manifest.functions)) {
-    return [];
-  }
-
-  return manifest.functions
-    .map((func) => (typeof func?.name === 'string' ? func.name.trim() : ''))
-    .filter(Boolean)
-    .sort((left, right) => left.localeCompare(right));
-}
-
-/**
- * @param {{ functions?: any[] }} manifest - manifest.
- * @param {string} activityName - activityName.
+ * @param {any} value - value.
  * @returns {any} - Result.
  */
-function getManifestActivityDefinition(manifest, activityName) {
-  const trimmedName = String(activityName || '').trim();
-  const functions = Array.isArray(manifest.functions) ? manifest.functions : [];
-  const definition = functions.find(
-    (func) =>
-      typeof func?.name === 'string' && func.name.trim() === trimmedName,
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * @param {RunLocalAppOptions} options - options.
+ * @param {any} manifest - manifest.
+ * @param {any} publicManifest - publicManifest.
+ * @returns {string} - Result.
+ */
+function resolveActivityName(options, manifest, publicManifest) {
+  const activityName =
+    typeof options.activityName === 'string' && options.activityName.trim()
+      ? options.activityName.trim()
+      : typeof options.functionName === 'string' && options.functionName.trim()
+        ? options.functionName.trim()
+        : '';
+
+  if (activityName) {
+    return activityName;
+  }
+
+  const availableActivities = getManifestActivityNames(
+    manifest,
+    publicManifest,
+  );
+  if (availableActivities.length === 1) {
+    return availableActivities[0];
+  }
+
+  throw new Error('Activity name is required.');
+}
+
+/**
+ * @param {{ appExport: any, manifest: any, publicManifest: any }} loaded - loaded.
+ * @returns {ActorSystem} - Result.
+ */
+function toPackageableActorSystem(loaded) {
+  if (loaded.appExport instanceof ActorSystem) {
+    return loaded.appExport;
+  }
+
+  const manifest = loaded.manifest;
+  const publicManifest = loaded.publicManifest;
+  const cliEntrypoint =
+    typeof publicManifest?.cli?.entrypoint === 'string' &&
+    publicManifest.cli.entrypoint
+      ? publicManifest.cli.entrypoint
+      : undefined;
+
+  if (!cliEntrypoint) {
+    throw new Error(
+      'Manifest-defined app packaging requires cli.entrypoint in wharfie.app.js.',
+    );
+  }
+
+  const functions = getManifestActivityNames(manifest, publicManifest).map(
+    (activityName) =>
+      createManifestActivityFunction({
+        manifest,
+        publicManifest,
+        activityName,
+      }),
   );
 
-  if (definition) {
-    return definition;
-  }
-
-  const availableActivities = getAvailableActivityNames(manifest);
-  const suggestions = availableActivities.length
-    ? ` Available activities: ${availableActivities.join(', ')}`
-    : '';
-  throw new Error(`Unknown activity '${trimmedName}'.${suggestions}`);
-}
-
-/**
- * @param {any} manifestFunction - manifestFunction.
- * @returns {WharfieFunction} - Result.
- */
-function createManifestActivity(manifestFunction) {
-  return new WharfieFunction({
-    name: manifestFunction.name,
-    entrypoint: manifestFunction.entrypoint,
-    properties: {
-      ...(Array.isArray(manifestFunction.external)
-        ? { external: manifestFunction.external }
-        : {}),
-      ...(isObjectRecord(manifestFunction.environmentVariables)
-        ? { environmentVariables: manifestFunction.environmentVariables }
-        : {}),
-      ...(isObjectRecord(manifestFunction.resources)
-        ? { resources: manifestFunction.resources }
-        : {}),
+  const properties = /** @type {any} */ ({
+    targets: Array.isArray(publicManifest.targets)
+      ? publicManifest.targets
+      : Array.isArray(manifest.targets)
+        ? manifest.targets
+        : [],
+    resources: getManifestResourcesSpec(manifest, publicManifest),
+    ...(Array.isArray(manifest.workflows)
+      ? { workflows: manifest.workflows }
+      : {}),
+    ...(isObjectRecord(manifest.scheduler)
+      ? { scheduler: manifest.scheduler }
+      : {}),
+    cli: {
+      entrypoint: cliEntrypoint,
     },
   });
-}
 
-/**
- * @param {any} manifest - manifest.
- * @returns {Record<string, any>} - Result.
- */
-function getManifestResourceSpecs(manifest) {
-  if (isObjectRecord(manifest?.resources)) {
-    return manifest.resources;
-  }
-  if (isObjectRecord(manifest?.capabilities)) {
-    return manifest.capabilities;
-  }
-  return {};
-}
-
-/**
- * @param {any} manifest - manifest.
- * @returns {Promise<{ resources: Record<string, any>, close: () => Promise<void> }>} - Result.
- */
-function createManifestRuntimeResources(manifest) {
-  return createActorSystemResources(getManifestResourceSpecs(manifest));
+  return new ActorSystem({
+    name: manifest.app.name,
+    functions,
+    properties,
+  });
 }
 
 /**
@@ -226,13 +234,9 @@ function getSeaBuildResources(actorSystem) {
 function cloneTarget(target) {
   return {
     nodeVersion: String(target.nodeVersion),
-    platform: /** @type {PackageArtifactPlatform} */ (target.platform),
-    architecture: /** @type {PackageArtifactArchitecture} */ (
-      target.architecture
-    ),
-    ...(typeof target.libc === 'string'
-      ? { libc: /** @type {PackageArtifactLibc} */ (target.libc) }
-      : {}),
+    platform: String(target.platform),
+    architecture: String(target.architecture),
+    ...(typeof target.libc === 'string' ? { libc: target.libc } : {}),
   };
 }
 
@@ -355,13 +359,9 @@ function applyTargetSelection(actorSystem, selectedTargets) {
 function getBuildTarget(build) {
   return {
     nodeVersion: String(build.get('nodeVersion')),
-    platform: /** @type {PackageArtifactPlatform} */ (build.get('platform')),
-    architecture: /** @type {PackageArtifactArchitecture} */ (
-      build.get('architecture')
-    ),
-    ...(build.has('libc')
-      ? { libc: /** @type {PackageArtifactLibc} */ (build.get('libc')) }
-      : {}),
+    platform: String(build.get('platform')),
+    architecture: String(build.get('architecture')),
+    ...(build.has('libc') ? { libc: String(build.get('libc')) } : {}),
   };
 }
 
@@ -400,7 +400,7 @@ async function attachEmbeddedManifestAssets(builds, manifest) {
     builds.map(async (build) => {
       const buildTarget = getBuildTarget(build);
       const embeddedManifest = {
-        ...manifest,
+        ...cloneJson(manifest),
         ...(Array.isArray(manifest.targets)
           ? { targets: [cloneTarget(buildTarget)] }
           : {}),
@@ -417,202 +417,12 @@ async function attachEmbeddedManifestAssets(builds, manifest) {
 }
 
 /**
- * @param {any} manifest - manifest.
- * @returns {void}
- */
-function assertPackageableManifest(manifest) {
-  if (!Array.isArray(manifest.targets) || manifest.targets.length === 0) {
-    throw new Error(
-      'App has no build targets. Define targets in wharfie.app.js before packaging.',
-    );
-  }
-}
-
-/**
- * @param {PackageArtifactTarget} target - target.
- * @returns {boolean} - Result.
- */
-function isCurrentHostTarget(target) {
-  const targetPlatform = String(target.platform);
-  const targetArchitecture = String(target.architecture);
-  const targetNodeVersion = String(target.nodeVersion).replace(/^v/, '');
-  const currentNodeVersion = String(process.versions.node).replace(/^v/, '');
-
-  return (
-    targetPlatform === process.platform &&
-    targetArchitecture === process.arch &&
-    (targetNodeVersion === currentNodeVersion ||
-      targetNodeVersion === currentNodeVersion.split('.')[0])
-  );
-}
-
-/**
- * @param {PackageArtifactTarget[]} targets - targets.
- * @returns {void}
- */
-function assertPlainObjectTargetsAreSupported(targets) {
-  const unsupported = targets.filter((target) => !isCurrentHostTarget(target));
-  if (unsupported.length === 0) {
-    return;
-  }
-
-  throw new Error(
-    `Manifest-defined CLI app packaging currently supports only the current host target (${ActorSystem.getBuildTargetSelector(
-      {
-        nodeVersion: process.versions.node,
-        platform: process.platform,
-        architecture: process.arch,
-      },
-    )}). Unsupported target(s): ${unsupported
-      .map((target) => ActorSystem.getBuildTargetSelector(target))
-      .join(', ')}`,
-  );
-}
-
-/**
- * @param {any} manifest - manifest.
- * @returns {void}
- */
-function assertPlainObjectPackageableManifest(manifest) {
-  assertPackageableManifest(manifest);
-
-  if (
-    !isObjectRecord(manifest.cli) ||
-    typeof manifest.cli.entrypoint !== 'string'
-  ) {
-    throw new Error(
-      'Manifest-defined CLI app packaging requires cli.entrypoint in wharfie.app.js.',
-    );
-  }
-}
-
-/**
- * @param {any} manifest - manifest.
- * @param {PackageArtifactTarget} target - target.
- * @returns {FunctionResource[]} - Result.
- */
-function createManifestFunctionResources(manifest, target) {
-  /** @type {any[]} */
-  const functions = Array.isArray(manifest.functions) ? manifest.functions : [];
-
-  return functions.map(
-    (/** @type {any} */ func) =>
-      new FunctionResource({
-        name: `${func.name}-${target.nodeVersion}-${target.platform}-${target.architecture}`,
-        properties: {
-          functionName: func.name,
-          entrypoint: func.entrypoint,
-          ...(Array.isArray(func.external) ? { external: func.external } : {}),
-          ...(isObjectRecord(func.environmentVariables)
-            ? { environmentVariables: func.environmentVariables }
-            : {}),
-          ...(isObjectRecord(func.resources)
-            ? { resources: func.resources }
-            : {}),
-          buildTarget: () => cloneTarget(target),
-        },
-      }),
-  );
-}
-
-/**
- * @param {any} manifest - manifest.
- * @param {PackageArtifactTarget} target - target.
- * @param {FunctionResource[]} functionResources - functionResources.
- * @returns {SeaBuild} - Result.
- */
-function createManifestCliBuild(manifest, target, functionResources) {
-  const selector = ActorSystem.getBuildTargetSelector(target);
-  return new SeaBuild({
-    name: `${manifest.app.name}-build-${selector}`,
-    dependsOn: [...functionResources],
-    properties: {
-      entryCode: () =>
-        createPackagedAppEntryCode({
-          cliEntrypointPath: manifest.cli.entrypoint,
-          cliExportName:
-            typeof manifest.cli.export === 'string'
-              ? manifest.cli.export
-              : undefined,
-        }),
-      resolveDir: () => path.dirname(manifest.cli.entrypoint),
-      nodeBinaryPath: () => process.execPath,
-      nodeVersion: target.nodeVersion,
-      platform: target.platform,
-      architecture: target.architecture,
-      ...(typeof target.libc === 'string' ? { libc: target.libc } : {}),
-      environmentVariables: () => ({}),
-      assets: () =>
-        functionResources.reduce(
-          (/** @type {Record<string, string>} */ acc, func) => {
-            acc[
-              func.name.replace(
-                `-${target.nodeVersion}-${target.platform}-${target.architecture}`,
-                '',
-              )
-            ] = func.get('singleExecutableAssetPath');
-            return acc;
-          },
-          {},
-        ),
-    },
-  });
-}
-
-/**
- * @param {(FunctionResource | SeaBuild)[]} resources - resources.
- * @returns {Promise<void>} - Result.
- */
-async function initializeBuildResources(resources) {
-  await Promise.all(
-    resources.map(async (resource) => {
-      const maybeInitializable =
-        /** @type {{ initializeEnvironment?: () => Promise<void> }} */ (
-          resource
-        );
-      if (typeof maybeInitializable.initializeEnvironment === 'function') {
-        await maybeInitializable.initializeEnvironment();
-      }
-    }),
-  );
-}
-
-/**
- * @param {any} manifest - manifest.
- * @param {PackageArtifactTarget[]} selectedTargets - selectedTargets.
- * @returns {Promise<Array<{ build: SeaBuild, functionResources: FunctionResource[] }>>} - Result.
- */
-async function buildManifestCliArtifacts(manifest, selectedTargets) {
-  assertPlainObjectPackageableManifest(manifest);
-  assertPlainObjectTargetsAreSupported(selectedTargets);
-
-  /** @type {{ build: SeaBuild, functionResources: FunctionResource[] }[]} */
-  const plans = [];
-
-  for (const target of selectedTargets) {
-    const functionResources = createManifestFunctionResources(manifest, target);
-    const build = createManifestCliBuild(manifest, target, functionResources);
-    const allResources = [...functionResources, build];
-    await initializeBuildResources(allResources);
-    plans.push({ build, functionResources });
-  }
-
-  return plans;
-}
-
-/**
  * @param {RunLocalAppOptions} options - options.
  * @returns {Promise<{ manifest: any, result: any }>} - Result.
  */
 export async function runLocalApp(options) {
-  const { manifest } = await loadApp({ dir: options.dir });
-  const activityDefinition = getManifestActivityDefinition(
-    manifest,
-    options.activityName,
-  );
-  const activity = createManifestActivity(activityDefinition);
-  const appRuntimeResources = await createManifestRuntimeResources(manifest);
-
+  const { manifest, publicManifest } = await loadApp({ dir: options.dir });
+  const activityName = resolveActivityName(options, manifest, publicManifest);
   const eventSource = options.eventInput ?? options.stdinInput;
   const event = parseJsonInput(eventSource, 'event', {});
   const context = parseJsonInput(options.contextInput, 'context', {});
@@ -621,15 +431,18 @@ export async function runLocalApp(options) {
     throw new Error('Context JSON must be an object.');
   }
 
-  try {
-    const result = await activity.fn(event, context, {
-      baseResources: appRuntimeResources.resources,
-    });
-    return { manifest, result };
-  } finally {
-    await activity.closeRuntimeResources();
-    await appRuntimeResources.close();
-  }
+  const result = await invokeManifestActivity({
+    manifest,
+    publicManifest,
+    activityName,
+    event,
+    context,
+  });
+
+  return {
+    manifest: publicManifest,
+    result,
+  };
 }
 
 /**
@@ -637,70 +450,54 @@ export async function runLocalApp(options) {
  * @returns {Promise<PackageLocalAppResult>} - Result.
  */
 export async function packageLocalApp(options) {
-  let { appExport, manifest } = await loadApp({ dir: options.dir });
-  assertPackageableManifest(manifest);
+  let loaded = await loadApp({ dir: options.dir });
+  let actorSystem = toPackageableActorSystem(loaded);
+  let manifest = cloneJson(loaded.publicManifest);
+
+  const availableTargets = Array.isArray(manifest.targets)
+    ? manifest.targets
+    : [];
+  if (availableTargets.length === 0) {
+    throw new Error(
+      'App has no build targets. Define targets in wharfie.app.js before packaging.',
+    );
+  }
 
   const selectedTargets = selectTargets(
-    /** @type {PackageArtifactTarget[]} */ (manifest.targets || []),
+    availableTargets,
     options.targetFilters,
   );
   if (selectedTargets.length === 0) {
     throw new Error('No targets matched the requested package filter.');
   }
 
-  /** @type {SeaBuild[]} */
-  let builds = [];
-  /** @type {FunctionResource[]} */
-  let plainObjectFunctionResources = [];
-
-  if (appExport instanceof ActorSystem) {
-    let actorSystem = appExport;
-    const requestedTargetSelectors = selectedTargets.map((target) =>
-      ActorSystem.getBuildTargetSelector(target),
-    );
-    if (
-      Array.isArray(options.targetFilters) &&
-      options.targetFilters.length > 0 &&
-      requestedTargetSelectors.length > 0
-    ) {
-      ({ appExport, manifest } = await loadApp({
-        dir: options.dir,
-        requestedTargetSelectors,
-      }));
-      if (!(appExport instanceof ActorSystem)) {
-        throw new Error('Filtered packaging expected an ActorSystem export.');
-      }
-      actorSystem = appExport;
-    }
-
-    applyTargetSelection(actorSystem, selectedTargets);
-    manifest.targets = selectedTargets.map((target) => cloneTarget(target));
-
-    builds = getSeaBuildResources(actorSystem);
-    await attachEmbeddedManifestAssets(builds, manifest);
-
-    if (typeof actorSystem.initializeEnvironment === 'function') {
-      await actorSystem.initializeEnvironment();
-    }
-    await actorSystem.reconcile();
-  } else {
-    manifest.targets = selectedTargets.map((target) => cloneTarget(target));
-    const buildPlans = await buildManifestCliArtifacts(
-      manifest,
-      selectedTargets,
-    );
-    builds = buildPlans.map((plan) => plan.build);
-    plainObjectFunctionResources = buildPlans.flatMap(
-      (plan) => plan.functionResources,
-    );
-    await attachEmbeddedManifestAssets(builds, manifest);
-    for (const functionResource of plainObjectFunctionResources) {
-      await functionResource.reconcile();
-    }
-    for (const build of builds) {
-      await build.reconcile();
-    }
+  const requestedTargetSelectors = selectedTargets.map((target) =>
+    ActorSystem.getBuildTargetSelector(target),
+  );
+  if (
+    loaded.appExport instanceof ActorSystem &&
+    Array.isArray(options.targetFilters) &&
+    options.targetFilters.length > 0 &&
+    requestedTargetSelectors.length > 0
+  ) {
+    loaded = await loadApp({
+      dir: options.dir,
+      requestedTargetSelectors,
+    });
+    actorSystem = toPackageableActorSystem(loaded);
+    manifest = cloneJson(loaded.publicManifest);
   }
+
+  applyTargetSelection(actorSystem, selectedTargets);
+  manifest.targets = selectedTargets.map((target) => cloneTarget(target));
+
+  const builds = getSeaBuildResources(actorSystem);
+
+  if (typeof actorSystem.initializeEnvironment === 'function') {
+    await actorSystem.initializeEnvironment();
+  }
+  await attachEmbeddedManifestAssets(builds, manifest);
+  await actorSystem.reconcile();
 
   if (builds.length === 0) {
     throw new Error(
@@ -737,15 +534,9 @@ export async function packageLocalApp(options) {
     });
   }
 
-  const manifestTargets = Array.isArray(manifest.targets)
-    ? manifest.targets.map((target) =>
-        cloneTarget(/** @type {PackageArtifactTarget} */ (target)),
-      )
-    : undefined;
-
   return {
     app: manifest.app,
-    ...(manifestTargets ? { targets: manifestTargets } : {}),
+    ...(Array.isArray(manifest.targets) ? { targets: manifest.targets } : {}),
     outputDir,
     artifacts,
   };

--- a/src/cli/app/runnable-app-resources.js
+++ b/src/cli/app/runnable-app-resources.js
@@ -1,0 +1,95 @@
+import { resolveSharedResourceSpecs } from '../../core/runtime/shared-resource-registry.js';
+
+/**
+ * @param {unknown} value - value.
+ * @returns {value is Record<string, any>} - Result.
+ */
+function isObjectRecord(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * @param {Record<string, any>} container - container.
+ * @param {string} key - key.
+ * @returns {Promise<void>} - Result.
+ */
+async function resolveContainerResourceField(container, key) {
+  if (!Object.prototype.hasOwnProperty.call(container, key)) {
+    return;
+  }
+
+  const current = container[key];
+  if (!isObjectRecord(current)) {
+    return;
+  }
+
+  container[key] = await resolveSharedResourceSpecs(current);
+}
+
+/**
+ * @param {Record<string, any>} container - container.
+ * @returns {Promise<void>} - Result.
+ */
+async function resolvePlainAppResourceFields(container) {
+  await resolveContainerResourceField(container, 'resources');
+  await resolveContainerResourceField(container, 'capabilities');
+
+  if (isObjectRecord(container.properties)) {
+    await resolveContainerResourceField(container.properties, 'resources');
+    await resolveContainerResourceField(container.properties, 'capabilities');
+  }
+}
+
+/**
+ * @param {any} fn - fn.
+ * @returns {Promise<void>} - Result.
+ */
+async function resolveFunctionResourceFields(fn) {
+  if (!isObjectRecord(fn) || !isObjectRecord(fn.properties)) {
+    return;
+  }
+
+  await resolveContainerResourceField(fn.properties, 'resources');
+}
+
+/**
+ * @param {any} appExport - appExport.
+ * @returns {Promise<void>} - Result.
+ */
+export async function resolveRunnableAppResourceRefs(appExport) {
+  if (!isObjectRecord(appExport)) {
+    return;
+  }
+
+  if (
+    typeof appExport.get === 'function' &&
+    typeof appExport._setUNSAFE === 'function'
+  ) {
+    const currentResources = appExport.get(
+      'resources',
+      appExport.properties?.resources ?? {},
+    );
+    if (isObjectRecord(currentResources)) {
+      const resolvedResources =
+        await resolveSharedResourceSpecs(currentResources);
+      appExport._setUNSAFE('resources', resolvedResources);
+      if (isObjectRecord(appExport.properties)) {
+        appExport.properties.resources = resolvedResources;
+      }
+    }
+  } else {
+    await resolvePlainAppResourceFields(appExport);
+    if (isObjectRecord(appExport.app)) {
+      await resolvePlainAppResourceFields(appExport.app);
+    }
+  }
+
+  const functions = Array.isArray(appExport.functions)
+    ? appExport.functions
+    : [];
+  await Promise.all(functions.map((fn) => resolveFunctionResourceFields(fn)));
+}
+
+export default {
+  resolveRunnableAppResourceRefs,
+};

--- a/src/cli/cmds/app_cmds/manifest.js
+++ b/src/cli/cmds/app_cmds/manifest.js
@@ -3,29 +3,23 @@ import { Command } from 'commander';
 import { loadApp } from '../../app/load-app.js';
 import { displayFailure } from '../../output/basic.js';
 
-// Usage:
-//   wharfie app manifest                # pretty JSON (default)
-//   wharfie app manifest --no-pretty    # compact JSON
-//   wharfie app manifest ./path/to/app  # explicit app directory
-
 /**
  * @param {string} dir - App directory.
  * @param {{ json?: boolean, pretty?: boolean }} options - options.
  */
 async function printManifest(dir, options) {
-  const { manifest } = await loadApp({ dir });
+  const { publicManifest } = await loadApp({ dir });
 
-  // Default to pretty JSON.
   const pretty = options.pretty !== false;
   const output = pretty
-    ? JSON.stringify(manifest, null, 2)
-    : JSON.stringify(manifest);
+    ? JSON.stringify(publicManifest, null, 2)
+    : JSON.stringify(publicManifest);
 
   process.stdout.write(`${output}\n`);
 }
 
 const manifestCommand = new Command('manifest')
-  .description('Print the compiled manifest from wharfie.app.js')
+  .description('Print the public manifest from wharfie.app.js')
   .argument('[dir]', 'Directory containing wharfie.app.js (default: cwd)')
   .option('--json', 'Output JSON (default)')
   .option('--no-pretty', 'Disable pretty JSON output')

--- a/src/cli/cmds/app_cmds/package.js
+++ b/src/cli/cmds/app_cmds/package.js
@@ -27,7 +27,7 @@ async function packageApp(dir, options) {
 }
 
 const packageCommand = new Command('package')
-  .description('Package an ActorSystem app into executable artifacts')
+  .description('Package a Wharfie app into executable artifacts')
   .argument('[dir]', 'Directory containing wharfie.app.js (default: cwd)')
   .option(
     '--output-dir <dir>',

--- a/src/cli/cmds/app_cmds/run.js
+++ b/src/cli/cmds/app_cmds/run.js
@@ -4,13 +4,13 @@ import { runLocalApp, stringifyJson } from '../../app/local-app.js';
 import { displayFailure } from '../../output/basic.js';
 
 /**
- * @param {string} functionName - functionName.
+ * @param {string} activityName - activityName.
  * @param {{ dir?: string, event?: string, context?: string, pretty?: boolean }} options - options.
  */
-async function runFunction(functionName, options) {
+async function runActivity(activityName, options) {
   const { result } = await runLocalApp({
     dir: options.dir || process.cwd(),
-    functionName,
+    activityName,
     eventInput: options.event,
     contextInput: options.context,
     stdinInput: process.env.stdin,
@@ -20,16 +20,16 @@ async function runFunction(functionName, options) {
 }
 
 const runCommand = new Command('run')
-  .description('Invoke a function from wharfie.app.js locally')
-  .argument('<functionName>', 'Function name to invoke')
+  .description('Invoke an activity from wharfie.app.js locally')
+  .argument('<activityName>', 'Activity name to invoke')
   .option('--dir <dir>', 'Directory containing wharfie.app.js', process.cwd())
   .option('--event <json>', 'Event JSON (default: stdin JSON or {})')
   .option('--context <json>', 'Context JSON (default: {})')
   .option('--json', 'Output JSON (default)')
   .option('--no-pretty', 'Disable pretty JSON output')
-  .action(async (functionName, options) => {
+  .action(async (activityName, options) => {
     try {
-      await runFunction(functionName, options);
+      await runActivity(activityName, options);
     } catch (err) {
       displayFailure(err);
       process.exitCode = 1;

--- a/src/cli/cmds/operation-rows.js
+++ b/src/cli/cmds/operation-rows.js
@@ -10,17 +10,6 @@ export function toIsoTimestamp(value) {
 }
 
 /**
- * @param {Record<string, any> | undefined} operation - operation.
- * @returns {Record<string, any>} - Result.
- */
-function getOperationConfig(operation) {
-  return operation?.operation_config &&
-    typeof operation.operation_config === 'object'
-    ? operation.operation_config
-    : {};
-}
-
-/**
  * @param {Array<Record<string, any>>} operations - operations.
  * @returns {Array<Record<string, string>>} - Result.
  */
@@ -30,32 +19,27 @@ export function formatOperationRows(operations = []) {
       (left, right) =>
         (Number(right.started_at) || 0) - (Number(left.started_at) || 0),
     )
-    .map((operation) => {
-      const config = getOperationConfig(operation);
-      return {
-        id: operation.id,
-        app:
-          typeof config.app === 'string' && config.app.trim() ? config.app : '',
-        activity:
-          typeof config.activity === 'string' && config.activity.trim()
-            ? config.activity
-            : '',
-        workflow:
-          typeof config.workflow === 'string' && config.workflow.trim()
-            ? config.workflow
-            : typeof config.workflow_name === 'string' &&
-                config.workflow_name.trim()
-              ? config.workflow_name
-              : '',
-        type: operation.type,
-        status: operation.status,
-        trigger:
-          typeof config.trigger?.source === 'string' &&
-          config.trigger.source.trim()
-            ? config.trigger.source
-            : '',
-        started_at: toIsoTimestamp(operation.started_at),
-        last_updated_at: toIsoTimestamp(operation.last_updated_at),
-      };
-    });
+    .map((operation) => ({
+      id: operation.id,
+      app:
+        typeof operation.operation_config?.app_name === 'string'
+          ? operation.operation_config.app_name
+          : '',
+      activity:
+        typeof operation.operation_config?.activity_name === 'string'
+          ? operation.operation_config.activity_name
+          : '',
+      workflow:
+        typeof operation.operation_config?.workflow_name === 'string'
+          ? operation.operation_config.workflow_name
+          : '',
+      trigger:
+        typeof operation.operation_config?.trigger?.source === 'string'
+          ? operation.operation_config.trigger.source
+          : '',
+      type: operation.type,
+      status: operation.status,
+      started_at: toIsoTimestamp(operation.started_at),
+      last_updated_at: toIsoTimestamp(operation.last_updated_at),
+    }));
 }

--- a/src/cli/cmds/operation-rows.js
+++ b/src/cli/cmds/operation-rows.js
@@ -10,6 +10,17 @@ export function toIsoTimestamp(value) {
 }
 
 /**
+ * @param {Record<string, any> | undefined} operation - operation.
+ * @returns {Record<string, any>} - Result.
+ */
+function getOperationConfig(operation) {
+  return operation?.operation_config &&
+    typeof operation.operation_config === 'object'
+    ? operation.operation_config
+    : {};
+}
+
+/**
  * @param {Array<Record<string, any>>} operations - operations.
  * @returns {Array<Record<string, string>>} - Result.
  */
@@ -19,11 +30,32 @@ export function formatOperationRows(operations = []) {
       (left, right) =>
         (Number(right.started_at) || 0) - (Number(left.started_at) || 0),
     )
-    .map((operation) => ({
-      id: operation.id,
-      type: operation.type,
-      status: operation.status,
-      started_at: toIsoTimestamp(operation.started_at),
-      last_updated_at: toIsoTimestamp(operation.last_updated_at),
-    }));
+    .map((operation) => {
+      const config = getOperationConfig(operation);
+      return {
+        id: operation.id,
+        app:
+          typeof config.app === 'string' && config.app.trim() ? config.app : '',
+        activity:
+          typeof config.activity === 'string' && config.activity.trim()
+            ? config.activity
+            : '',
+        workflow:
+          typeof config.workflow === 'string' && config.workflow.trim()
+            ? config.workflow
+            : typeof config.workflow_name === 'string' &&
+                config.workflow_name.trim()
+              ? config.workflow_name
+              : '',
+        type: operation.type,
+        status: operation.status,
+        trigger:
+          typeof config.trigger?.source === 'string' &&
+          config.trigger.source.trim()
+            ? config.trigger.source
+            : '',
+        started_at: toIsoTimestamp(operation.started_at),
+        last_updated_at: toIsoTimestamp(operation.last_updated_at),
+      };
+    });
 }

--- a/src/cli/cmds/ops_cmds/cancel.js
+++ b/src/cli/cmds/ops_cmds/cancel.js
@@ -1,6 +1,8 @@
 import { Command } from 'commander';
 
+import { loadApp } from '../../app/load-app.js';
 import { withOperationsStore } from '../operations-store.js';
+import { getSyntheticAppResourceId } from '../../../core/runtime/app-runs.js';
 import {
   displayFailure,
   displayInstruction,
@@ -8,9 +10,9 @@ import {
 } from '../../output/basic.js';
 
 /**
- * Cancels operations for a given resource ID, operation ID, or operation type.
+ * Cancels operations for a given app resource ID, operation ID, or operation type.
  * @param {import('../../../core/lib/db/tables/operations.js').OperationsTableClient} store - store.
- * @param {string} resource_id - The ID of the resource.
+ * @param {string} resource_id - The synthetic app resource ID.
  * @param {string} [operation_id] - The specific operation ID to cancel.
  * @param {string} [operation_type] - The type of operation to cancel.
  */
@@ -42,15 +44,15 @@ const cancel = async (store, resource_id, operation_id, operation_type) => {
 };
 
 const cancelCommand = new Command('cancel')
-  .description('Cancel operations for a single resource')
-  .argument('<resource_id>', 'Wharfie resource ID')
+  .description('Cancel persisted runs for an app')
+  .option('--dir <dir>', 'Directory containing wharfie.app.js', process.cwd())
   .option('-o, --operationId <operationId>', 'Operation ID')
   .option(
     '-t, --type <type>',
     'Operation type',
     /^(LOAD|BACKFILL|MIGRATE|PIPELINE)$/i,
   )
-  .action(async (resource_id, options) => {
+  .action(async (options) => {
     const { type, operationId } = options;
     const normalizedType = type ? String(type).toUpperCase() : undefined;
 
@@ -60,8 +62,12 @@ const cancelCommand = new Command('cancel')
     }
 
     try {
+      const appDir = options.dir || process.cwd();
+      const { manifest } = await loadApp({ dir: appDir });
+      const resourceId = getSyntheticAppResourceId(manifest);
+
       await withOperationsStore((store) =>
-        cancel(store, resource_id, operationId, normalizedType),
+        cancel(store, resourceId, operationId, normalizedType),
       );
     } catch (err) {
       displayFailure(err);

--- a/src/cli/cmds/ops_cmds/cancel.js
+++ b/src/cli/cmds/ops_cmds/cancel.js
@@ -2,17 +2,17 @@ import { Command } from 'commander';
 
 import { loadApp } from '../../app/load-app.js';
 import { withOperationsStore } from '../operations-store.js';
-import { getSyntheticAppResourceId } from '../../../core/runtime/app-runs.js';
 import {
   displayFailure,
   displayInstruction,
   displaySuccess,
 } from '../../output/basic.js';
+import { getAppResourceId } from '../../../core/runtime/app-runs.js';
 
 /**
- * Cancels operations for a given app resource ID, operation ID, or operation type.
+ * Cancels operations for a given app resource, operation ID, or operation type.
  * @param {import('../../../core/lib/db/tables/operations.js').OperationsTableClient} store - store.
- * @param {string} resource_id - The synthetic app resource ID.
+ * @param {string} resource_id - The ID of the resource.
  * @param {string} [operation_id] - The specific operation ID to cancel.
  * @param {string} [operation_type] - The type of operation to cancel.
  */
@@ -44,7 +44,7 @@ const cancel = async (store, resource_id, operation_id, operation_type) => {
 };
 
 const cancelCommand = new Command('cancel')
-  .description('Cancel persisted runs for an app')
+  .description('Cancel persisted operations for an app')
   .option('--dir <dir>', 'Directory containing wharfie.app.js', process.cwd())
   .option('-o, --operationId <operationId>', 'Operation ID')
   .option(
@@ -62,9 +62,8 @@ const cancelCommand = new Command('cancel')
     }
 
     try {
-      const appDir = options.dir || process.cwd();
-      const { manifest } = await loadApp({ dir: appDir });
-      const resourceId = getSyntheticAppResourceId(manifest);
+      const { manifest } = await loadApp({ dir: options.dir || process.cwd() });
+      const resourceId = getAppResourceId(manifest.app.name);
 
       await withOperationsStore((store) =>
         cancel(store, resourceId, operationId, normalizedType),

--- a/src/cli/cmds/ops_cmds/list.js
+++ b/src/cli/cmds/ops_cmds/list.js
@@ -3,25 +3,22 @@ import { Command } from 'commander';
 import { loadApp } from '../../app/load-app.js';
 import { withOperationsStore } from '../operations-store.js';
 import { formatOperationRows } from '../operation-rows.js';
-import { getSyntheticAppResourceId } from '../../../core/runtime/app-runs.js';
 import { displayFailure, displaySuccess } from '../../output/basic.js';
+import { getAppResourceId } from '../../../core/runtime/app-runs.js';
 
 const listCommand = new Command('list')
-  .description('List persisted runs for an app')
+  .description('List persisted operations for an app')
   .option('--dir <dir>', 'Directory containing wharfie.app.js', process.cwd())
   .action(async (options) => {
     try {
-      const appDir = options.dir || process.cwd();
-      const { manifest } = await loadApp({ dir: appDir });
-      const resourceId = getSyntheticAppResourceId(manifest);
+      const { manifest } = await loadApp({ dir: options.dir || process.cwd() });
+      const resourceId = getAppResourceId(manifest.app.name);
 
       await withOperationsStore(async (store) => {
         const records = await store.getRecords(resourceId);
         const operations = records.operations || [];
 
-        displaySuccess(
-          `${operations.length} operations found for ${manifest.app.name}.`,
-        );
+        displaySuccess(`${operations.length} operations found.`);
         console.table(formatOperationRows(operations));
       });
     } catch (err) {

--- a/src/cli/cmds/ops_cmds/list.js
+++ b/src/cli/cmds/ops_cmds/list.js
@@ -1,19 +1,27 @@
 import { Command } from 'commander';
 
+import { loadApp } from '../../app/load-app.js';
 import { withOperationsStore } from '../operations-store.js';
 import { formatOperationRows } from '../operation-rows.js';
+import { getSyntheticAppResourceId } from '../../../core/runtime/app-runs.js';
 import { displayFailure, displaySuccess } from '../../output/basic.js';
 
 const listCommand = new Command('list')
-  .description('List operations for a resource')
-  .argument('<resource_id>', 'Wharfie resource ID')
-  .action(async (resource_id) => {
+  .description('List persisted runs for an app')
+  .option('--dir <dir>', 'Directory containing wharfie.app.js', process.cwd())
+  .action(async (options) => {
     try {
+      const appDir = options.dir || process.cwd();
+      const { manifest } = await loadApp({ dir: appDir });
+      const resourceId = getSyntheticAppResourceId(manifest);
+
       await withOperationsStore(async (store) => {
-        const records = await store.getRecords(resource_id);
+        const records = await store.getRecords(resourceId);
         const operations = records.operations || [];
 
-        displaySuccess(`${operations.length} operations found.`);
+        displaySuccess(
+          `${operations.length} operations found for ${manifest.app.name}.`,
+        );
         console.table(formatOperationRows(operations));
       });
     } catch (err) {

--- a/src/cli/cmds/ops_cmds/run.js
+++ b/src/cli/cmds/ops_cmds/run.js
@@ -1,10 +1,14 @@
 import { Command } from 'commander';
 
 import { loadApp } from '../../app/load-app.js';
+import { parseJsonInput } from '../../app/local-app.js';
 import { withOperationsStore } from '../operations-store.js';
+import {
+  createAppActivityOperation,
+  createAppWorkflowOperation,
+  persistAndRunAppOperation,
+} from '../../../core/runtime/app-runs.js';
 import Action from '../../../core/lib/graph/action.js';
-import Operation from '../../../core/lib/graph/operation.js';
-import { runOperation } from '../../../core/lib/graph/runner.js';
 import {
   displayFailure,
   displayInfo,
@@ -12,25 +16,11 @@ import {
 } from '../../output/basic.js';
 
 /**
- * @param {any} appExport - appExport.
- * @returns {void}
+ * @param {unknown} value - value.
+ * @returns {value is Record<string, any>} - Result.
  */
-function assertRunnableApp(appExport) {
-  if (!appExport || typeof appExport.invoke !== 'function') {
-    throw new Error(
-      'App is not runnable. Expected a default export with invoke(functionName, event, context).',
-    );
-  }
-}
-
-/**
- * @param {Record<string, any> | undefined} placement - placement.
- * @returns {string} - Result.
- */
-function getPlacementMode(placement) {
-  const mode = placement?.mode;
-  if (typeof mode !== 'string' || !mode.trim()) return 'local';
-  return mode.trim().toLowerCase();
+function isObjectRecord(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
 /**
@@ -55,237 +45,98 @@ function formatActionRows(operation, fallbackStatuses) {
   }));
 }
 
-/**
- * @param {any} manifest - manifest.
- * @param {string} workflowName - workflowName.
- * @returns {any | undefined} - Result.
- */
-function findWorkflowDefinition(manifest, workflowName) {
-  const trimmedName = String(workflowName || '').trim();
-  if (!trimmedName) return undefined;
-
-  /** @type {any[]} */
-  const workflows = Array.isArray(manifest?.workflows)
-    ? manifest.workflows
-    : [];
-  return workflows.find(
-    (/** @type {any} */ workflow) =>
-      workflow?.name && String(workflow.name) === trimmedName,
-  );
-}
-
-/**
- * @param {{ workflow: any, resourceId: string, operationId?: string | undefined }} options - options.
- * @returns {import('../../../core/lib/graph/operation.js').default} - Result.
- */
-function createOperationFromWorkflow({ workflow, resourceId, operationId }) {
-  const operation = new Operation({
-    resource_id: resourceId,
-    resource_version: 1,
-    ...(typeof operationId === 'string' && operationId.trim()
-      ? { id: operationId.trim() }
-      : {}),
-    type:
-      typeof workflow?.type === 'string' && workflow.type.trim()
-        ? workflow.type.trim().toUpperCase()
-        : Operation.Type.PIPELINE,
-    operation_config: {
-      workflow_name: workflow?.name,
-      source: 'app-manifest',
-    },
-  });
-
-  const actions = Array.isArray(workflow?.actions) ? workflow.actions : [];
-  for (const action of actions) {
-    operation.createAction({
-      id: action.id,
-      type: action.type,
-      function_name: action.functionName,
-      inputs: action.inputs,
-      placement: action.placement,
-      retry: action.retry,
-    });
-  }
-
-  for (const action of actions) {
-    const dependencies = Array.isArray(action?.dependsOn)
-      ? action.dependsOn
-      : [];
-    for (const dependencyId of dependencies) {
-      if (typeof dependencyId !== 'string' || !dependencyId.trim()) {
-        continue;
-      }
-      operation._addDependency(dependencyId.trim(), action.id);
-    }
-  }
-
-  return operation;
-}
-
 const runCommand = new Command('run')
   .description(
-    'Execute a persisted operation or an app-defined workflow locally',
-  )
-  .argument('<resource_id>', 'Wharfie resource ID')
-  .argument(
-    '[operation_id]',
-    'Operation ID (or operation ID override when --workflow is used)',
+    'Create and execute a persisted app activity or workflow locally',
   )
   .option('--dir <dir>', 'Directory containing wharfie.app.js', process.cwd())
+  .option(
+    '--activity <activityName>',
+    'Activity name declared in wharfie.app.js',
+  )
   .option(
     '--workflow <workflowName>',
     'Workflow name declared in wharfie.app.js',
   )
-  .action(async (resource_id, operation_id, options) => {
-    /** @type {{ appExport: any, manifest: any } | undefined} */
-    let loadedApp;
-
+  .option('--operationId <operationId>', 'Operation ID override')
+  .option('--event <json>', 'Event JSON for activity runs (default: {})')
+  .option('--context <json>', 'Context JSON merged beneath workflow metadata')
+  .action(async (options) => {
     try {
-      await withOperationsStore(async (store) => {
-        const workflowName =
-          typeof options.workflow === 'string' ? options.workflow.trim() : '';
-        const appDir = options.dir || process.cwd();
+      const activityName =
+        typeof options.activity === 'string' ? options.activity.trim() : '';
+      const workflowName =
+        typeof options.workflow === 'string' ? options.workflow.trim() : '';
+      const appDir = options.dir || process.cwd();
 
-        if (!workflowName && !operation_id) {
-          throw new Error(
-            'ops run requires <operation_id> unless --workflow <workflowName> is provided.',
-          );
-        }
+      if (!activityName && !workflowName) {
+        throw new Error(
+          'ops run requires either --activity <activityName> or --workflow <workflowName>.',
+        );
+      }
 
-        /**
-         * @returns {Promise<{ appExport: any, manifest: any }>} - Result.
-         */
-        const ensureLoadedApp = async () => {
-          if (loadedApp) {
-            return loadedApp;
-          }
-          loadedApp = await loadApp({ dir: appDir });
-          assertRunnableApp(loadedApp.appExport);
-          return loadedApp;
-        };
+      if (activityName && workflowName) {
+        throw new Error(
+          'ops run cannot accept both --activity <activityName> and --workflow <workflowName>.',
+        );
+      }
 
-        let resolvedOperationId = operation_id;
+      const context = parseJsonInput(options.context, 'context', {});
+      if (!isObjectRecord(context)) {
+        throw new Error('Context JSON must be an object.');
+      }
 
-        if (workflowName) {
-          const loaded = await ensureLoadedApp();
-          const workflow = findWorkflowDefinition(
-            loaded.manifest,
+      if (workflowName && typeof options.event === 'string') {
+        throw new Error('--event is only supported with --activity runs.');
+      }
+
+      const event = parseJsonInput(options.event, 'event', {});
+      const { manifest } = await loadApp({ dir: appDir });
+
+      const operation = activityName
+        ? createAppActivityOperation({
+            manifest,
+            activityName,
+            event,
+            operationId: options.operationId,
+          })
+        : createAppWorkflowOperation({
+            manifest,
             workflowName,
-          );
-
-          if (!workflow) {
-            /** @type {string[]} */
-            const availableWorkflows = Array.isArray(loaded.manifest?.workflows)
-              ? loaded.manifest.workflows
-                  .map((/** @type {any} */ candidate) => candidate?.name)
-                  .filter(
-                    (/** @type {unknown} */ candidate) =>
-                      typeof candidate === 'string',
-                  )
-              : [];
-            throw new Error(
-              `Workflow '${workflowName}' was not found in ${appDir}. Available workflows: ${
-                availableWorkflows.length > 0
-                  ? availableWorkflows.join(', ')
-                  : '(none)'
-              }`,
-            );
-          }
-
-          const workflowOperation = createOperationFromWorkflow({
-            workflow,
-            resourceId: resource_id,
-            operationId: operation_id,
+            operationId: options.operationId,
           });
-          resolvedOperationId = workflowOperation.id;
-          await store.putOperation(workflowOperation);
 
-          displayInfo(
-            `Running workflow: ${resource_id}#${resolvedOperationId} (${workflow.name})`,
-          );
-        } else {
-          displayInfo(
-            `Running operation: ${resource_id}#${resolvedOperationId}`,
-          );
-        }
+      await withOperationsStore(async (store) => {
+        displayInfo(
+          `Running ${activityName ? 'activity' : 'workflow'}: ${operation.resource_id}#${operation.id} (${activityName || workflowName})`,
+        );
 
-        /**
-         * @param {import('../../../core/lib/graph/action.js').default} action - action.
-         * @returns {Promise<{ ok: boolean, outputs?: any }>} - Result.
-         */
-        const executeAction = async (action) => {
-          if (
-            action.type === Action.Type.START ||
-            action.type === Action.Type.FINISH
-          ) {
-            displayInfo(`- ${action.id} (${action.type})`);
-            return { ok: true };
-          }
-
-          if (action.type !== Action.Type.INVOKE_FUNCTION) {
-            throw new Error(
-              `Unsupported action type '${action.type}' for ops run. Only START, FINISH, and INVOKE_FUNCTION are currently executable.`,
-            );
-          }
-
-          if (!action.function_name || !String(action.function_name).trim()) {
-            throw new Error(
-              `INVOKE_FUNCTION action '${action.id}' is missing function_name.`,
-            );
-          }
-
-          const placementMode = getPlacementMode(action.placement);
-          if (placementMode !== 'local' && placementMode !== 'in_process') {
-            throw new Error(
-              `INVOKE_FUNCTION action '${action.id}' requested unsupported placement mode '${placementMode}'. Local execution currently supports only 'local' or 'in_process'.`,
-            );
-          }
-
-          const { appExport } = await ensureLoadedApp();
-          const app = appExport;
-          const attemptCount = Number(action.attempt_count || 0) + 1;
-          displayInfo(
-            `- ${action.id} (${action.type}:${action.function_name} attempt=${attemptCount})`,
-          );
-
-          const outputs = await app.invoke(
-            action.function_name,
-            action.inputs ?? {},
-            {
-              workflow: {
-                resourceId: action.resource_id,
-                operationId: action.operation_id,
-                actionId: action.id,
-                actionType: action.type,
-                attemptCount,
-                placement: action.placement,
-              },
-            },
-          );
-
-          return {
-            ok: true,
-            outputs,
-          };
-        };
-
-        if (!resolvedOperationId) {
-          throw new Error('Operation ID is required to run a persisted DAG.');
-        }
-
-        const result = await runOperation({
+        const result = await persistAndRunAppOperation({
           store,
-          resourceId: resource_id,
-          operationId: resolvedOperationId,
-          executeAction,
+          manifest,
+          operation,
+          baseContext: context,
+          onActionStart: (action, { attemptCount }) => {
+            if (
+              action.type === Action.Type.START ||
+              action.type === Action.Type.FINISH
+            ) {
+              displayInfo(`- ${action.id} (${action.type})`);
+              return;
+            }
+
+            displayInfo(
+              `- ${action.id} (${action.type}:${action.function_name} attempt=${attemptCount})`,
+            );
+          },
         });
 
         const finalRecords = await store.getRecords(
-          resource_id,
-          resolvedOperationId,
+          operation.resource_id,
+          operation.id,
         );
         const finalOperation = finalRecords.operations.find(
-          (operation) => operation.id === resolvedOperationId,
+          (record) => record.id === operation.id,
         );
 
         console.table(
@@ -301,7 +152,7 @@ const runCommand = new Command('run')
             details.push(`blocked=${result.blockedActionIds.join(',')}`);
           }
           throw new Error(
-            `Operation ${resource_id}#${resolvedOperationId} finished with status ${result.status}${
+            `Operation ${operation.resource_id}#${operation.id} finished with status ${result.status}${
               details.length > 0 ? ` (${details.join(' ')})` : ''
             }.`,
           );
@@ -312,10 +163,6 @@ const runCommand = new Command('run')
     } catch (err) {
       displayFailure(err);
       process.exitCode = 1;
-    } finally {
-      if (typeof loadedApp?.appExport?.closeRuntimeResources === 'function') {
-        await loadedApp.appExport.closeRuntimeResources();
-      }
     }
   });
 

--- a/src/cli/cmds/ops_cmds/run.js
+++ b/src/cli/cmds/ops_cmds/run.js
@@ -1,14 +1,11 @@
 import { Command } from 'commander';
 
 import { loadApp } from '../../app/load-app.js';
-import { parseJsonInput } from '../../app/local-app.js';
+import { resolveRunnableAppResourceRefs } from '../../app/runnable-app-resources.js';
 import { withOperationsStore } from '../operations-store.js';
-import {
-  createAppActivityOperation,
-  createAppWorkflowOperation,
-  persistAndRunAppOperation,
-} from '../../../core/runtime/app-runs.js';
 import Action from '../../../core/lib/graph/action.js';
+import Operation from '../../../core/lib/graph/operation.js';
+import { runOperation } from '../../../core/lib/graph/runner.js';
 import {
   displayFailure,
   displayInfo,
@@ -16,11 +13,25 @@ import {
 } from '../../output/basic.js';
 
 /**
- * @param {unknown} value - value.
- * @returns {value is Record<string, any>} - Result.
+ * @param {any} appExport - appExport.
+ * @returns {void}
  */
-function isObjectRecord(value) {
-  return !!value && typeof value === 'object' && !Array.isArray(value);
+function assertRunnableApp(appExport) {
+  if (!appExport || typeof appExport.invoke !== 'function') {
+    throw new Error(
+      'App is not runnable. Expected a default export with invoke(functionName, event, context).',
+    );
+  }
+}
+
+/**
+ * @param {Record<string, any> | undefined} placement - placement.
+ * @returns {string} - Result.
+ */
+function getPlacementMode(placement) {
+  const mode = placement?.mode;
+  if (typeof mode !== 'string' || !mode.trim()) return 'local';
+  return mode.trim().toLowerCase();
 }
 
 /**
@@ -45,98 +56,238 @@ function formatActionRows(operation, fallbackStatuses) {
   }));
 }
 
+/**
+ * @param {any} manifest - manifest.
+ * @param {string} workflowName - workflowName.
+ * @returns {any | undefined} - Result.
+ */
+function findWorkflowDefinition(manifest, workflowName) {
+  const trimmedName = String(workflowName || '').trim();
+  if (!trimmedName) return undefined;
+
+  /** @type {any[]} */
+  const workflows = Array.isArray(manifest?.workflows)
+    ? manifest.workflows
+    : [];
+  return workflows.find(
+    (/** @type {any} */ workflow) =>
+      workflow?.name && String(workflow.name) === trimmedName,
+  );
+}
+
+/**
+ * @param {{ workflow: any, resourceId: string, operationId?: string | undefined }} options - options.
+ * @returns {import('../../../core/lib/graph/operation.js').default} - Result.
+ */
+function createOperationFromWorkflow({ workflow, resourceId, operationId }) {
+  const operation = new Operation({
+    resource_id: resourceId,
+    resource_version: 1,
+    ...(typeof operationId === 'string' && operationId.trim()
+      ? { id: operationId.trim() }
+      : {}),
+    type:
+      typeof workflow?.type === 'string' && workflow.type.trim()
+        ? workflow.type.trim().toUpperCase()
+        : Operation.Type.PIPELINE,
+    operation_config: {
+      workflow_name: workflow?.name,
+      source: 'app-manifest',
+    },
+  });
+
+  const actions = Array.isArray(workflow?.actions) ? workflow.actions : [];
+  for (const action of actions) {
+    operation.createAction({
+      id: action.id,
+      type: action.type,
+      function_name: action.functionName,
+      inputs: action.inputs,
+      placement: action.placement,
+      retry: action.retry,
+    });
+  }
+
+  for (const action of actions) {
+    const dependencies = Array.isArray(action?.dependsOn)
+      ? action.dependsOn
+      : [];
+    for (const dependencyId of dependencies) {
+      if (typeof dependencyId !== 'string' || !dependencyId.trim()) {
+        continue;
+      }
+      operation._addDependency(dependencyId.trim(), action.id);
+    }
+  }
+
+  return operation;
+}
+
 const runCommand = new Command('run')
   .description(
-    'Create and execute a persisted app activity or workflow locally',
+    'Execute a persisted operation or an app-defined workflow locally',
+  )
+  .argument('<resource_id>', 'Wharfie resource ID')
+  .argument(
+    '[operation_id]',
+    'Operation ID (or operation ID override when --workflow is used)',
   )
   .option('--dir <dir>', 'Directory containing wharfie.app.js', process.cwd())
-  .option(
-    '--activity <activityName>',
-    'Activity name declared in wharfie.app.js',
-  )
   .option(
     '--workflow <workflowName>',
     'Workflow name declared in wharfie.app.js',
   )
-  .option('--operationId <operationId>', 'Operation ID override')
-  .option('--event <json>', 'Event JSON for activity runs (default: {})')
-  .option('--context <json>', 'Context JSON merged beneath workflow metadata')
-  .action(async (options) => {
+  .action(async (resource_id, operation_id, options) => {
+    /** @type {{ appExport: any, manifest: any } | undefined} */
+    let loadedApp;
+
     try {
-      const activityName =
-        typeof options.activity === 'string' ? options.activity.trim() : '';
-      const workflowName =
-        typeof options.workflow === 'string' ? options.workflow.trim() : '';
-      const appDir = options.dir || process.cwd();
-
-      if (!activityName && !workflowName) {
-        throw new Error(
-          'ops run requires either --activity <activityName> or --workflow <workflowName>.',
-        );
-      }
-
-      if (activityName && workflowName) {
-        throw new Error(
-          'ops run cannot accept both --activity <activityName> and --workflow <workflowName>.',
-        );
-      }
-
-      const context = parseJsonInput(options.context, 'context', {});
-      if (!isObjectRecord(context)) {
-        throw new Error('Context JSON must be an object.');
-      }
-
-      if (workflowName && typeof options.event === 'string') {
-        throw new Error('--event is only supported with --activity runs.');
-      }
-
-      const event = parseJsonInput(options.event, 'event', {});
-      const { manifest } = await loadApp({ dir: appDir });
-
-      const operation = activityName
-        ? createAppActivityOperation({
-            manifest,
-            activityName,
-            event,
-            operationId: options.operationId,
-          })
-        : createAppWorkflowOperation({
-            manifest,
-            workflowName,
-            operationId: options.operationId,
-          });
-
       await withOperationsStore(async (store) => {
-        displayInfo(
-          `Running ${activityName ? 'activity' : 'workflow'}: ${operation.resource_id}#${operation.id} (${activityName || workflowName})`,
-        );
+        const workflowName =
+          typeof options.workflow === 'string' ? options.workflow.trim() : '';
+        const appDir = options.dir || process.cwd();
 
-        const result = await persistAndRunAppOperation({
-          store,
-          manifest,
-          operation,
-          baseContext: context,
-          onActionStart: (action, { attemptCount }) => {
-            if (
-              action.type === Action.Type.START ||
-              action.type === Action.Type.FINISH
-            ) {
-              displayInfo(`- ${action.id} (${action.type})`);
-              return;
-            }
+        if (!workflowName && !operation_id) {
+          throw new Error(
+            'ops run requires <operation_id> unless --workflow <workflowName> is provided.',
+          );
+        }
 
-            displayInfo(
-              `- ${action.id} (${action.type}:${action.function_name} attempt=${attemptCount})`,
+        /**
+         * @returns {Promise<{ appExport: any, manifest: any }>} - Result.
+         */
+        const ensureLoadedApp = async () => {
+          if (loadedApp) {
+            return loadedApp;
+          }
+          loadedApp = await loadApp({ dir: appDir });
+          await resolveRunnableAppResourceRefs(loadedApp.appExport);
+          assertRunnableApp(loadedApp.appExport);
+          return loadedApp;
+        };
+
+        let resolvedOperationId = operation_id;
+
+        if (workflowName) {
+          const loaded = await ensureLoadedApp();
+          const workflow = findWorkflowDefinition(
+            loaded.manifest,
+            workflowName,
+          );
+
+          if (!workflow) {
+            /** @type {string[]} */
+            const availableWorkflows = Array.isArray(loaded.manifest?.workflows)
+              ? loaded.manifest.workflows
+                  .map((/** @type {any} */ candidate) => candidate?.name)
+                  .filter(
+                    (/** @type {unknown} */ candidate) =>
+                      typeof candidate === 'string',
+                  )
+              : [];
+            throw new Error(
+              `Workflow '${workflowName}' was not found in ${appDir}. Available workflows: ${
+                availableWorkflows.length > 0
+                  ? availableWorkflows.join(', ')
+                  : '(none)'
+              }`,
             );
-          },
+          }
+
+          const workflowOperation = createOperationFromWorkflow({
+            workflow,
+            resourceId: resource_id,
+            operationId: operation_id,
+          });
+          resolvedOperationId = workflowOperation.id;
+          await store.putOperation(workflowOperation);
+
+          displayInfo(
+            `Running workflow: ${resource_id}#${resolvedOperationId} (${workflow.name})`,
+          );
+        } else {
+          displayInfo(
+            `Running operation: ${resource_id}#${resolvedOperationId}`,
+          );
+        }
+
+        /**
+         * @param {import('../../../core/lib/graph/action.js').default} action - action.
+         * @returns {Promise<{ ok: boolean, outputs?: any }>} - Result.
+         */
+        const executeAction = async (action) => {
+          if (
+            action.type === Action.Type.START ||
+            action.type === Action.Type.FINISH
+          ) {
+            displayInfo(`- ${action.id} (${action.type})`);
+            return { ok: true };
+          }
+
+          if (action.type !== Action.Type.INVOKE_FUNCTION) {
+            throw new Error(
+              `Unsupported action type '${action.type}' for ops run. Only START, FINISH, and INVOKE_FUNCTION are currently executable.`,
+            );
+          }
+
+          if (!action.function_name || !String(action.function_name).trim()) {
+            throw new Error(
+              `INVOKE_FUNCTION action '${action.id}' is missing function_name.`,
+            );
+          }
+
+          const placementMode = getPlacementMode(action.placement);
+          if (placementMode !== 'local' && placementMode !== 'in_process') {
+            throw new Error(
+              `INVOKE_FUNCTION action '${action.id}' requested unsupported placement mode '${placementMode}'. Local execution currently supports only 'local' or 'in_process'.`,
+            );
+          }
+
+          const { appExport } = await ensureLoadedApp();
+          const app = appExport;
+          const attemptCount = Number(action.attempt_count || 0) + 1;
+          displayInfo(
+            `- ${action.id} (${action.type}:${action.function_name} attempt=${attemptCount})`,
+          );
+
+          const outputs = await app.invoke(
+            action.function_name,
+            action.inputs ?? {},
+            {
+              workflow: {
+                resourceId: action.resource_id,
+                operationId: action.operation_id,
+                actionId: action.id,
+                actionType: action.type,
+                attemptCount,
+                placement: action.placement,
+              },
+            },
+          );
+
+          return {
+            ok: true,
+            outputs,
+          };
+        };
+
+        if (!resolvedOperationId) {
+          throw new Error('Operation ID is required to run a persisted DAG.');
+        }
+
+        const result = await runOperation({
+          store,
+          resourceId: resource_id,
+          operationId: resolvedOperationId,
+          executeAction,
         });
 
         const finalRecords = await store.getRecords(
-          operation.resource_id,
-          operation.id,
+          resource_id,
+          resolvedOperationId,
         );
         const finalOperation = finalRecords.operations.find(
-          (record) => record.id === operation.id,
+          (operation) => operation.id === resolvedOperationId,
         );
 
         console.table(
@@ -152,7 +303,7 @@ const runCommand = new Command('run')
             details.push(`blocked=${result.blockedActionIds.join(',')}`);
           }
           throw new Error(
-            `Operation ${operation.resource_id}#${operation.id} finished with status ${result.status}${
+            `Operation ${resource_id}#${resolvedOperationId} finished with status ${result.status}${
               details.length > 0 ? ` (${details.join(' ')})` : ''
             }.`,
           );
@@ -163,6 +314,10 @@ const runCommand = new Command('run')
     } catch (err) {
       displayFailure(err);
       process.exitCode = 1;
+    } finally {
+      if (typeof loadedApp?.appExport?.closeRuntimeResources === 'function') {
+        await loadedApp.appExport.closeRuntimeResources();
+      }
     }
   });
 

--- a/src/cli/cmds/ops_cmds/run.js
+++ b/src/cli/cmds/ops_cmds/run.js
@@ -1,28 +1,23 @@
 import { Command } from 'commander';
 
 import { loadApp } from '../../app/load-app.js';
-import { resolveRunnableAppResourceRefs } from '../../app/runnable-app-resources.js';
+import { parseJsonInput } from '../../app/local-app.js';
 import { withOperationsStore } from '../operations-store.js';
 import Action from '../../../core/lib/graph/action.js';
-import Operation from '../../../core/lib/graph/operation.js';
 import { runOperation } from '../../../core/lib/graph/runner.js';
+import {
+  createOperationFromActivity,
+  createOperationFromWorkflow,
+  findManifestWorkflowDefinition,
+  getAppResourceId,
+  getManifestActivityNames,
+  invokeManifestActivity,
+} from '../../../core/runtime/app-runs.js';
 import {
   displayFailure,
   displayInfo,
   displaySuccess,
 } from '../../output/basic.js';
-
-/**
- * @param {any} appExport - appExport.
- * @returns {void}
- */
-function assertRunnableApp(appExport) {
-  if (!appExport || typeof appExport.invoke !== 'function') {
-    throw new Error(
-      'App is not runnable. Expected a default export with invoke(functionName, event, context).',
-    );
-  }
-}
 
 /**
  * @param {Record<string, any> | undefined} placement - placement.
@@ -50,7 +45,7 @@ function formatActionRows(operation, fallbackStatuses) {
   return operation.getSequentialActionOrder().map((action) => ({
     action_id: action.id,
     type: action.type,
-    function_name: action.function_name || '',
+    activity: action.function_name || '',
     status: action.status,
     attempt_count: action.attempt_count || 0,
   }));
@@ -58,158 +53,110 @@ function formatActionRows(operation, fallbackStatuses) {
 
 /**
  * @param {any} manifest - manifest.
- * @param {string} workflowName - workflowName.
- * @returns {any | undefined} - Result.
+ * @returns {string[]} - Result.
  */
-function findWorkflowDefinition(manifest, workflowName) {
-  const trimmedName = String(workflowName || '').trim();
-  if (!trimmedName) return undefined;
-
-  /** @type {any[]} */
-  const workflows = Array.isArray(manifest?.workflows)
+function getWorkflowNames(manifest) {
+  return Array.isArray(manifest?.workflows)
     ? manifest.workflows
+        .map((/** @type {any} */ workflow) => workflow?.name)
+        .filter(
+          (/** @type {unknown} */ candidate) => typeof candidate === 'string',
+        )
     : [];
-  return workflows.find(
-    (/** @type {any} */ workflow) =>
-      workflow?.name && String(workflow.name) === trimmedName,
-  );
-}
-
-/**
- * @param {{ workflow: any, resourceId: string, operationId?: string | undefined }} options - options.
- * @returns {import('../../../core/lib/graph/operation.js').default} - Result.
- */
-function createOperationFromWorkflow({ workflow, resourceId, operationId }) {
-  const operation = new Operation({
-    resource_id: resourceId,
-    resource_version: 1,
-    ...(typeof operationId === 'string' && operationId.trim()
-      ? { id: operationId.trim() }
-      : {}),
-    type:
-      typeof workflow?.type === 'string' && workflow.type.trim()
-        ? workflow.type.trim().toUpperCase()
-        : Operation.Type.PIPELINE,
-    operation_config: {
-      workflow_name: workflow?.name,
-      source: 'app-manifest',
-    },
-  });
-
-  const actions = Array.isArray(workflow?.actions) ? workflow.actions : [];
-  for (const action of actions) {
-    operation.createAction({
-      id: action.id,
-      type: action.type,
-      function_name: action.functionName,
-      inputs: action.inputs,
-      placement: action.placement,
-      retry: action.retry,
-    });
-  }
-
-  for (const action of actions) {
-    const dependencies = Array.isArray(action?.dependsOn)
-      ? action.dependsOn
-      : [];
-    for (const dependencyId of dependencies) {
-      if (typeof dependencyId !== 'string' || !dependencyId.trim()) {
-        continue;
-      }
-      operation._addDependency(dependencyId.trim(), action.id);
-    }
-  }
-
-  return operation;
 }
 
 const runCommand = new Command('run')
-  .description(
-    'Execute a persisted operation or an app-defined workflow locally',
-  )
-  .argument('<resource_id>', 'Wharfie resource ID')
-  .argument(
-    '[operation_id]',
-    'Operation ID (or operation ID override when --workflow is used)',
-  )
+  .description('Execute a persisted app activity or workflow locally')
   .option('--dir <dir>', 'Directory containing wharfie.app.js', process.cwd())
+  .option(
+    '--activity <activityName>',
+    'Activity name declared in wharfie.app.js',
+  )
   .option(
     '--workflow <workflowName>',
     'Workflow name declared in wharfie.app.js',
   )
-  .action(async (resource_id, operation_id, options) => {
-    /** @type {{ appExport: any, manifest: any } | undefined} */
-    let loadedApp;
-
+  .option('--event <json>', 'Activity event JSON (default: {})')
+  .option('--operation-id <operationId>', 'Override generated operation id')
+  .action(async (options) => {
     try {
       await withOperationsStore(async (store) => {
+        const activityName =
+          typeof options.activity === 'string' ? options.activity.trim() : '';
         const workflowName =
           typeof options.workflow === 'string' ? options.workflow.trim() : '';
         const appDir = options.dir || process.cwd();
 
-        if (!workflowName && !operation_id) {
+        if (!activityName && !workflowName) {
           throw new Error(
-            'ops run requires <operation_id> unless --workflow <workflowName> is provided.',
+            'ops run requires --activity <activityName> or --workflow <workflowName>.',
+          );
+        }
+        if (activityName && workflowName) {
+          throw new Error(
+            'ops run accepts either --activity <activityName> or --workflow <workflowName>, not both.',
           );
         }
 
-        /**
-         * @returns {Promise<{ appExport: any, manifest: any }>} - Result.
-         */
-        const ensureLoadedApp = async () => {
-          if (loadedApp) {
-            return loadedApp;
-          }
-          loadedApp = await loadApp({ dir: appDir });
-          await resolveRunnableAppResourceRefs(loadedApp.appExport);
-          assertRunnableApp(loadedApp.appExport);
-          return loadedApp;
-        };
+        const loadedApp = await loadApp({ dir: appDir });
+        const { manifest, publicManifest } = loadedApp;
+        const appName = manifest.app.name;
+        const resourceId = getAppResourceId(appName);
 
-        let resolvedOperationId = operation_id;
+        /** @type {import('../../../core/lib/graph/operation.js').default} */
+        let operation;
 
-        if (workflowName) {
-          const loaded = await ensureLoadedApp();
-          const workflow = findWorkflowDefinition(
-            loaded.manifest,
-            workflowName,
+        if (activityName) {
+          const availableActivities = getManifestActivityNames(
+            manifest,
+            publicManifest,
           );
-
-          if (!workflow) {
-            /** @type {string[]} */
-            const availableWorkflows = Array.isArray(loaded.manifest?.workflows)
-              ? loaded.manifest.workflows
-                  .map((/** @type {any} */ candidate) => candidate?.name)
-                  .filter(
-                    (/** @type {unknown} */ candidate) =>
-                      typeof candidate === 'string',
-                  )
-              : [];
+          if (!availableActivities.includes(activityName)) {
             throw new Error(
-              `Workflow '${workflowName}' was not found in ${appDir}. Available workflows: ${
-                availableWorkflows.length > 0
-                  ? availableWorkflows.join(', ')
-                  : '(none)'
+              `Activity '${activityName}' was not found in ${appDir}. Available activities: ${
+                availableActivities.join(', ') || '(none)'
               }`,
             );
           }
 
-          const workflowOperation = createOperationFromWorkflow({
-            workflow,
-            resourceId: resource_id,
-            operationId: operation_id,
+          operation = createOperationFromActivity({
+            appName,
+            activityName,
+            event: parseJsonInput(options.event, 'event', {}),
+            operationId: options.operationId,
+            trigger: { source: 'manual' },
           });
-          resolvedOperationId = workflowOperation.id;
-          await store.putOperation(workflowOperation);
-
           displayInfo(
-            `Running workflow: ${resource_id}#${resolvedOperationId} (${workflow.name})`,
+            `Running activity: ${resourceId}#${operation.id} (${activityName})`,
           );
         } else {
+          const workflow = findManifestWorkflowDefinition({
+            manifest,
+            publicManifest,
+            workflowName,
+          });
+
+          if (!workflow) {
+            const availableWorkflows = getWorkflowNames(manifest);
+            throw new Error(
+              `Workflow '${workflowName}' was not found in ${appDir}. Available workflows: ${
+                availableWorkflows.join(', ') || '(none)'
+              }`,
+            );
+          }
+
+          operation = createOperationFromWorkflow({
+            workflow,
+            appName,
+            operationId: options.operationId,
+            trigger: { source: 'manual' },
+          });
           displayInfo(
-            `Running operation: ${resource_id}#${resolvedOperationId}`,
+            `Running workflow: ${resourceId}#${operation.id} (${workflow.name})`,
           );
         }
+
+        await store.putOperation(operation);
 
         /**
          * @param {import('../../../core/lib/graph/action.js').default} action - action.
@@ -232,7 +179,7 @@ const runCommand = new Command('run')
 
           if (!action.function_name || !String(action.function_name).trim()) {
             throw new Error(
-              `INVOKE_FUNCTION action '${action.id}' is missing function_name.`,
+              `INVOKE_FUNCTION action '${action.id}' is missing activity.`,
             );
           }
 
@@ -243,17 +190,17 @@ const runCommand = new Command('run')
             );
           }
 
-          const { appExport } = await ensureLoadedApp();
-          const app = appExport;
           const attemptCount = Number(action.attempt_count || 0) + 1;
           displayInfo(
             `- ${action.id} (${action.type}:${action.function_name} attempt=${attemptCount})`,
           );
 
-          const outputs = await app.invoke(
-            action.function_name,
-            action.inputs ?? {},
-            {
+          const outputs = await invokeManifestActivity({
+            manifest,
+            publicManifest,
+            activityName: action.function_name,
+            event: action.inputs ?? {},
+            context: {
               workflow: {
                 resourceId: action.resource_id,
                 operationId: action.operation_id,
@@ -263,7 +210,7 @@ const runCommand = new Command('run')
                 placement: action.placement,
               },
             },
-          );
+          });
 
           return {
             ok: true,
@@ -271,23 +218,16 @@ const runCommand = new Command('run')
           };
         };
 
-        if (!resolvedOperationId) {
-          throw new Error('Operation ID is required to run a persisted DAG.');
-        }
-
         const result = await runOperation({
           store,
-          resourceId: resource_id,
-          operationId: resolvedOperationId,
+          resourceId,
+          operationId: operation.id,
           executeAction,
         });
 
-        const finalRecords = await store.getRecords(
-          resource_id,
-          resolvedOperationId,
-        );
+        const finalRecords = await store.getRecords(resourceId, operation.id);
         const finalOperation = finalRecords.operations.find(
-          (operation) => operation.id === resolvedOperationId,
+          (candidate) => candidate.id === operation.id,
         );
 
         console.table(
@@ -303,7 +243,7 @@ const runCommand = new Command('run')
             details.push(`blocked=${result.blockedActionIds.join(',')}`);
           }
           throw new Error(
-            `Operation ${resource_id}#${resolvedOperationId} finished with status ${result.status}${
+            `Operation ${resourceId}#${operation.id} finished with status ${result.status}${
               details.length > 0 ? ` (${details.join(' ')})` : ''
             }.`,
           );
@@ -314,10 +254,6 @@ const runCommand = new Command('run')
     } catch (err) {
       displayFailure(err);
       process.exitCode = 1;
-    } finally {
-      if (typeof loadedApp?.appExport?.closeRuntimeResources === 'function') {
-        await loadedApp.appExport.closeRuntimeResources();
-      }
     }
   });
 

--- a/src/core/lib/graph/app-run.js
+++ b/src/core/lib/graph/app-run.js
@@ -1,0 +1,204 @@
+import { createId } from '../id.js';
+import Action, { Status as ActionStatus } from './action.js';
+import Operation, { Type as OperationType } from './operation.js';
+import { runOperation } from './runner.js';
+
+/**
+ * @typedef QueueRunMetadata
+ * @property {string} [queueUrl] - queueUrl.
+ * @property {string} [messageId] - messageId.
+ * @property {string} [receiptHandle] - receiptHandle.
+ */
+
+/**
+ * @typedef RunPersistedEventActivityOptions
+ * @property {import('../db/tables/operations.js').OperationsTableClient} store - store.
+ * @property {string} appName - appName.
+ * @property {string} activity - activity.
+ * @property {any} [event] - event.
+ * @property {any} [context] - context.
+ * @property {any} [payload] - raw payload.
+ * @property {QueueRunMetadata} [message] - message metadata.
+ * @property {(request: { functionName: string, event?: any, context?: any }) => Promise<any>} execute - execute.
+ */
+
+/**
+ * @param {unknown} value - value.
+ * @returns {string | undefined} - Result.
+ */
+function normalizeOptionalString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * @param {string} appName - appName.
+ * @returns {string} - Result.
+ */
+export function getSyntheticAppResourceId(appName) {
+  const normalized = normalizeOptionalString(appName);
+  if (!normalized) {
+    throw new Error('runPersistedEventActivity requires appName');
+  }
+  return `app:${normalized}`;
+}
+
+/**
+ * @param {{
+ *   appName: string,
+ *   activity: string,
+ *   operationId: string,
+ *   previousAttemptCount?: number,
+ *   payload?: any,
+ *   event?: any,
+ *   message?: QueueRunMetadata,
+ * }} options - options.
+ * @returns {Operation} - Result.
+ */
+function createEventOperation({
+  appName,
+  activity,
+  operationId,
+  previousAttemptCount = 0,
+  payload,
+  event,
+  message,
+}) {
+  const resourceId = getSyntheticAppResourceId(appName);
+  const trigger = {
+    source: 'event',
+    ...(normalizeOptionalString(message?.queueUrl)
+      ? { queueUrl: normalizeOptionalString(message?.queueUrl) }
+      : {}),
+    ...(normalizeOptionalString(message?.messageId)
+      ? { messageId: normalizeOptionalString(message?.messageId) }
+      : {}),
+    ...(normalizeOptionalString(message?.receiptHandle)
+      ? { receiptHandle: normalizeOptionalString(message?.receiptHandle) }
+      : {}),
+  };
+
+  const operation = new Operation({
+    resource_id: resourceId,
+    resource_version: 1,
+    id: operationId,
+    type: OperationType.PIPELINE,
+    operation_config: {
+      app: appName,
+      activity,
+      trigger,
+    },
+    operation_inputs:
+      payload !== undefined
+        ? payload
+        : {
+            event,
+          },
+  });
+
+  operation.createAction({
+    id: 'invoke',
+    type: Action.Type.INVOKE_FUNCTION,
+    function_name: activity,
+    inputs: event,
+    retry: { maxAttempts: 1 },
+    attempt_count: previousAttemptCount,
+  });
+
+  return operation;
+}
+
+/**
+ * @param {RunPersistedEventActivityOptions} options - options.
+ * @returns {Promise<{ resourceId: string, operationId: string, status: 'COMPLETED' | 'FAILED' | 'BLOCKED' }>} - Result.
+ */
+export async function runPersistedEventActivity({
+  store,
+  appName,
+  activity,
+  event,
+  context,
+  payload,
+  message,
+  execute,
+}) {
+  if (!store) {
+    throw new Error('runPersistedEventActivity requires store');
+  }
+  const normalizedActivity = normalizeOptionalString(activity);
+  if (!normalizedActivity) {
+    throw new Error('runPersistedEventActivity requires activity');
+  }
+  if (typeof execute !== 'function') {
+    throw new Error('runPersistedEventActivity requires execute(request)');
+  }
+
+  const resourceId = getSyntheticAppResourceId(appName);
+  const operationId = normalizeOptionalString(message?.messageId) || createId();
+
+  const existingRecords = await store.getRecords(resourceId, operationId);
+  const existingAction = existingRecords.actions.find(
+    (candidate) => candidate.id === 'invoke',
+  );
+  const previousAttemptCount = Number(existingAction?.attempt_count || 0);
+
+  const operation = createEventOperation({
+    appName,
+    activity: normalizedActivity,
+    operationId,
+    previousAttemptCount,
+    payload,
+    event,
+    message,
+  });
+
+  await store.putOperation(operation);
+
+  const result = await runOperation({
+    store,
+    resourceId,
+    operationId,
+    executeAction: async (action) => {
+      if (action.type !== Action.Type.INVOKE_FUNCTION) {
+        return { ok: true };
+      }
+
+      const outputs = await execute({
+        functionName: action.function_name || normalizedActivity,
+        event: action.inputs,
+        context,
+      });
+
+      return { ok: true, outputs };
+    },
+  });
+
+  if (result.status !== 'COMPLETED') {
+    const finalRecords = await store.getRecords(resourceId, operationId);
+    const failedAction = finalRecords.actions.find(
+      (candidate) => candidate.status === ActionStatus.FAILED,
+    );
+    const messageText =
+      typeof failedAction?.error?.message === 'string' &&
+      failedAction.error.message.trim()
+        ? failedAction.error.message.trim()
+        : `Persisted event run ${resourceId}#${operationId} finished with status ${result.status}`;
+    const error = new Error(messageText);
+    Object.assign(error, {
+      resourceId,
+      operationId,
+      status: result.status,
+    });
+    throw error;
+  }
+
+  return {
+    resourceId,
+    operationId,
+    status: result.status,
+  };
+}
+
+export default {
+  getSyntheticAppResourceId,
+  runPersistedEventActivity,
+};

--- a/src/core/lib/node-sea.js
+++ b/src/core/lib/node-sea.js
@@ -38,6 +38,19 @@ function resolveNodeSeaModule() {
 }
 
 /**
+ * @returns {Record<string, string> | null} - Result.
+ */
+function resolveFallbackAssetMap() {
+  const candidate = /** @type {{ __wharfieSeaAssets?: unknown }} */ (globalThis)
+    .__wharfieSeaAssets;
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+    return null;
+  }
+
+  return /** @type {Record<string, string>} */ (candidate);
+}
+
+/**
  * @param {string} name - SEA asset name.
  * @param {string} [encoding] - Optional asset encoding.
  * @returns {any} - Asset contents.
@@ -45,13 +58,23 @@ function resolveNodeSeaModule() {
 export function getAsset(name, encoding) {
   const resolvedNodeSeaModule = resolveNodeSeaModule();
 
-  if (typeof resolvedNodeSeaModule?.getAsset !== 'function') {
+  if (typeof resolvedNodeSeaModule?.getAsset === 'function') {
+    return typeof encoding === 'string'
+      ? resolvedNodeSeaModule.getAsset(name, encoding)
+      : resolvedNodeSeaModule.getAsset(name);
+  }
+
+  const fallbackAssetMap = resolveFallbackAssetMap();
+  const assetValue = fallbackAssetMap?.[name];
+  if (typeof assetValue !== 'string') {
     throw new Error('node:sea is unavailable in this Node.js runtime');
   }
 
-  return typeof encoding === 'string'
-    ? resolvedNodeSeaModule.getAsset(name, encoding)
-    : resolvedNodeSeaModule.getAsset(name);
+  const buffer = Buffer.from(assetValue, 'base64');
+  if (typeof encoding === 'string' && Buffer.isEncoding(encoding)) {
+    return buffer.toString(/** @type {any} */ (encoding));
+  }
+  return buffer;
 }
 
 /**
@@ -60,9 +83,11 @@ export function getAsset(name, encoding) {
 export function isSea() {
   const resolvedNodeSeaModule = resolveNodeSeaModule();
 
-  return typeof resolvedNodeSeaModule?.isSea === 'function'
-    ? resolvedNodeSeaModule.isSea()
-    : false;
+  if (typeof resolvedNodeSeaModule?.isSea === 'function') {
+    return resolvedNodeSeaModule.isSea();
+  }
+
+  return Boolean(resolveFallbackAssetMap());
 }
 
 export default {

--- a/src/core/lib/paths.js
+++ b/src/core/lib/paths.js
@@ -4,12 +4,24 @@ import { promises } from 'node:fs';
 const paths = envPaths('wharfie');
 
 /**
+ * @returns {string} - Result.
+ */
+function getConfigDir() {
+  const configDir = process.env.CONFIG_DIR;
+  if (typeof configDir === 'string' && configDir.trim()) {
+    return configDir.trim();
+  }
+
+  return paths.config;
+}
+
+/**
  *
  */
 async function createWharfiePaths() {
   await Promise.all([
     promises.mkdir(paths.data, { recursive: true }),
-    promises.mkdir(paths.config, { recursive: true }),
+    promises.mkdir(getConfigDir(), { recursive: true }),
     promises.mkdir(paths.log, { recursive: true }),
     promises.mkdir(paths.temp, { recursive: true }),
   ]);
@@ -18,4 +30,5 @@ async function createWharfiePaths() {
 export default {
   ...paths,
   createWharfiePaths,
+  getConfigDir,
 };

--- a/src/core/resources/builds/actor-system-cli/control_cmds/state_cmds/serve_cmds/lambda.js
+++ b/src/core/resources/builds/actor-system-cli/control_cmds/state_cmds/serve_cmds/lambda.js
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import Function from '../../../../function.js';
+import makeOperationsStore from '../../../../../../lib/graph/operations-store.js';
 import { createActorSystemResources } from '../../../../../../runtime/resources.js';
 import { createGrpcRpcClient } from '../../../../../../runtime/services/rpc-grpc.js';
 import { startLambdaService } from '../../../../../../runtime/services/lambda-service.js';
@@ -107,6 +108,20 @@ const lambdaCmd = new Command('lambda')
 
     const objectStorage = local.objectStorage;
     const pollQueueUrls = bootstrap.pollQueueUrls;
+    const operationsTableName =
+      typeof process.env.OPERATIONS_TABLE === 'string' &&
+      process.env.OPERATIONS_TABLE.trim()
+        ? process.env.OPERATIONS_TABLE.trim()
+        : undefined;
+    const appName =
+      typeof bootstrap.manifest?.app?.name === 'string' &&
+      bootstrap.manifest.app.name.trim()
+        ? bootstrap.manifest.app.name.trim()
+        : undefined;
+    const operationsStore =
+      db && operationsTableName
+        ? makeOperationsStore({ db, tableName: operationsTableName })
+        : undefined;
 
     const svc = await startLambdaService({
       host: String(opts.host),
@@ -131,6 +146,8 @@ const lambdaCmd = new Command('lambda')
               waitTimeSeconds: Number(opts.pollWaitSeconds),
               maxNumberOfMessages: Number(opts.pollMaxMessages),
               visibilityTimeout: Number(opts.pollVisibilityTimeout),
+              operationsStore,
+              appName,
               log: (msg, extra) =>
                 console.error('[lambda-service:poll]', msg, extra ?? ''),
             }

--- a/src/core/resources/builds/actor-system-cli/index.js
+++ b/src/core/resources/builds/actor-system-cli/index.js
@@ -4,6 +4,12 @@ import paths from '../../../lib/paths.js';
 import functionsCLI from './functions.js';
 import infrastructureCLI from './infrastructure.js';
 import controlCLI from './control.js';
+import stateStartCmd from './control_cmds/state_cmds/start.js';
+import {
+  BOOTSTRAP_MODE_ENV,
+  BOOTSTRAP_MODE_STATE_START,
+  resolveBootstrapInvocation,
+} from './lib/bootstrap-mode.js';
 
 /**
  *
@@ -24,6 +30,22 @@ async function entrypoint() {
   process.env.CONFIG_FILE_PATH = `${process.env.CONFIG_DIR}/wharfie.config`;
   process.env.LOGGING_FORMAT = 'cli';
   process.env.LOGGING_LEVEL = 'warn';
+
+  const bootstrapInvocation = resolveBootstrapInvocation();
+  if (bootstrapInvocation) {
+    await paths.createWharfiePaths();
+    if (bootstrapInvocation.mode !== BOOTSTRAP_MODE_STATE_START) {
+      throw new Error(
+        `Unsupported ${BOOTSTRAP_MODE_ENV}: ${bootstrapInvocation.mode}`,
+      );
+    }
+    await stateStartCmd.parseAsync(
+      [argv[0] || 'node', 'start', ...bootstrapInvocation.args],
+      { from: 'node' },
+    );
+    return;
+  }
+
   const program = new Command();
   program.name('wharfie').description('CLI tool for Wharfie');
   // .version(version);ctor/resources/builds/actor-system.js

--- a/src/core/resources/builds/actor-system-cli/infrastructure_cmds/deploy.js
+++ b/src/core/resources/builds/actor-system-cli/infrastructure_cmds/deploy.js
@@ -140,7 +140,7 @@ export function createDeployCommand(deps = {}) {
     )
     .option(
       '--start-arg <arg>',
-      'Additional argument passed to `ctl state start` (repeatable)',
+      'Additional hidden runtime bootstrap argument passed to the packaged artifact (repeatable)',
       appendRepeatableOption,
       /** @type {string[]} */ ([]),
     )

--- a/src/core/resources/builds/actor-system-cli/infrastructure_cmds/deploy.js
+++ b/src/core/resources/builds/actor-system-cli/infrastructure_cmds/deploy.js
@@ -140,7 +140,7 @@ export function createDeployCommand(deps = {}) {
     )
     .option(
       '--start-arg <arg>',
-      'Additional hidden runtime bootstrap argument passed to the packaged artifact (repeatable)',
+      'Additional runtime bootstrap argument passed to the packaged artifact (repeatable)',
       appendRepeatableOption,
       /** @type {string[]} */ ([]),
     )

--- a/src/core/resources/builds/actor-system-cli/lib/app-manifest.js
+++ b/src/core/resources/builds/actor-system-cli/lib/app-manifest.js
@@ -140,6 +140,46 @@ export function getManifestResources(manifest) {
 }
 
 /**
+ * @param {any} manifest - manifest.
+ * @returns {Record<string, any>} - Result.
+ */
+export function getManifestActivities(manifest) {
+  if (isObjectRecord(manifest?.activities)) {
+    return manifest.activities;
+  }
+
+  const functions = Array.isArray(manifest?.functions)
+    ? manifest.functions
+    : [];
+  return functions.reduce(
+    (/** @type {Record<string, any>} */ acc, /** @type {any} */ definition) => {
+      if (
+        !isObjectRecord(definition) ||
+        typeof definition.name !== 'string' ||
+        !isObjectRecord(definition.entrypoint)
+      ) {
+        return acc;
+      }
+
+      acc[definition.name] = {
+        entrypoint: definition.entrypoint,
+        ...(Array.isArray(definition.external)
+          ? { external: definition.external }
+          : {}),
+        ...(isObjectRecord(definition.environmentVariables)
+          ? { environmentVariables: definition.environmentVariables }
+          : {}),
+        ...(isObjectRecord(definition.resources)
+          ? { resources: definition.resources }
+          : {}),
+      };
+      return acc;
+    },
+    /** @type {Record<string, any>} */ ({}),
+  );
+}
+
+/**
  * @param {unknown} value - value.
  * @returns {string[]} - Result.
  */
@@ -203,7 +243,13 @@ export function getManifestFunctions(manifest) {
     return manifest.functions;
   }
 
-  return Array.isArray(manifest?.activities) ? manifest.activities : [];
+  const activities = getManifestActivities(manifest);
+  return Object.keys(activities)
+    .sort((left, right) => left.localeCompare(right))
+    .map((name) => ({
+      name,
+      ...activities[name],
+    }));
 }
 
 /**
@@ -232,6 +278,7 @@ export function getManifestPrimaryTarget(manifest) {
 }
 
 export default {
+  getManifestActivities,
   getManifestAppName,
   getManifestFunctions,
   getManifestPollQueueUrls,

--- a/src/core/resources/builds/actor-system-cli/lib/app-manifest.js
+++ b/src/core/resources/builds/actor-system-cli/lib/app-manifest.js
@@ -199,7 +199,11 @@ export function getManifestAppName(manifest) {
  * @returns {any[]} - Result.
  */
 export function getManifestFunctions(manifest) {
-  return Array.isArray(manifest?.functions) ? manifest.functions : [];
+  if (Array.isArray(manifest?.functions)) {
+    return manifest.functions;
+  }
+
+  return Array.isArray(manifest?.activities) ? manifest.activities : [];
 }
 
 /**

--- a/src/core/resources/builds/actor-system-cli/lib/bootstrap-mode.js
+++ b/src/core/resources/builds/actor-system-cli/lib/bootstrap-mode.js
@@ -1,0 +1,97 @@
+/**
+ * @typedef RuntimeBootstrapInvocation
+ * @property {string} mode - mode.
+ * @property {string[]} args - args.
+ */
+
+export const BOOTSTRAP_MODE_ENV = 'WHARFIE_BOOTSTRAP_MODE';
+export const BOOTSTRAP_ARGS_ENV = 'WHARFIE_BOOTSTRAP_ARGS';
+export const BOOTSTRAP_MODE_STATE_START = 'state-start';
+
+/**
+ * @param {unknown} value - value.
+ * @param {string} label - label.
+ * @returns {any} - Result.
+ */
+function parseJson(value, label) {
+  try {
+    return JSON.parse(String(value));
+  } catch (error) {
+    const message =
+      error && typeof error === 'object' && 'message' in error
+        ? String(error.message)
+        : String(error);
+    throw new Error(`Failed to parse ${label}: ${message}`);
+  }
+}
+
+/**
+ * @param {unknown} value - value.
+ * @param {string} label - label.
+ * @returns {string[]} - Result.
+ */
+function normalizeStringArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON array of strings.`);
+  }
+
+  return value.map((entry) => {
+    if (typeof entry !== 'string') {
+      throw new Error(`${label} must be a JSON array of strings.`);
+    }
+    return entry;
+  });
+}
+
+/**
+ * @param {{ mode?: string, args?: string[] }} [options] - options.
+ * @returns {Record<string, string>} - Result.
+ */
+export function createBootstrapEnvironment(options = {}) {
+  const mode =
+    typeof options.mode === 'string' && options.mode.trim()
+      ? options.mode.trim()
+      : BOOTSTRAP_MODE_STATE_START;
+  const args = normalizeStringArray(
+    Array.isArray(options.args) ? options.args : [],
+    BOOTSTRAP_ARGS_ENV,
+  );
+
+  return {
+    [BOOTSTRAP_MODE_ENV]: mode,
+    [BOOTSTRAP_ARGS_ENV]: JSON.stringify(args),
+  };
+}
+
+/**
+ * @param {Record<string, string | undefined>} [environment] - environment.
+ * @returns {RuntimeBootstrapInvocation | undefined} - Result.
+ */
+export function resolveBootstrapInvocation(environment = process.env) {
+  const modeValue = environment[BOOTSTRAP_MODE_ENV];
+  if (typeof modeValue !== 'string' || !modeValue.trim()) {
+    return undefined;
+  }
+
+  const argsValue = environment[BOOTSTRAP_ARGS_ENV];
+  const args =
+    typeof argsValue === 'string' && argsValue.trim()
+      ? normalizeStringArray(
+          parseJson(argsValue, BOOTSTRAP_ARGS_ENV),
+          BOOTSTRAP_ARGS_ENV,
+        )
+      : [];
+
+  return {
+    mode: modeValue.trim(),
+    args,
+  };
+}
+
+export default {
+  BOOTSTRAP_MODE_ENV,
+  BOOTSTRAP_ARGS_ENV,
+  BOOTSTRAP_MODE_STATE_START,
+  createBootstrapEnvironment,
+  resolveBootstrapInvocation,
+};

--- a/src/core/resources/builds/actor-system-cli/lib/runtime-bootstrap.js
+++ b/src/core/resources/builds/actor-system-cli/lib/runtime-bootstrap.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import { resolveSharedResourceSpecs } from '../../../../runtime/shared-resource-registry.js';
 import {
+  getManifestActivities,
   getManifestFunctions,
   getManifestPollQueueUrls,
   getManifestResources,
@@ -95,6 +96,7 @@ function normalizeStringArray(value) {
  * Extract cron triggers from a manifest/config-like object.
  *
  * Supported shapes (MVP):
+ * - { scheduler: { triggers: [{ activity, cron }] } }
  * - { scheduler: { triggers: [{ actor, cron }] } }
  * - { cronTriggers: [{ actor, cron }] }
  * - { cron: [{ actor, cron }] }
@@ -119,11 +121,13 @@ export function extractCronTriggers(spec) {
     for (const trigger of candidate) {
       if (!isObjectRecord(trigger)) continue;
       const actor =
-        typeof trigger.actor === 'string'
-          ? trigger.actor
-          : typeof trigger.functionName === 'string'
-            ? trigger.functionName
-            : null;
+        typeof trigger.activity === 'string'
+          ? trigger.activity
+          : typeof trigger.actor === 'string'
+            ? trigger.actor
+            : typeof trigger.functionName === 'string'
+              ? trigger.functionName
+              : null;
       const cron = typeof trigger.cron === 'string' ? trigger.cron : null;
       if (!actor || !cron) continue;
       triggers.push({ actor: actor.trim(), cron: cron.trim() });
@@ -167,7 +171,7 @@ export async function loadRuntimeBootstrap(opts = {}, options = {}) {
     : {};
 
   const explicitPollQueueUrls = normalizeStringArray(opts.pollQueueUrl);
-  const pollQueueManifest = manifest
+  const pollQueueSource = manifest
     ? {
         ...manifest,
         capabilities: resourcesSpec,
@@ -177,9 +181,10 @@ export async function loadRuntimeBootstrap(opts = {}, options = {}) {
   const pollQueueUrls =
     explicitPollQueueUrls.length > 0
       ? explicitPollQueueUrls
-      : getManifestPollQueueUrls(pollQueueManifest);
+      : getManifestPollQueueUrls(pollQueueSource);
   const schedulerTriggers = extractCronTriggers(manifest || resourcesSpec);
   const functions = getManifestFunctions(manifest);
+  const activities = getManifestActivities(manifest);
 
   return {
     manifest,
@@ -190,7 +195,9 @@ export async function loadRuntimeBootstrap(opts = {}, options = {}) {
       db: resourcesSpec.db !== undefined,
       queue: resourcesSpec.queue !== undefined,
       objectStorage: resourcesSpec.objectStorage !== undefined,
-      lambda: manifest ? functions.length > 0 : true,
+      lambda: manifest
+        ? functions.length > 0 || Object.keys(activities).length > 0
+        : true,
       scheduler: schedulerTriggers.length > 0,
     },
   };

--- a/src/core/resources/builds/actor-system-cli/lib/runtime-bootstrap.js
+++ b/src/core/resources/builds/actor-system-cli/lib/runtime-bootstrap.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { resolveSharedResourceSpecs } from '../../../../runtime/shared-resource-registry.js';
 import {
   getManifestFunctions,
   getManifestPollQueueUrls,
@@ -156,17 +157,27 @@ export async function loadRuntimeBootstrap(opts = {}, options = {}) {
     ? loadResourcesSpec(opts)
     : undefined;
   const manifestResources = getManifestResources(manifest);
-  const resourcesSpec = isObjectRecord(explicitResources)
+  const unresolvedResourcesSpec = isObjectRecord(explicitResources)
     ? explicitResources
     : isObjectRecord(manifestResources)
       ? manifestResources
       : {};
+  const resourcesSpec = isObjectRecord(unresolvedResourcesSpec)
+    ? await resolveSharedResourceSpecs(unresolvedResourcesSpec)
+    : {};
 
   const explicitPollQueueUrls = normalizeStringArray(opts.pollQueueUrl);
+  const pollQueueManifest = manifest
+    ? {
+        ...manifest,
+        capabilities: resourcesSpec,
+        resources: resourcesSpec,
+      }
+    : resourcesSpec;
   const pollQueueUrls =
     explicitPollQueueUrls.length > 0
       ? explicitPollQueueUrls
-      : getManifestPollQueueUrls(manifest);
+      : getManifestPollQueueUrls(pollQueueManifest);
   const schedulerTriggers = extractCronTriggers(manifest || resourcesSpec);
   const functions = getManifestFunctions(manifest);
 

--- a/src/core/resources/builds/actor-system-cli/lib/systemd-release.js
+++ b/src/core/resources/builds/actor-system-cli/lib/systemd-release.js
@@ -186,6 +186,7 @@ export function createReleasePaths(options) {
  * @property {ReleasePaths} paths - paths.
  * @property {ReleaseRecord} record - record.
  * @property {string} unitContent - unitContent.
+ * @property {string[]} execArgs - execArgs.
  * @property {string[]} bootstrapArgs - bootstrapArgs.
  * @property {Record<string, string>} environment - environment.
  * @property {Array<{ command: string, args: string[] }>} shellCommands - shellCommands.
@@ -221,6 +222,8 @@ export function createDeployPlan(options) {
     options.role || 'all',
     ...(Array.isArray(options.extraArgs) ? options.extraArgs : []),
   ];
+  /** @type {string[]} */
+  const execArgs = [];
   const paths = createReleasePaths({
     appName,
     releaseRoot: options.releaseRoot || '/var/lib/wharfie',
@@ -283,6 +286,7 @@ export function createDeployPlan(options) {
     paths,
     record,
     unitContent,
+    execArgs,
     bootstrapArgs,
     environment,
     shellCommands: [

--- a/src/core/resources/builds/actor-system-cli/lib/systemd-release.js
+++ b/src/core/resources/builds/actor-system-cli/lib/systemd-release.js
@@ -5,6 +5,10 @@ import {
   getManifestAppName,
   getManifestPrimaryTarget,
 } from './app-manifest.js';
+import {
+  BOOTSTRAP_MODE_STATE_START,
+  createBootstrapEnvironment,
+} from './bootstrap-mode.js';
 
 /**
  * @param {string} value - value.
@@ -182,7 +186,7 @@ export function createReleasePaths(options) {
  * @property {ReleasePaths} paths - paths.
  * @property {ReleaseRecord} record - record.
  * @property {string} unitContent - unitContent.
- * @property {string[]} execArgs - execArgs.
+ * @property {string[]} bootstrapArgs - bootstrapArgs.
  * @property {Record<string, string>} environment - environment.
  * @property {Array<{ command: string, args: string[] }>} shellCommands - shellCommands.
  */
@@ -212,10 +216,7 @@ export function createDeployPlan(options) {
       .replace(/[-:]/g, '')
       .replace(/\.\d{3}Z$/, 'Z')}`;
   const unitName = `${serviceName}.service`;
-  const execArgs = [
-    'ctl',
-    'state',
-    'start',
+  const bootstrapArgs = [
     '--role',
     options.role || 'all',
     ...(Array.isArray(options.extraArgs) ? options.extraArgs : []),
@@ -231,7 +232,7 @@ export function createDeployPlan(options) {
   const workingDirectory = path.resolve(
     options.workingDirectory || paths.currentLinkPath,
   );
-  const environment = Object.keys(options.environment || {}).reduce(
+  const configuredEnvironment = Object.keys(options.environment || {}).reduce(
     (acc, key) => {
       const value = options.environment?.[key];
       if (typeof value === 'string') {
@@ -241,9 +242,14 @@ export function createDeployPlan(options) {
     },
     /** @type {Record<string, string>} */ ({}),
   );
-  const execStart = [paths.currentArtifactPath, ...execArgs]
-    .map((segment) => shellQuote(segment))
-    .join(' ');
+  const environment = {
+    ...configuredEnvironment,
+    ...createBootstrapEnvironment({
+      mode: BOOTSTRAP_MODE_STATE_START,
+      args: bootstrapArgs,
+    }),
+  };
+  const execStart = shellQuote(paths.currentArtifactPath);
   const unitContent = buildLinuxSystemdUnit({
     description: `${appName} artifact service`,
     execStart,
@@ -277,7 +283,7 @@ export function createDeployPlan(options) {
     paths,
     record,
     unitContent,
-    execArgs,
+    bootstrapArgs,
     environment,
     shellCommands: [
       { command: 'systemctl', args: ['daemon-reload'] },

--- a/src/core/resources/builds/actor-system.js
+++ b/src/core/resources/builds/actor-system.js
@@ -5,12 +5,22 @@ import FunctionResource from './function-resource.js';
 import SeaBuild from './sea-build.js';
 import MacOSBinarySignature from './macos-binary-signature.js';
 import cli from './actor-system-cli/index.js';
-import { createPackagedAppEntryCode } from './lib/packaged-app-entry-code.js';
 import { createActorSystemResources } from '../../runtime/resources.js';
 import { withResourceScope } from '../resource-scope.js';
 import { createResourceScope } from '../runtime-config.js';
 
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const actorSystemMetaUrl =
+  typeof import.meta.url === 'string' ? import.meta.url : '';
+const actorSystemFilePath = actorSystemMetaUrl.startsWith('file:')
+  ? fileURLToPath(actorSystemMetaUrl)
+  : actorSystemMetaUrl;
+const actorSystemDir =
+  typeof import.meta.dirname === 'string'
+    ? import.meta.dirname
+    : path.dirname(actorSystemFilePath);
 
 /**
  * @typedef {import('node:process')['platform']} TargetPlatform
@@ -45,6 +55,7 @@ import path from 'node:path';
  * @property {ActorSystemResourcesSpec} [resources] - resources.
  * @property {import('./function.js').default[]} [functions] - functions.
  * @property {any[]} [workflows] - Serializable workflow definitions.
+ * @property {{ entrypoint: string }} [cli] - CLI entrypoint config.
  */
 
 /**
@@ -128,53 +139,6 @@ function buildTargetSelector(target) {
   return `node${target.nodeVersion}-${target.platform}-${target.architecture}${
     target.libc ? `-${target.libc}` : ''
   }`;
-}
-
-/**
- * @param {unknown} cliSpec - cliSpec.
- * @returns {{ entrypoint: string, export?: string } | undefined} - Result.
- */
-function normalizeCliSpec(cliSpec) {
-  if (typeof cliSpec === 'string' && cliSpec.trim()) {
-    return { entrypoint: cliSpec.trim() };
-  }
-
-  if (!cliSpec || typeof cliSpec !== 'object') {
-    return undefined;
-  }
-
-  const cliRecord = /** @type {{ entrypoint?: unknown, export?: unknown }} */ (
-    cliSpec
-  );
-  const cliEntrypoint =
-    cliRecord.entrypoint && typeof cliRecord.entrypoint === 'object'
-      ? /** @type {{ path?: unknown, export?: unknown }} */ (
-          cliRecord.entrypoint
-        )
-      : null;
-
-  const entrypoint =
-    typeof cliRecord.entrypoint === 'string'
-      ? cliRecord.entrypoint.trim()
-      : typeof cliEntrypoint?.path === 'string'
-        ? cliEntrypoint.path.trim()
-        : '';
-
-  if (!entrypoint) {
-    return undefined;
-  }
-
-  const exportName =
-    typeof cliRecord.export === 'string' && cliRecord.export.trim()
-      ? cliRecord.export.trim()
-      : typeof cliEntrypoint?.export === 'string' && cliEntrypoint.export.trim()
-        ? cliEntrypoint.export.trim()
-        : '';
-
-  return {
-    entrypoint,
-    ...(exportName ? { export: exportName } : {}),
-  };
 }
 
 /**
@@ -386,13 +350,86 @@ class ActorSystem extends BuildResourceGroup {
       dependsOn: [node_binary, ...targetFunctions],
       properties: {
         entryCode: () => {
-          const cliSpec = normalizeCliSpec(this.get('cli', undefined));
-          return createPackagedAppEntryCode({
-            cliEntrypointPath: cliSpec?.entrypoint,
-            cliExportName: cliSpec?.export,
-          });
+          const developerCliEntrypoint =
+            typeof this.get('cli', {})?.entrypoint === 'string' &&
+            this.get('cli', {}).entrypoint
+              ? path.resolve(this.get('cli', {}).entrypoint)
+              : null;
+          const packagedAppEntryPath = path.resolve(
+            actorSystemDir,
+            'packaged-app-entry.js',
+          );
+          const runtimeCliPath = path.resolve(
+            actorSystemDir,
+            'actor-system-cli',
+            'index.js',
+          );
+          const runtimeStartPath = path.resolve(
+            actorSystemDir,
+            'actor-system-cli',
+            'control_cmds',
+            'state_cmds',
+            'start.js',
+          );
+          const runtimeDbPath = path.resolve(
+            actorSystemDir,
+            'actor-system-cli',
+            'control_cmds',
+            'state_cmds',
+            'serve_cmds',
+            'db.js',
+          );
+          const runtimeQueuePath = path.resolve(
+            actorSystemDir,
+            'actor-system-cli',
+            'control_cmds',
+            'state_cmds',
+            'serve_cmds',
+            'queue.js',
+          );
+          const runtimeLambdaPath = path.resolve(
+            actorSystemDir,
+            'actor-system-cli',
+            'control_cmds',
+            'state_cmds',
+            'serve_cmds',
+            'lambda.js',
+          );
+          const developerImport = developerCliEntrypoint
+            ? `import * as developerCliModule from ${JSON.stringify(
+                developerCliEntrypoint,
+              )};`
+            : 'const developerCliModule = null;';
+
+          return `
+              import sourceMapSupport from 'source-map-support';
+              import { runPackagedApp } from ${JSON.stringify(
+                packagedAppEntryPath,
+              )};
+              ${developerImport}
+              import runtimeCli from ${JSON.stringify(runtimeCliPath)};
+              import startCmd from ${JSON.stringify(runtimeStartPath)};
+              import serveDbCmd from ${JSON.stringify(runtimeDbPath)};
+              import serveQueueCmd from ${JSON.stringify(runtimeQueuePath)};
+              import serveLambdaCmd from ${JSON.stringify(runtimeLambdaPath)};
+              (async () => {
+                console.time('overall');
+                sourceMapSupport.install();
+                await runPackagedApp({
+                  developerCliModule,
+                  runtimeModules: {
+                    cli: runtimeCli,
+                    start: startCmd,
+                    'serve-db': serveDbCmd,
+                    'serve-queue': serveQueueCmd,
+                    'serve-lambda': serveLambdaCmd,
+                  },
+                });
+                console.timeEnd('overall');
+              })();
+          `;
         },
-        resolveDir: () => path.dirname(import.meta.dirname),
+        resolveDir: () => path.dirname(actorSystemDir),
         nodeBinaryPath: () => node_binary.get('binaryPath'),
         nodeVersion: () => node_binary.get('exactVersion').slice(1),
         platform,

--- a/src/core/resources/builds/actor-system.js
+++ b/src/core/resources/builds/actor-system.js
@@ -5,6 +5,7 @@ import FunctionResource from './function-resource.js';
 import SeaBuild from './sea-build.js';
 import MacOSBinarySignature from './macos-binary-signature.js';
 import cli from './actor-system-cli/index.js';
+import { createPackagedAppEntryCode } from './lib/packaged-app-entry-code.js';
 import { createActorSystemResources } from '../../runtime/resources.js';
 import { withResourceScope } from '../resource-scope.js';
 import { createResourceScope } from '../runtime-config.js';
@@ -127,6 +128,53 @@ function buildTargetSelector(target) {
   return `node${target.nodeVersion}-${target.platform}-${target.architecture}${
     target.libc ? `-${target.libc}` : ''
   }`;
+}
+
+/**
+ * @param {unknown} cliSpec - cliSpec.
+ * @returns {{ entrypoint: string, export?: string } | undefined} - Result.
+ */
+function normalizeCliSpec(cliSpec) {
+  if (typeof cliSpec === 'string' && cliSpec.trim()) {
+    return { entrypoint: cliSpec.trim() };
+  }
+
+  if (!cliSpec || typeof cliSpec !== 'object') {
+    return undefined;
+  }
+
+  const cliRecord = /** @type {{ entrypoint?: unknown, export?: unknown }} */ (
+    cliSpec
+  );
+  const cliEntrypoint =
+    cliRecord.entrypoint && typeof cliRecord.entrypoint === 'object'
+      ? /** @type {{ path?: unknown, export?: unknown }} */ (
+          cliRecord.entrypoint
+        )
+      : null;
+
+  const entrypoint =
+    typeof cliRecord.entrypoint === 'string'
+      ? cliRecord.entrypoint.trim()
+      : typeof cliEntrypoint?.path === 'string'
+        ? cliEntrypoint.path.trim()
+        : '';
+
+  if (!entrypoint) {
+    return undefined;
+  }
+
+  const exportName =
+    typeof cliRecord.export === 'string' && cliRecord.export.trim()
+      ? cliRecord.export.trim()
+      : typeof cliEntrypoint?.export === 'string' && cliEntrypoint.export.trim()
+        ? cliEntrypoint.export.trim()
+        : '';
+
+  return {
+    entrypoint,
+    ...(exportName ? { export: exportName } : {}),
+  };
 }
 
 /**
@@ -338,21 +386,11 @@ class ActorSystem extends BuildResourceGroup {
       dependsOn: [node_binary, ...targetFunctions],
       properties: {
         entryCode: () => {
-          const __dirname = import.meta.dirname;
-          return `
-              import cli from '${path.resolve(
-                __dirname,
-                'actor-system-cli',
-                'index.js',
-              )}';
-              import sourceMapSupport from 'source-map-support';
-              (async () => {
-                console.time('overall');
-                sourceMapSupport.install();
-                await cli()
-                console.timeEnd('overall');
-              })();
-          `;
+          const cliSpec = normalizeCliSpec(this.get('cli', undefined));
+          return createPackagedAppEntryCode({
+            cliEntrypointPath: cliSpec?.entrypoint,
+            cliExportName: cliSpec?.export,
+          });
         },
         resolveDir: () => path.dirname(import.meta.dirname),
         nodeBinaryPath: () => node_binary.get('binaryPath'),

--- a/src/core/resources/builds/lib/packaged-app-entry-code.js
+++ b/src/core/resources/builds/lib/packaged-app-entry-code.js
@@ -1,0 +1,49 @@
+import { fileURLToPath } from 'node:url';
+
+/**
+ * @param {string | undefined} value - value.
+ * @returns {string | undefined} - Result.
+ */
+function normalizeOptionalString(value) {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+/**
+ * @param {{ cliEntrypointPath?: string, cliExportName?: string }} [options] - options.
+ * @returns {string} - Result.
+ */
+export function createPackagedAppEntryCode(options = {}) {
+  const cliEntrypointPath = normalizeOptionalString(options.cliEntrypointPath);
+  const cliExportName = normalizeOptionalString(options.cliExportName);
+  const packagedAppEntryPath = fileURLToPath(
+    new URL('../packaged-app-entry.js', import.meta.url),
+  );
+
+  return `
+    import { runPackagedApp } from ${JSON.stringify(packagedAppEntryPath)};
+    import sourceMapSupport from 'source-map-support';
+    ${
+      cliEntrypointPath
+        ? `import * as appCliModule from ${JSON.stringify(cliEntrypointPath)};`
+        : 'const appCliModule = undefined;'
+    }
+    (async () => {
+      console.time('overall');
+      sourceMapSupport.install();
+      await runPackagedApp({
+        cliModule: appCliModule,
+        ${
+          cliExportName
+            ? `cliExportName: ${JSON.stringify(cliExportName)},`
+            : ''
+        }
+        argv: process.argv,
+      });
+      console.timeEnd('overall');
+    })();
+  `;
+}
+
+export default createPackagedAppEntryCode;

--- a/src/core/resources/builds/packaged-app-entry.js
+++ b/src/core/resources/builds/packaged-app-entry.js
@@ -51,12 +51,18 @@ export function getBootstrapMode(environment = process.env) {
  */
 export function getRuntimeCommand(environment = process.env) {
   const bootstrapInvocation = resolveBootstrapInvocation(environment);
+  const runtimeCommand =
+    typeof environment.WHARFIE_RUNTIME_COMMAND === 'string'
+      ? environment.WHARFIE_RUNTIME_COMMAND.trim()
+      : '';
+
   if (bootstrapInvocation) {
-    if (
-      bootstrapInvocation.mode === BOOTSTRAP_MODE_STATE_START ||
-      bootstrapInvocation.mode === 'runtime'
-    ) {
+    if (bootstrapInvocation.mode === BOOTSTRAP_MODE_STATE_START) {
       return 'start';
+    }
+
+    if (bootstrapInvocation.mode === 'runtime') {
+      return runtimeCommand || 'start';
     }
 
     throw new Error(
@@ -64,11 +70,7 @@ export function getRuntimeCommand(environment = process.env) {
     );
   }
 
-  const command =
-    typeof environment.WHARFIE_RUNTIME_COMMAND === 'string'
-      ? environment.WHARFIE_RUNTIME_COMMAND.trim()
-      : '';
-  return command || 'start';
+  return runtimeCommand || 'start';
 }
 
 /**
@@ -78,6 +80,13 @@ export function getRuntimeCommand(environment = process.env) {
 function getRuntimeArgs(environment = process.env) {
   const bootstrapInvocation = resolveBootstrapInvocation(environment);
   if (bootstrapInvocation) {
+    if (bootstrapInvocation.mode === 'runtime') {
+      const runtimeArgsValue = environment.WHARFIE_RUNTIME_ARGS;
+      return typeof runtimeArgsValue === 'string' && runtimeArgsValue.trim()
+        ? parseBootstrapArgs(runtimeArgsValue, 'WHARFIE_RUNTIME_ARGS')
+        : bootstrapInvocation.args;
+    }
+
     return bootstrapInvocation.args;
   }
 

--- a/src/core/resources/builds/packaged-app-entry.js
+++ b/src/core/resources/builds/packaged-app-entry.js
@@ -1,0 +1,111 @@
+import internalCli from './actor-system-cli/index.js';
+
+const INTERNAL_COMMANDS = new Set(['ctl', 'func', 'infra']);
+
+/**
+ * @param {unknown} value - value.
+ * @returns {value is string[]} - Result.
+ */
+function isStringArray(value) {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === 'string')
+  );
+}
+
+/**
+ * @param {string | undefined} raw - raw.
+ * @returns {string[]} - Result.
+ */
+function parseBootstrapArgs(raw) {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return isStringArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * @param {Record<string, any> | undefined} cliModule - cliModule.
+ * @param {string | undefined} cliExportName - cliExportName.
+ * @returns {((argv?: string[]) => Promise<any> | any) | undefined} - Result.
+ */
+function resolveCliHandler(cliModule, cliExportName) {
+  if (!cliModule || typeof cliModule !== 'object') {
+    return undefined;
+  }
+
+  const explicitCandidate =
+    typeof cliExportName === 'string' && cliExportName.trim()
+      ? cliModule[cliExportName]
+      : undefined;
+
+  if (typeof explicitCandidate === 'function') {
+    return explicitCandidate.bind(cliModule);
+  }
+
+  const candidates = [
+    cliModule.default,
+    cliModule.main,
+    cliModule.entrypoint,
+    cliModule.cli,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'function') {
+      return candidate.bind(cliModule);
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * @param {string[]} argv - argv.
+ * @returns {Promise<any>} - Result.
+ */
+async function runInternalRuntime(argv) {
+  const bootstrapArgs = parseBootstrapArgs(process.env.WHARFIE_BOOTSTRAP_ARGS);
+  const runtimeArgv = [
+    argv[0] || process.execPath,
+    argv[1] || process.argv[1] || 'wharfie',
+    'ctl',
+    'state',
+    'start',
+    ...bootstrapArgs,
+  ];
+  return await internalCli(runtimeArgv);
+}
+
+/**
+ * @param {{ cliModule?: Record<string, any>, cliExportName?: string, argv?: string[] }} [options] - options.
+ * @returns {Promise<any>} - Result.
+ */
+export async function runPackagedApp(options = {}) {
+  const argv = Array.isArray(options.argv) ? options.argv : process.argv;
+  const args = argv.slice(2);
+
+  if (process.env.WHARFIE_BOOTSTRAP_MODE === 'runtime') {
+    return await runInternalRuntime(argv);
+  }
+
+  if (args.length > 0 && INTERNAL_COMMANDS.has(String(args[0] || '').trim())) {
+    return await internalCli(argv);
+  }
+
+  const cliHandler = resolveCliHandler(
+    options.cliModule,
+    options.cliExportName,
+  );
+  if (cliHandler) {
+    return await cliHandler(argv);
+  }
+
+  return await internalCli(argv);
+}
+
+export default runPackagedApp;

--- a/src/core/resources/builds/packaged-app-entry.js
+++ b/src/core/resources/builds/packaged-app-entry.js
@@ -1,63 +1,128 @@
-import internalCli from './actor-system-cli/index.js';
+import {
+  BOOTSTRAP_MODE_STATE_START,
+  resolveBootstrapInvocation,
+} from './actor-system-cli/lib/bootstrap-mode.js';
 
 const INTERNAL_COMMANDS = new Set(['ctl', 'func', 'infra']);
 
 /**
- * @param {unknown} value - value.
- * @returns {value is string[]} - Result.
+ * @param {string | undefined} value - value.
+ * @param {string} label - label.
+ * @returns {string[]} - Result.
  */
-function isStringArray(value) {
-  return (
-    Array.isArray(value) && value.every((item) => typeof item === 'string')
+export function parseBootstrapArgs(
+  value = typeof process.env.WHARFIE_BOOTSTRAP_ARGS === 'string'
+    ? process.env.WHARFIE_BOOTSTRAP_ARGS
+    : process.env.WHARFIE_RUNTIME_ARGS,
+  label = typeof process.env.WHARFIE_BOOTSTRAP_ARGS === 'string'
+    ? 'WHARFIE_BOOTSTRAP_ARGS'
+    : 'WHARFIE_RUNTIME_ARGS',
+) {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  if (!raw) {
+    return [];
+  }
+
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${label} must be a JSON array of strings.`);
+  }
+
+  return parsed.map((candidate) => String(candidate));
+}
+
+/**
+ * @param {Record<string, string | undefined>} [environment] - environment.
+ * @returns {'cli' | 'runtime'} - Result.
+ */
+export function getBootstrapMode(environment = process.env) {
+  if (resolveBootstrapInvocation(environment)) {
+    return 'runtime';
+  }
+
+  return environment.WHARFIE_RUNTIME_COMMAND || environment.WHARFIE_RUNTIME_ARGS
+    ? 'runtime'
+    : 'cli';
+}
+
+/**
+ * @param {Record<string, string | undefined>} [environment] - environment.
+ * @returns {string} - Result.
+ */
+export function getRuntimeCommand(environment = process.env) {
+  const bootstrapInvocation = resolveBootstrapInvocation(environment);
+  if (bootstrapInvocation) {
+    if (
+      bootstrapInvocation.mode === BOOTSTRAP_MODE_STATE_START ||
+      bootstrapInvocation.mode === 'runtime'
+    ) {
+      return 'start';
+    }
+
+    throw new Error(
+      `Unsupported packaged bootstrap mode '${bootstrapInvocation.mode}'.`,
+    );
+  }
+
+  const command =
+    typeof environment.WHARFIE_RUNTIME_COMMAND === 'string'
+      ? environment.WHARFIE_RUNTIME_COMMAND.trim()
+      : '';
+  return command || 'start';
+}
+
+/**
+ * @param {Record<string, string | undefined>} [environment] - environment.
+ * @returns {string[]} - Result.
+ */
+function getRuntimeArgs(environment = process.env) {
+  const bootstrapInvocation = resolveBootstrapInvocation(environment);
+  if (bootstrapInvocation) {
+    return bootstrapInvocation.args;
+  }
+
+  return parseBootstrapArgs(
+    environment.WHARFIE_RUNTIME_ARGS,
+    'WHARFIE_RUNTIME_ARGS',
   );
 }
 
 /**
- * @param {string | undefined} raw - raw.
- * @returns {string[]} - Result.
- */
-function parseBootstrapArgs(raw) {
-  if (typeof raw !== 'string' || !raw.trim()) {
-    return [];
-  }
-
-  try {
-    const parsed = JSON.parse(raw);
-    return isStringArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
-
-/**
- * @param {Record<string, any> | undefined} cliModule - cliModule.
+ * @param {Record<string, any> | null | undefined} moduleLike - moduleLike.
  * @param {string | undefined} cliExportName - cliExportName.
- * @returns {((argv?: string[]) => Promise<any> | any) | undefined} - Result.
+ * @returns {{ kind: 'command' | 'function', value: any } | undefined} - Result.
  */
-function resolveCliHandler(cliModule, cliExportName) {
-  if (!cliModule || typeof cliModule !== 'object') {
-    return undefined;
-  }
+function resolveCliHandler(moduleLike, cliExportName) {
+  const candidate = moduleLike || {};
 
-  const explicitCandidate =
-    typeof cliExportName === 'string' && cliExportName.trim()
-      ? cliModule[cliExportName]
-      : undefined;
-
-  if (typeof explicitCandidate === 'function') {
-    return explicitCandidate.bind(cliModule);
+  if (
+    typeof cliExportName === 'string' &&
+    cliExportName.trim() &&
+    candidate &&
+    typeof candidate === 'object'
+  ) {
+    const explicit = candidate[cliExportName];
+    if (explicit && typeof explicit.parseAsync === 'function') {
+      return { kind: 'command', value: explicit };
+    }
+    if (typeof explicit === 'function') {
+      return { kind: 'function', value: explicit.bind(candidate) };
+    }
   }
 
   const candidates = [
-    cliModule.default,
-    cliModule.main,
-    cliModule.entrypoint,
-    cliModule.cli,
+    candidate.default,
+    candidate.main,
+    candidate.entrypoint,
+    candidate.cli,
   ];
 
-  for (const candidate of candidates) {
-    if (typeof candidate === 'function') {
-      return candidate.bind(cliModule);
+  for (const current of candidates) {
+    if (current && typeof current.parseAsync === 'function') {
+      return { kind: 'command', value: current };
+    }
+    if (typeof current === 'function') {
+      return { kind: 'function', value: current.bind(candidate) };
     }
   }
 
@@ -65,47 +130,93 @@ function resolveCliHandler(cliModule, cliExportName) {
 }
 
 /**
- * @param {string[]} argv - argv.
- * @returns {Promise<any>} - Result.
+ * @param {Record<string, any> | null | undefined} moduleLike - moduleLike.
+ * @param {{ cliExportName?: string, argv?: string[] }} [options] - options.
+ * @returns {Promise<void>} - Result.
  */
-async function runInternalRuntime(argv) {
-  const bootstrapArgs = parseBootstrapArgs(process.env.WHARFIE_BOOTSTRAP_ARGS);
-  const runtimeArgv = [
-    argv[0] || process.execPath,
-    argv[1] || process.argv[1] || 'wharfie',
-    'ctl',
-    'state',
-    'start',
-    ...bootstrapArgs,
-  ];
-  return await internalCli(runtimeArgv);
+export async function runDeveloperCli(moduleLike, options = {}) {
+  const argv = Array.isArray(options.argv) ? options.argv : process.argv;
+  const handler = resolveCliHandler(moduleLike, options.cliExportName);
+
+  if (!handler) {
+    throw new Error(
+      'cli.entrypoint must export a default function, a default Commander command, or a named main() function.',
+    );
+  }
+
+  if (handler.kind === 'command') {
+    await handler.value.parseAsync(argv);
+    return;
+  }
+
+  await handler.value(argv);
 }
 
 /**
- * @param {{ cliModule?: Record<string, any>, cliExportName?: string, argv?: string[] }} [options] - options.
- * @returns {Promise<any>} - Result.
+ * @param {Record<string, any>} runtimeModules - runtimeModules.
+ * @param {{ argv?: string[] }} [options] - options.
+ * @returns {Promise<void>} - Result.
+ */
+export async function runRuntimeBootstrap(runtimeModules, options = {}) {
+  const runtimeCommand = getRuntimeCommand();
+  const runtimeArgs = getRuntimeArgs();
+
+  /** @type {any} */
+  const command = runtimeModules?.[runtimeCommand];
+  if (!command || typeof command.parseAsync !== 'function') {
+    throw new Error(
+      `Unknown packaged runtime command '${runtimeCommand}'. Available commands: ${
+        Object.keys(runtimeModules || {})
+          .sort((left, right) => left.localeCompare(right))
+          .join(', ') || '(none)'
+      }`,
+    );
+  }
+
+  const argv = Array.isArray(options.argv) ? options.argv : process.argv;
+  await command.parseAsync(
+    [argv[0] || 'node', runtimeCommand, ...runtimeArgs],
+    {
+      from: 'node',
+    },
+  );
+}
+
+/**
+ * @param {{ developerCliModule?: Record<string, any> | null, cliModule?: Record<string, any> | null, cliExportName?: string, runtimeModules?: Record<string, any>, argv?: string[] }} [options] - options.
+ * @returns {Promise<void>} - Result.
  */
 export async function runPackagedApp(options = {}) {
   const argv = Array.isArray(options.argv) ? options.argv : process.argv;
   const args = argv.slice(2);
+  const runtimeModules = options.runtimeModules || {};
 
-  if (process.env.WHARFIE_BOOTSTRAP_MODE === 'runtime') {
-    return await runInternalRuntime(argv);
+  if (getBootstrapMode() === 'runtime') {
+    await runRuntimeBootstrap(runtimeModules, { argv });
+    return;
   }
 
   if (args.length > 0 && INTERNAL_COMMANDS.has(String(args[0] || '').trim())) {
-    return await internalCli(argv);
+    const internalCli = runtimeModules.cli;
+    if (typeof internalCli === 'function') {
+      await internalCli(argv);
+      return;
+    }
+    if (internalCli && typeof internalCli.parseAsync === 'function') {
+      await internalCli.parseAsync(argv);
+      return;
+    }
   }
 
-  const cliHandler = resolveCliHandler(
-    options.cliModule,
-    options.cliExportName,
-  );
-  if (cliHandler) {
-    return await cliHandler(argv);
+  const developerCliModule = options.developerCliModule ?? options.cliModule;
+  if (!developerCliModule) {
+    throw new Error('Packaged app is missing cli.entrypoint.');
   }
 
-  return await internalCli(argv);
+  await runDeveloperCli(developerCliModule, {
+    cliExportName: options.cliExportName,
+    argv,
+  });
 }
 
 export default runPackagedApp;

--- a/src/core/resources/builds/sea-build.js
+++ b/src/core/resources/builds/sea-build.js
@@ -1,4 +1,5 @@
 import { v4 } from 'uuid';
+import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { promises, existsSync, writeFileSync, readFileSync } from 'node:fs';
 import { build as _build } from '../../lib/esbuild.js';
@@ -140,6 +141,64 @@ async function _withSuppressedPostjectWarnings(fn) {
   }
 }
 
+/** @type {boolean | undefined} */
+let _supportsExperimentalSeaConfig;
+
+/**
+ * @returns {boolean} - Result.
+ */
+function supportsExperimentalSeaConfig() {
+  if (typeof _supportsExperimentalSeaConfig === 'boolean') {
+    return _supportsExperimentalSeaConfig;
+  }
+
+  const result = spawnSync(process.execPath, ['--help'], {
+    encoding: 'utf8',
+  });
+  const output = `${result.stdout || ''}
+${result.stderr || ''}`;
+  _supportsExperimentalSeaConfig = output.includes('--experimental-sea-config');
+  return _supportsExperimentalSeaConfig;
+}
+
+/**
+ * @param {Record<string, string>} assets - assets.
+ * @returns {Promise<Record<string, string>>} - Result.
+ */
+async function encodeEmbeddedAssets(assets) {
+  /** @type {Record<string, string>} */
+  const encoded = {};
+
+  for (const [name, assetPath] of Object.entries(assets).sort(
+    ([left], [right]) => left.localeCompare(right),
+  )) {
+    if (typeof assetPath !== 'string' || !assetPath) {
+      continue;
+    }
+
+    const buffer = await promises.readFile(assetPath);
+    encoded[name] = buffer.toString('base64');
+  }
+
+  return encoded;
+}
+
+/**
+ * @param {string} bundleCode - bundleCode.
+ * @param {Record<string, string>} encodedAssets - encodedAssets.
+ * @returns {string} - Result.
+ */
+function buildFallbackExecutableSource(bundleCode, encodedAssets) {
+  return `#!/usr/bin/env node
+globalThis.__wharfieSeaAssets = Object.assign(
+  {},
+  globalThis.__wharfieSeaAssets || {},
+  ${JSON.stringify(encodedAssets)}
+);
+${bundleCode}
+`;
+}
+
 /**
  * @typedef {import('node:process')['platform']} TargetPlatform -
  * @typedef {import('node:process')['arch']} TargetArch -
@@ -191,20 +250,47 @@ class SeaBuild extends BaseResource {
     await promises.mkdir(tmpBuildDir, { recursive: true });
     await this.esbuild(tmpBuildDir);
     await this.prepareExternalBinaries();
-    const tempNodeBinaryPath = join(tmpBuildDir, 'node-binary');
-    await promises.copyFile(
-      await this.get('nodeBinaryPath'),
-      tempNodeBinaryPath,
-    );
-    await this.seaBuild(tmpBuildDir, tempNodeBinaryPath);
+
     if (!existsSync(SeaBuild.BINARIES_DIR)) {
       await promises.mkdir(SeaBuild.BINARIES_DIR, { recursive: true });
     }
-    await promises.copyFile(tempNodeBinaryPath, binaryPath);
+
+    if (supportsExperimentalSeaConfig()) {
+      const tempNodeBinaryPath = join(tmpBuildDir, 'node-binary');
+      await promises.copyFile(
+        await this.get('nodeBinaryPath'),
+        tempNodeBinaryPath,
+      );
+      await this.seaBuild(tmpBuildDir, tempNodeBinaryPath);
+      await promises.copyFile(tempNodeBinaryPath, binaryPath);
+    } else {
+      await this.scriptBuild(tmpBuildDir, binaryPath);
+    }
+
     this._setUNSAFE('binaryPath', binaryPath);
   }
 
   async prepareExternalBinaries() {}
+
+  /**
+   * @param {string} buildDir - buildDir.
+   * @param {string} outputPath - outputPath.
+   * @returns {Promise<void>} - Result.
+   */
+  async scriptBuild(buildDir, outputPath) {
+    const bundleCode = await promises.readFile(
+      this.get('codeBundlePath'),
+      'utf8',
+    );
+    const encodedAssets = await encodeEmbeddedAssets(this.get('assets', {}));
+    const executableSource = buildFallbackExecutableSource(
+      bundleCode,
+      encodedAssets,
+    );
+
+    await promises.writeFile(outputPath, executableSource, 'utf8');
+    await promises.chmod(outputPath, 0o755);
+  }
 
   async fetchUserDefinedBinaries() {}
 
@@ -343,7 +429,6 @@ class SeaBuild extends BaseResource {
     }
 
     await this.build();
-    console.log(this.get('binaryPath'));
   }
 
   async _destroy() {

--- a/src/core/runtime/app-runs.js
+++ b/src/core/runtime/app-runs.js
@@ -1,0 +1,572 @@
+import Action from '../lib/graph/action.js';
+import Operation, { Type as OperationType } from '../lib/graph/operation.js';
+import { runOperation } from '../lib/graph/runner.js';
+import WharfieFunction from '../resources/builds/function.js';
+
+import { createActorSystemResources } from './resources.js';
+
+/**
+ * @param {unknown} value - value.
+ * @returns {value is Record<string, any>} - Result.
+ */
+function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @returns {string} - Result.
+ */
+function getManifestAppName(manifest) {
+  const appName = manifest?.app?.name;
+  if (typeof appName !== 'string' || !appName.trim()) {
+    throw new Error('App manifest is missing app.name.');
+  }
+
+  return appName.trim();
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @returns {string} - Result.
+ */
+export function getSyntheticAppResourceId(manifest) {
+  return `app:${getManifestAppName(manifest)}`;
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @returns {Record<string, any>} - Result.
+ */
+function getManifestResources(manifest) {
+  if (isPlainObject(manifest?.resources)) {
+    return manifest.resources;
+  }
+
+  if (isPlainObject(manifest?.capabilities)) {
+    return manifest.capabilities;
+  }
+
+  return {};
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @returns {Array<Record<string, any>>} - Result.
+ */
+function getManifestActivities(manifest) {
+  return Array.isArray(manifest?.functions)
+    ? manifest.functions.filter(
+        (/** @type {any} */ activity) =>
+          isPlainObject(activity) &&
+          typeof activity.name === 'string' &&
+          activity.name.trim(),
+      )
+    : [];
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @returns {string[]} - Result.
+ */
+export function getManifestActivityNames(manifest) {
+  return getManifestActivities(manifest)
+    .map((activity) => String(activity.name).trim())
+    .filter((name) => name.length > 0)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @param {string} activityName - activityName.
+ * @returns {Record<string, any> | undefined} - Result.
+ */
+export function findManifestActivity(manifest, activityName) {
+  const trimmedName = String(activityName || '').trim();
+  if (!trimmedName) return undefined;
+
+  return getManifestActivities(manifest).find(
+    (activity) => String(activity.name).trim() === trimmedName,
+  );
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @returns {Array<Record<string, any>>} - Result.
+ */
+function getManifestWorkflows(manifest) {
+  return Array.isArray(manifest?.workflows)
+    ? manifest.workflows.filter(
+        (/** @type {any} */ workflow) =>
+          isPlainObject(workflow) &&
+          typeof workflow.name === 'string' &&
+          workflow.name.trim(),
+      )
+    : [];
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @returns {string[]} - Result.
+ */
+export function getManifestWorkflowNames(manifest) {
+  return getManifestWorkflows(manifest)
+    .map((workflow) => String(workflow.name).trim())
+    .filter((name) => name.length > 0)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @param {string} workflowName - workflowName.
+ * @returns {Record<string, any> | undefined} - Result.
+ */
+export function findManifestWorkflow(manifest, workflowName) {
+  const trimmedName = String(workflowName || '').trim();
+  if (!trimmedName) return undefined;
+
+  return getManifestWorkflows(manifest).find(
+    (workflow) => String(workflow.name).trim() === trimmedName,
+  );
+}
+
+/**
+ * @param {string} name - name.
+ * @returns {string} - Result.
+ */
+function toActionIdSegment(name) {
+  const normalized = String(name || '')
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+
+  return normalized || 'activity';
+}
+
+/**
+ * @param {{
+ *   manifest: any,
+ *   activityName?: string,
+ *   workflowName?: string,
+ *   triggerSource?: string,
+ * }} options - options.
+ * @returns {Record<string, any>} - Result.
+ */
+function createOperationConfig({
+  manifest,
+  activityName,
+  workflowName,
+  triggerSource = 'manual',
+}) {
+  return {
+    app: getManifestAppName(manifest),
+    ...(typeof activityName === 'string' && activityName.trim()
+      ? { activity: activityName.trim() }
+      : {}),
+    ...(typeof workflowName === 'string' && workflowName.trim()
+      ? { workflow: workflowName.trim() }
+      : {}),
+    trigger: {
+      source: String(triggerSource || 'manual').trim() || 'manual',
+    },
+    source: 'app-manifest',
+  };
+}
+
+/**
+ * @param {{
+ *   manifest: any,
+ *   activityName: string,
+ *   event?: any,
+ *   operationId?: string,
+ *   triggerSource?: string,
+ * }} options - options.
+ * @returns {import('../lib/graph/operation.js').default} - Result.
+ */
+export function createAppActivityOperation({
+  manifest,
+  activityName,
+  event = {},
+  operationId,
+  triggerSource = 'manual',
+}) {
+  const activity = findManifestActivity(manifest, activityName);
+  if (!activity) {
+    const availableActivities = getManifestActivityNames(manifest);
+    throw new Error(
+      `Activity '${activityName}' was not found in the app manifest. Available activities: ${
+        availableActivities.length > 0
+          ? availableActivities.join(', ')
+          : '(none)'
+      }`,
+    );
+  }
+
+  const operation = new Operation({
+    resource_id: getSyntheticAppResourceId(manifest),
+    resource_version: 1,
+    ...(typeof operationId === 'string' && operationId.trim()
+      ? { id: operationId.trim() }
+      : {}),
+    type: OperationType.PIPELINE,
+    operation_config: createOperationConfig({
+      manifest,
+      activityName: activity.name,
+      triggerSource,
+    }),
+    operation_inputs: event,
+  });
+
+  const startAction = operation.createAction({
+    id: 'start',
+    type: Action.Type.START,
+  });
+  const invokeAction = operation.createAction({
+    id: `invoke-${toActionIdSegment(activity.name)}`,
+    type: Action.Type.INVOKE_FUNCTION,
+    function_name: activity.name,
+    inputs: event,
+    placement: { mode: 'local' },
+    retry: { max_attempts: 1 },
+    dependsOn: [startAction],
+  });
+
+  operation.createAction({
+    id: 'finish',
+    type: Action.Type.FINISH,
+    dependsOn: [invokeAction],
+  });
+
+  return operation;
+}
+
+/**
+ * @param {Record<string, any>} action - action.
+ * @returns {string | undefined} - Result.
+ */
+function getWorkflowActionFunctionName(action) {
+  if (typeof action?.functionName === 'string' && action.functionName.trim()) {
+    return action.functionName.trim();
+  }
+
+  if (
+    typeof action?.function_name === 'string' &&
+    action.function_name.trim()
+  ) {
+    return action.function_name.trim();
+  }
+
+  if (typeof action?.activity === 'string' && action.activity.trim()) {
+    return action.activity.trim();
+  }
+
+  return undefined;
+}
+
+/**
+ * @param {{
+ *   manifest: any,
+ *   workflowName: string,
+ *   operationId?: string,
+ *   triggerSource?: string,
+ * }} options - options.
+ * @returns {import('../lib/graph/operation.js').default} - Result.
+ */
+export function createAppWorkflowOperation({
+  manifest,
+  workflowName,
+  operationId,
+  triggerSource = 'manual',
+}) {
+  const workflow = findManifestWorkflow(manifest, workflowName);
+  if (!workflow) {
+    const availableWorkflows = getManifestWorkflowNames(manifest);
+    throw new Error(
+      `Workflow '${workflowName}' was not found in the app manifest. Available workflows: ${
+        availableWorkflows.length > 0 ? availableWorkflows.join(', ') : '(none)'
+      }`,
+    );
+  }
+
+  const operation = new Operation({
+    resource_id: getSyntheticAppResourceId(manifest),
+    resource_version: 1,
+    ...(typeof operationId === 'string' && operationId.trim()
+      ? { id: operationId.trim() }
+      : {}),
+    type:
+      typeof workflow?.type === 'string' && workflow.type.trim()
+        ? workflow.type.trim().toUpperCase()
+        : OperationType.PIPELINE,
+    operation_config: createOperationConfig({
+      manifest,
+      workflowName: workflow.name,
+      triggerSource,
+    }),
+  });
+
+  const actions = Array.isArray(workflow.actions) ? workflow.actions : [];
+  for (const action of actions) {
+    operation.createAction({
+      id: action.id,
+      type: action.type,
+      function_name: getWorkflowActionFunctionName(action),
+      inputs: action.inputs,
+      placement: action.placement,
+      retry: action.retry,
+    });
+  }
+
+  for (const action of actions) {
+    const dependencies = Array.isArray(action?.dependsOn)
+      ? action.dependsOn
+      : [];
+    for (const dependencyId of dependencies) {
+      if (typeof dependencyId !== 'string' || !dependencyId.trim()) {
+        continue;
+      }
+      operation._addDependency(dependencyId.trim(), action.id);
+    }
+  }
+
+  return operation;
+}
+
+/**
+ * @param {Record<string, any> | undefined} placement - placement.
+ * @returns {string} - Result.
+ */
+function getPlacementMode(placement) {
+  const mode = placement?.mode;
+  if (typeof mode !== 'string' || !mode.trim()) return 'local';
+  return mode.trim().toLowerCase();
+}
+
+/**
+ * @param {Record<string, any>} activity - activity.
+ * @returns {import('../resources/builds/function.js').default} - Result.
+ */
+function createManifestFunction(activity) {
+  return new WharfieFunction({
+    name: String(activity.name),
+    entrypoint: activity.entrypoint,
+    properties: {
+      ...(Array.isArray(activity.external)
+        ? { external: activity.external }
+        : {}),
+      ...(isPlainObject(activity.environmentVariables)
+        ? { environmentVariables: activity.environmentVariables }
+        : {}),
+      ...(isPlainObject(activity.resources)
+        ? { resources: activity.resources }
+        : {}),
+    },
+  });
+}
+
+/**
+ * @param {Record<string, any>} workflowContext - workflowContext.
+ * @param {any} baseContext - baseContext.
+ * @returns {Record<string, any>} - Result.
+ */
+function mergeExecutionContext(workflowContext, baseContext) {
+  if (!isPlainObject(baseContext)) {
+    return {
+      workflow: workflowContext,
+    };
+  }
+
+  const inheritedWorkflow = isPlainObject(baseContext.workflow)
+    ? baseContext.workflow
+    : {};
+
+  return {
+    ...baseContext,
+    workflow: {
+      ...inheritedWorkflow,
+      ...workflowContext,
+    },
+  };
+}
+
+/**
+ * @typedef AppOperationStartEvent
+ * @property {number} attemptCount - attemptCount.
+ */
+
+/**
+ * @typedef CreateAppOperationExecutorOptions
+ * @property {any} manifest - manifest.
+ * @property {Record<string, any>} [baseContext] - baseContext.
+ * @property {(action: import('../lib/graph/action.js').default, details: AppOperationStartEvent) => void} [onActionStart] - onActionStart.
+ */
+
+/**
+ * @param {CreateAppOperationExecutorOptions} options - options.
+ * @returns {{ executeAction: (action: import('../lib/graph/action.js').default) => Promise<{ ok: boolean, outputs?: any }>, close: () => Promise<void> }} - Result.
+ */
+export function createAppOperationExecutor({
+  manifest,
+  baseContext = {},
+  onActionStart,
+}) {
+  /** @type {Promise<{ resources: Record<string, any>, close: () => Promise<void> }> | null} */
+  let appResourcesPromise = null;
+
+  /**
+   * @returns {Promise<{ resources: Record<string, any>, close: () => Promise<void> }>} - Result.
+   */
+  async function ensureAppResources() {
+    if (appResourcesPromise) {
+      return appResourcesPromise;
+    }
+
+    appResourcesPromise = createActorSystemResources(
+      getManifestResources(manifest),
+    );
+    return appResourcesPromise;
+  }
+
+  /**
+   * @param {import('../lib/graph/action.js').default} action - action.
+   * @returns {Promise<{ ok: boolean, outputs?: any }>} - Result.
+   */
+  async function executeAction(action) {
+    if (
+      action.type === Action.Type.START ||
+      action.type === Action.Type.FINISH
+    ) {
+      onActionStart?.(action, {
+        attemptCount: Number(action.attempt_count || 0),
+      });
+      return { ok: true };
+    }
+
+    if (action.type !== Action.Type.INVOKE_FUNCTION) {
+      throw new Error(
+        `Unsupported action type '${action.type}' for app runs. Only START, FINISH, and INVOKE_FUNCTION are currently executable.`,
+      );
+    }
+
+    if (!action.function_name || !String(action.function_name).trim()) {
+      throw new Error(
+        `INVOKE_FUNCTION action '${action.id}' is missing function_name.`,
+      );
+    }
+
+    const placementMode = getPlacementMode(action.placement);
+    if (placementMode !== 'local' && placementMode !== 'in_process') {
+      throw new Error(
+        `INVOKE_FUNCTION action '${action.id}' requested unsupported placement mode '${placementMode}'. Local execution currently supports only 'local' or 'in_process'.`,
+      );
+    }
+
+    const activity = findManifestActivity(manifest, action.function_name);
+    if (!activity) {
+      const availableActivities = getManifestActivityNames(manifest);
+      throw new Error(
+        `Activity '${action.function_name}' was not found in the app manifest. Available activities: ${
+          availableActivities.length > 0
+            ? availableActivities.join(', ')
+            : '(none)'
+        }`,
+      );
+    }
+
+    const attemptCount = Number(action.attempt_count || 0) + 1;
+    onActionStart?.(action, { attemptCount });
+
+    const appResources = await ensureAppResources();
+    const fn = createManifestFunction(activity);
+
+    try {
+      const outputs = await fn.fn(
+        action.inputs ?? {},
+        mergeExecutionContext(
+          {
+            resourceId: action.resource_id,
+            operationId: action.operation_id,
+            actionId: action.id,
+            actionType: action.type,
+            attemptCount,
+            placement: action.placement,
+          },
+          baseContext,
+        ),
+        {
+          baseResources: appResources.resources,
+        },
+      );
+
+      return {
+        ok: true,
+        outputs,
+      };
+    } finally {
+      await fn.closeRuntimeResources();
+    }
+  }
+
+  return {
+    executeAction,
+    close: async () => {
+      if (!appResourcesPromise) {
+        return;
+      }
+
+      const appResources = await appResourcesPromise;
+      await appResources.close();
+      appResourcesPromise = null;
+    },
+  };
+}
+
+/**
+ * @typedef {import('../lib/graph/runner.js').OperationRunnerStore & {
+ *   putOperation: (operation: import('../lib/graph/operation.js').default) => Promise<void>
+ * }} AppOperationStore
+ */
+
+/**
+ * @typedef PersistAndRunAppOperationOptions
+ * @property {AppOperationStore} store - store.
+ * @property {any} manifest - manifest.
+ * @property {import('../lib/graph/operation.js').default} operation - operation.
+ * @property {Record<string, any>} [baseContext] - baseContext.
+ * @property {(action: import('../lib/graph/action.js').default, details: AppOperationStartEvent) => void} [onActionStart] - onActionStart.
+ */
+
+/**
+ * @param {PersistAndRunAppOperationOptions} options - options.
+ * @returns {Promise<{ status: 'COMPLETED' | 'FAILED' | 'BLOCKED'; executedActionIds: string[]; failedActionIds: string[]; blockedActionIds: string[]; finalStatusByActionId: Record<string, string> }>} - Result.
+ */
+export async function persistAndRunAppOperation({
+  store,
+  manifest,
+  operation,
+  baseContext = {},
+  onActionStart,
+}) {
+  const executor = createAppOperationExecutor({
+    manifest,
+    baseContext,
+    onActionStart,
+  });
+
+  try {
+    await store.putOperation(operation);
+    return await runOperation({
+      store,
+      resourceId: operation.resource_id,
+      operationId: operation.id,
+      executeAction: executor.executeAction,
+    });
+  } finally {
+    await executor.close();
+  }
+}

--- a/src/core/runtime/app-runs.js
+++ b/src/core/runtime/app-runs.js
@@ -1,321 +1,299 @@
 import Action from '../lib/graph/action.js';
 import Operation, { Type as OperationType } from '../lib/graph/operation.js';
-import { runOperation } from '../lib/graph/runner.js';
 import WharfieFunction from '../resources/builds/function.js';
-
 import { createActorSystemResources } from './resources.js';
 
 /**
  * @param {unknown} value - value.
  * @returns {value is Record<string, any>} - Result.
  */
-function isPlainObject(value) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return false;
-  }
-  const proto = Object.getPrototypeOf(value);
-  return proto === Object.prototype || proto === null;
+function isObjectRecord(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
 /**
  * @param {any} manifest - manifest.
- * @returns {string} - Result.
- */
-function getManifestAppName(manifest) {
-  const appName = manifest?.app?.name;
-  if (typeof appName !== 'string' || !appName.trim()) {
-    throw new Error('App manifest is missing app.name.');
-  }
-
-  return appName.trim();
-}
-
-/**
- * @param {any} manifest - manifest.
- * @returns {string} - Result.
- */
-export function getSyntheticAppResourceId(manifest) {
-  return `app:${getManifestAppName(manifest)}`;
-}
-
-/**
- * @param {any} manifest - manifest.
+ * @param {any} publicManifest - publicManifest.
  * @returns {Record<string, any>} - Result.
  */
-function getManifestResources(manifest) {
-  if (isPlainObject(manifest?.resources)) {
+export function getManifestActivities(manifest, publicManifest) {
+  if (isObjectRecord(publicManifest?.activities)) {
+    return publicManifest.activities;
+  }
+
+  const functions = Array.isArray(manifest?.functions)
+    ? manifest.functions
+    : [];
+  return functions.reduce(
+    (/** @type {Record<string, any>} */ acc, /** @type {any} */ definition) => {
+      if (
+        !isObjectRecord(definition) ||
+        typeof definition.name !== 'string' ||
+        !isObjectRecord(definition.entrypoint)
+      ) {
+        return acc;
+      }
+
+      acc[definition.name] = {
+        entrypoint: definition.entrypoint,
+        ...(Array.isArray(definition.external)
+          ? { external: definition.external }
+          : {}),
+        ...(isObjectRecord(definition.environmentVariables)
+          ? { environmentVariables: definition.environmentVariables }
+          : {}),
+        ...(isObjectRecord(definition.resources)
+          ? { resources: definition.resources }
+          : {}),
+      };
+      return acc;
+    },
+    /** @type {Record<string, any>} */ ({}),
+  );
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @param {any} publicManifest - publicManifest.
+ * @returns {string[]} - Result.
+ */
+export function getManifestActivityNames(manifest, publicManifest) {
+  return Object.keys(getManifestActivities(manifest, publicManifest)).sort(
+    (left, right) => left.localeCompare(right),
+  );
+}
+
+/**
+ * @param {{ manifest: any, publicManifest: any, activityName: string }} options - options.
+ * @returns {any | undefined} - Result.
+ */
+export function getManifestActivityDefinition(options) {
+  const activityName = String(options.activityName || '').trim();
+  if (!activityName) return undefined;
+
+  const activities = getManifestActivities(
+    options.manifest,
+    options.publicManifest,
+  );
+  return activities[activityName];
+}
+
+/**
+ * @param {any} manifest - manifest.
+ * @param {any} publicManifest - publicManifest.
+ * @returns {Record<string, any>} - Result.
+ */
+export function getManifestResourcesSpec(manifest, publicManifest) {
+  if (isObjectRecord(publicManifest?.resources)) {
+    return publicManifest.resources;
+  }
+  if (isObjectRecord(manifest?.resources)) {
     return manifest.resources;
   }
-
-  if (isPlainObject(manifest?.capabilities)) {
+  if (isObjectRecord(manifest?.capabilities)) {
     return manifest.capabilities;
   }
-
   return {};
 }
 
 /**
- * @param {any} manifest - manifest.
- * @returns {Array<Record<string, any>>} - Result.
+ * @param {{ manifest: any, publicManifest: any, activityName: string }} options - options.
+ * @returns {WharfieFunction} - Result.
  */
-function getManifestActivities(manifest) {
-  return Array.isArray(manifest?.functions)
-    ? manifest.functions.filter(
-        (/** @type {any} */ activity) =>
-          isPlainObject(activity) &&
-          typeof activity.name === 'string' &&
-          activity.name.trim(),
-      )
+export function createManifestActivityFunction(options) {
+  const activityName = String(options.activityName || '').trim();
+  const definition = getManifestActivityDefinition(options);
+
+  if (!definition || !isObjectRecord(definition.entrypoint)) {
+    const available = getManifestActivityNames(
+      options.manifest,
+      options.publicManifest,
+    );
+    throw new Error(
+      `Unknown activity '${activityName}'. Available activities: ${available.join(', ') || '(none)'}`,
+    );
+  }
+
+  return new WharfieFunction({
+    name: activityName,
+    entrypoint: definition.entrypoint,
+    properties: {
+      ...(Array.isArray(definition.external)
+        ? { external: definition.external }
+        : {}),
+      ...(isObjectRecord(definition.environmentVariables)
+        ? { environmentVariables: definition.environmentVariables }
+        : {}),
+      ...(isObjectRecord(definition.resources)
+        ? { resources: definition.resources }
+        : {}),
+    },
+  });
+}
+
+/**
+ * @param {{ manifest: any, publicManifest: any, activityName: string, event?: any, context?: any, resourceResolution?: { registryPath?: string } }} options - options.
+ * @returns {Promise<any>} - Result.
+ */
+export async function invokeManifestActivity(options) {
+  const fn = createManifestActivityFunction(options);
+  const { resources: baseResources, close } = await createActorSystemResources(
+    getManifestResourcesSpec(options.manifest, options.publicManifest),
+    options.resourceResolution,
+  );
+
+  try {
+    return await fn.fn(options.event ?? {}, options.context ?? {}, {
+      baseResources,
+    });
+  } finally {
+    await Promise.allSettled([
+      close(),
+      typeof fn.closeRuntimeResources === 'function'
+        ? fn.closeRuntimeResources()
+        : Promise.resolve(),
+    ]);
+  }
+}
+
+/**
+ * @param {{ manifest: any, publicManifest: any, workflowName: string }} options - options.
+ * @returns {any | undefined} - Result.
+ */
+export function findManifestWorkflowDefinition(options) {
+  const workflowName = String(options.workflowName || '').trim();
+  if (!workflowName) return undefined;
+
+  /** @type {any[]} */
+  const workflows = Array.isArray(options.manifest?.workflows)
+    ? options.manifest.workflows
     : [];
-}
-
-/**
- * @param {any} manifest - manifest.
- * @returns {string[]} - Result.
- */
-export function getManifestActivityNames(manifest) {
-  return getManifestActivities(manifest)
-    .map((activity) => String(activity.name).trim())
-    .filter((name) => name.length > 0)
-    .sort((left, right) => left.localeCompare(right));
-}
-
-/**
- * @param {any} manifest - manifest.
- * @param {string} activityName - activityName.
- * @returns {Record<string, any> | undefined} - Result.
- */
-export function findManifestActivity(manifest, activityName) {
-  const trimmedName = String(activityName || '').trim();
-  if (!trimmedName) return undefined;
-
-  return getManifestActivities(manifest).find(
-    (activity) => String(activity.name).trim() === trimmedName,
+  return workflows.find(
+    (workflow) =>
+      typeof workflow?.name === 'string' &&
+      workflow.name.trim() === workflowName,
   );
 }
 
 /**
- * @param {any} manifest - manifest.
- * @returns {Array<Record<string, any>>} - Result.
- */
-function getManifestWorkflows(manifest) {
-  return Array.isArray(manifest?.workflows)
-    ? manifest.workflows.filter(
-        (/** @type {any} */ workflow) =>
-          isPlainObject(workflow) &&
-          typeof workflow.name === 'string' &&
-          workflow.name.trim(),
-      )
-    : [];
-}
-
-/**
- * @param {any} manifest - manifest.
- * @returns {string[]} - Result.
- */
-export function getManifestWorkflowNames(manifest) {
-  return getManifestWorkflows(manifest)
-    .map((workflow) => String(workflow.name).trim())
-    .filter((name) => name.length > 0)
-    .sort((left, right) => left.localeCompare(right));
-}
-
-/**
- * @param {any} manifest - manifest.
- * @param {string} workflowName - workflowName.
- * @returns {Record<string, any> | undefined} - Result.
- */
-export function findManifestWorkflow(manifest, workflowName) {
-  const trimmedName = String(workflowName || '').trim();
-  if (!trimmedName) return undefined;
-
-  return getManifestWorkflows(manifest).find(
-    (workflow) => String(workflow.name).trim() === trimmedName,
-  );
-}
-
-/**
- * @param {string} name - name.
+ * @param {string} appName - appName.
  * @returns {string} - Result.
  */
-function toActionIdSegment(name) {
-  const normalized = String(name || '')
-    .trim()
-    .replace(/[^A-Za-z0-9._-]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .toLowerCase();
-
-  return normalized || 'activity';
+export function getAppResourceId(appName) {
+  return `app:${String(appName || '').trim()}`;
 }
 
 /**
- * @param {{
- *   manifest: any,
- *   activityName?: string,
- *   workflowName?: string,
- *   triggerSource?: string,
- * }} options - options.
- * @returns {Record<string, any>} - Result.
+ * @returns {number} - Result.
  */
-function createOperationConfig({
-  manifest,
-  activityName,
-  workflowName,
-  triggerSource = 'manual',
-}) {
+export function getAppResourceVersion() {
+  return 1;
+}
+
+/**
+ * @param {any} trigger - trigger.
+ * @returns {{ source: string, scheduledTime?: string, event?: any }} - Result.
+ */
+function normalizeTrigger(trigger) {
+  if (!isObjectRecord(trigger)) {
+    return { source: 'manual' };
+  }
+
   return {
-    app: getManifestAppName(manifest),
-    ...(typeof activityName === 'string' && activityName.trim()
-      ? { activity: activityName.trim() }
+    source:
+      typeof trigger.source === 'string' && trigger.source.trim()
+        ? trigger.source.trim()
+        : 'manual',
+    ...(typeof trigger.scheduledTime === 'string' && trigger.scheduledTime
+      ? { scheduledTime: trigger.scheduledTime }
       : {}),
-    ...(typeof workflowName === 'string' && workflowName.trim()
-      ? { workflow: workflowName.trim() }
+    ...(Object.prototype.hasOwnProperty.call(trigger, 'event')
+      ? { event: trigger.event }
       : {}),
-    trigger: {
-      source: String(triggerSource || 'manual').trim() || 'manual',
-    },
-    source: 'app-manifest',
   };
 }
 
 /**
- * @param {{
- *   manifest: any,
- *   activityName: string,
- *   event?: any,
- *   operationId?: string,
- *   triggerSource?: string,
- * }} options - options.
- * @returns {import('../lib/graph/operation.js').default} - Result.
+ * @param {{ appName: string, activityName: string, event?: any, operationId?: string, trigger?: any }} options - options.
+ * @returns {Operation} - Result.
  */
-export function createAppActivityOperation({
-  manifest,
-  activityName,
-  event = {},
-  operationId,
-  triggerSource = 'manual',
-}) {
-  const activity = findManifestActivity(manifest, activityName);
-  if (!activity) {
-    const availableActivities = getManifestActivityNames(manifest);
-    throw new Error(
-      `Activity '${activityName}' was not found in the app manifest. Available activities: ${
-        availableActivities.length > 0
-          ? availableActivities.join(', ')
-          : '(none)'
-      }`,
-    );
-  }
-
+export function createOperationFromActivity(options) {
   const operation = new Operation({
-    resource_id: getSyntheticAppResourceId(manifest),
-    resource_version: 1,
-    ...(typeof operationId === 'string' && operationId.trim()
-      ? { id: operationId.trim() }
+    resource_id: getAppResourceId(options.appName),
+    resource_version: getAppResourceVersion(),
+    ...(typeof options.operationId === 'string' && options.operationId.trim()
+      ? { id: options.operationId.trim() }
       : {}),
     type: OperationType.PIPELINE,
-    operation_config: createOperationConfig({
-      manifest,
-      activityName: activity.name,
-      triggerSource,
-    }),
-    operation_inputs: event,
+    operation_config: {
+      source: 'app-manifest',
+      app_name: options.appName,
+      activity_name: options.activityName,
+      trigger: normalizeTrigger(options.trigger),
+    },
+    ...(Object.prototype.hasOwnProperty.call(options, 'event')
+      ? { operation_inputs: options.event }
+      : {}),
   });
 
-  const startAction = operation.createAction({
+  const start = operation.createAction({
     id: 'start',
     type: Action.Type.START,
   });
-  const invokeAction = operation.createAction({
-    id: `invoke-${toActionIdSegment(activity.name)}`,
+  const invoke = operation.createAction({
+    id: 'invoke',
     type: Action.Type.INVOKE_FUNCTION,
-    function_name: activity.name,
-    inputs: event,
+    function_name: options.activityName,
+    inputs: Object.prototype.hasOwnProperty.call(options, 'event')
+      ? options.event
+      : {},
     placement: { mode: 'local' },
-    retry: { max_attempts: 1 },
-    dependsOn: [startAction],
+    dependsOn: [start],
   });
-
   operation.createAction({
     id: 'finish',
     type: Action.Type.FINISH,
-    dependsOn: [invokeAction],
+    dependsOn: [invoke],
   });
 
   return operation;
 }
 
 /**
- * @param {Record<string, any>} action - action.
- * @returns {string | undefined} - Result.
+ * @param {{ workflow: any, appName: string, operationId?: string, trigger?: any }} options - options.
+ * @returns {Operation} - Result.
  */
-function getWorkflowActionFunctionName(action) {
-  if (typeof action?.functionName === 'string' && action.functionName.trim()) {
-    return action.functionName.trim();
-  }
-
-  if (
-    typeof action?.function_name === 'string' &&
-    action.function_name.trim()
-  ) {
-    return action.function_name.trim();
-  }
-
-  if (typeof action?.activity === 'string' && action.activity.trim()) {
-    return action.activity.trim();
-  }
-
-  return undefined;
-}
-
-/**
- * @param {{
- *   manifest: any,
- *   workflowName: string,
- *   operationId?: string,
- *   triggerSource?: string,
- * }} options - options.
- * @returns {import('../lib/graph/operation.js').default} - Result.
- */
-export function createAppWorkflowOperation({
-  manifest,
-  workflowName,
-  operationId,
-  triggerSource = 'manual',
-}) {
-  const workflow = findManifestWorkflow(manifest, workflowName);
-  if (!workflow) {
-    const availableWorkflows = getManifestWorkflowNames(manifest);
-    throw new Error(
-      `Workflow '${workflowName}' was not found in the app manifest. Available workflows: ${
-        availableWorkflows.length > 0 ? availableWorkflows.join(', ') : '(none)'
-      }`,
-    );
-  }
-
+export function createOperationFromWorkflow(options) {
+  const workflow = options.workflow;
   const operation = new Operation({
-    resource_id: getSyntheticAppResourceId(manifest),
-    resource_version: 1,
-    ...(typeof operationId === 'string' && operationId.trim()
-      ? { id: operationId.trim() }
+    resource_id: getAppResourceId(options.appName),
+    resource_version: getAppResourceVersion(),
+    ...(typeof options.operationId === 'string' && options.operationId.trim()
+      ? { id: options.operationId.trim() }
       : {}),
     type:
       typeof workflow?.type === 'string' && workflow.type.trim()
         ? workflow.type.trim().toUpperCase()
         : OperationType.PIPELINE,
-    operation_config: createOperationConfig({
-      manifest,
-      workflowName: workflow.name,
-      triggerSource,
-    }),
+    operation_config: {
+      workflow_name: workflow?.name,
+      app_name: options.appName,
+      source: 'app-manifest',
+      trigger: normalizeTrigger(options.trigger),
+    },
   });
 
-  const actions = Array.isArray(workflow.actions) ? workflow.actions : [];
+  const actions = Array.isArray(workflow?.actions) ? workflow.actions : [];
   for (const action of actions) {
     operation.createAction({
       id: action.id,
       type: action.type,
-      function_name: getWorkflowActionFunctionName(action),
+      function_name:
+        typeof action.functionName === 'string'
+          ? action.functionName
+          : typeof action.activity === 'string'
+            ? action.activity
+            : undefined,
       inputs: action.inputs,
       placement: action.placement,
       retry: action.retry,
@@ -325,7 +303,9 @@ export function createAppWorkflowOperation({
   for (const action of actions) {
     const dependencies = Array.isArray(action?.dependsOn)
       ? action.dependsOn
-      : [];
+      : Array.isArray(action?.dependencies)
+        ? action.dependencies
+        : [];
     for (const dependencyId of dependencies) {
       if (typeof dependencyId !== 'string' || !dependencyId.trim()) {
         continue;
@@ -337,236 +317,16 @@ export function createAppWorkflowOperation({
   return operation;
 }
 
-/**
- * @param {Record<string, any> | undefined} placement - placement.
- * @returns {string} - Result.
- */
-function getPlacementMode(placement) {
-  const mode = placement?.mode;
-  if (typeof mode !== 'string' || !mode.trim()) return 'local';
-  return mode.trim().toLowerCase();
-}
-
-/**
- * @param {Record<string, any>} activity - activity.
- * @returns {import('../resources/builds/function.js').default} - Result.
- */
-function createManifestFunction(activity) {
-  return new WharfieFunction({
-    name: String(activity.name),
-    entrypoint: activity.entrypoint,
-    properties: {
-      ...(Array.isArray(activity.external)
-        ? { external: activity.external }
-        : {}),
-      ...(isPlainObject(activity.environmentVariables)
-        ? { environmentVariables: activity.environmentVariables }
-        : {}),
-      ...(isPlainObject(activity.resources)
-        ? { resources: activity.resources }
-        : {}),
-    },
-  });
-}
-
-/**
- * @param {Record<string, any>} workflowContext - workflowContext.
- * @param {any} baseContext - baseContext.
- * @returns {Record<string, any>} - Result.
- */
-function mergeExecutionContext(workflowContext, baseContext) {
-  if (!isPlainObject(baseContext)) {
-    return {
-      workflow: workflowContext,
-    };
-  }
-
-  const inheritedWorkflow = isPlainObject(baseContext.workflow)
-    ? baseContext.workflow
-    : {};
-
-  return {
-    ...baseContext,
-    workflow: {
-      ...inheritedWorkflow,
-      ...workflowContext,
-    },
-  };
-}
-
-/**
- * @typedef AppOperationStartEvent
- * @property {number} attemptCount - attemptCount.
- */
-
-/**
- * @typedef CreateAppOperationExecutorOptions
- * @property {any} manifest - manifest.
- * @property {Record<string, any>} [baseContext] - baseContext.
- * @property {(action: import('../lib/graph/action.js').default, details: AppOperationStartEvent) => void} [onActionStart] - onActionStart.
- */
-
-/**
- * @param {CreateAppOperationExecutorOptions} options - options.
- * @returns {{ executeAction: (action: import('../lib/graph/action.js').default) => Promise<{ ok: boolean, outputs?: any }>, close: () => Promise<void> }} - Result.
- */
-export function createAppOperationExecutor({
-  manifest,
-  baseContext = {},
-  onActionStart,
-}) {
-  /** @type {Promise<{ resources: Record<string, any>, close: () => Promise<void> }> | null} */
-  let appResourcesPromise = null;
-
-  /**
-   * @returns {Promise<{ resources: Record<string, any>, close: () => Promise<void> }>} - Result.
-   */
-  async function ensureAppResources() {
-    if (appResourcesPromise) {
-      return appResourcesPromise;
-    }
-
-    appResourcesPromise = createActorSystemResources(
-      getManifestResources(manifest),
-    );
-    return appResourcesPromise;
-  }
-
-  /**
-   * @param {import('../lib/graph/action.js').default} action - action.
-   * @returns {Promise<{ ok: boolean, outputs?: any }>} - Result.
-   */
-  async function executeAction(action) {
-    if (
-      action.type === Action.Type.START ||
-      action.type === Action.Type.FINISH
-    ) {
-      onActionStart?.(action, {
-        attemptCount: Number(action.attempt_count || 0),
-      });
-      return { ok: true };
-    }
-
-    if (action.type !== Action.Type.INVOKE_FUNCTION) {
-      throw new Error(
-        `Unsupported action type '${action.type}' for app runs. Only START, FINISH, and INVOKE_FUNCTION are currently executable.`,
-      );
-    }
-
-    if (!action.function_name || !String(action.function_name).trim()) {
-      throw new Error(
-        `INVOKE_FUNCTION action '${action.id}' is missing function_name.`,
-      );
-    }
-
-    const placementMode = getPlacementMode(action.placement);
-    if (placementMode !== 'local' && placementMode !== 'in_process') {
-      throw new Error(
-        `INVOKE_FUNCTION action '${action.id}' requested unsupported placement mode '${placementMode}'. Local execution currently supports only 'local' or 'in_process'.`,
-      );
-    }
-
-    const activity = findManifestActivity(manifest, action.function_name);
-    if (!activity) {
-      const availableActivities = getManifestActivityNames(manifest);
-      throw new Error(
-        `Activity '${action.function_name}' was not found in the app manifest. Available activities: ${
-          availableActivities.length > 0
-            ? availableActivities.join(', ')
-            : '(none)'
-        }`,
-      );
-    }
-
-    const attemptCount = Number(action.attempt_count || 0) + 1;
-    onActionStart?.(action, { attemptCount });
-
-    const appResources = await ensureAppResources();
-    const fn = createManifestFunction(activity);
-
-    try {
-      const outputs = await fn.fn(
-        action.inputs ?? {},
-        mergeExecutionContext(
-          {
-            resourceId: action.resource_id,
-            operationId: action.operation_id,
-            actionId: action.id,
-            actionType: action.type,
-            attemptCount,
-            placement: action.placement,
-          },
-          baseContext,
-        ),
-        {
-          baseResources: appResources.resources,
-        },
-      );
-
-      return {
-        ok: true,
-        outputs,
-      };
-    } finally {
-      await fn.closeRuntimeResources();
-    }
-  }
-
-  return {
-    executeAction,
-    close: async () => {
-      if (!appResourcesPromise) {
-        return;
-      }
-
-      const appResources = await appResourcesPromise;
-      await appResources.close();
-      appResourcesPromise = null;
-    },
-  };
-}
-
-/**
- * @typedef {import('../lib/graph/runner.js').OperationRunnerStore & {
- *   putOperation: (operation: import('../lib/graph/operation.js').default) => Promise<void>
- * }} AppOperationStore
- */
-
-/**
- * @typedef PersistAndRunAppOperationOptions
- * @property {AppOperationStore} store - store.
- * @property {any} manifest - manifest.
- * @property {import('../lib/graph/operation.js').default} operation - operation.
- * @property {Record<string, any>} [baseContext] - baseContext.
- * @property {(action: import('../lib/graph/action.js').default, details: AppOperationStartEvent) => void} [onActionStart] - onActionStart.
- */
-
-/**
- * @param {PersistAndRunAppOperationOptions} options - options.
- * @returns {Promise<{ status: 'COMPLETED' | 'FAILED' | 'BLOCKED'; executedActionIds: string[]; failedActionIds: string[]; blockedActionIds: string[]; finalStatusByActionId: Record<string, string> }>} - Result.
- */
-export async function persistAndRunAppOperation({
-  store,
-  manifest,
-  operation,
-  baseContext = {},
-  onActionStart,
-}) {
-  const executor = createAppOperationExecutor({
-    manifest,
-    baseContext,
-    onActionStart,
-  });
-
-  try {
-    await store.putOperation(operation);
-    return await runOperation({
-      store,
-      resourceId: operation.resource_id,
-      operationId: operation.id,
-      executeAction: executor.executeAction,
-    });
-  } finally {
-    await executor.close();
-  }
-}
+export default {
+  createManifestActivityFunction,
+  createOperationFromActivity,
+  createOperationFromWorkflow,
+  findManifestWorkflowDefinition,
+  getAppResourceId,
+  getAppResourceVersion,
+  getManifestActivities,
+  getManifestActivityDefinition,
+  getManifestActivityNames,
+  getManifestResourcesSpec,
+  invokeManifestActivity,
+};

--- a/src/core/runtime/resources.js
+++ b/src/core/runtime/resources.js
@@ -1,4 +1,4 @@
-import { resolveSharedResourceSpecs } from './shared-resource-registry.js';
+import { resolveSharedResourceRefs } from './shared-resource-registry.js';
 
 /**
  * Actor-system runtime resources.
@@ -242,10 +242,11 @@ async function loadObjectStorageFactory(adapter) {
 /**
  * Create resources for an actor-system.
  * @param {ActorSystemResourceSpecs} [specs] - specs.
+ * @param {{ registryPath?: string }} [options] - options.
  * @returns {Promise<{ resources: ActorSystemResources, close: () => Promise<void> }>} - Result.
  */
-export async function createActorSystemResources(specs = {}) {
-  const resolvedSpecs = await resolveSharedResourceSpecs(specs);
+export async function createActorSystemResources(specs = {}, options = {}) {
+  const resolvedSpecs = await resolveSharedResourceRefs(specs, options);
 
   /** @type {ActorSystemResources} */
   const resources = {};
@@ -253,7 +254,7 @@ export async function createActorSystemResources(specs = {}) {
   /** @type {Array<() => Promise<void> | void>} */
   const closers = [];
 
-  const dbSpec = normalizeSpec(resolvedSpecs?.db, 'db');
+  const dbSpec = normalizeSpec(resolvedSpecs.db, 'db');
   if (dbSpec) {
     if ('instance' in dbSpec) {
       resources.db = dbSpec.instance;
@@ -267,7 +268,7 @@ export async function createActorSystemResources(specs = {}) {
     }
   }
 
-  const queueSpec = normalizeSpec(resolvedSpecs?.queue, 'queue');
+  const queueSpec = normalizeSpec(resolvedSpecs.queue, 'queue');
   if (queueSpec) {
     if ('instance' in queueSpec) {
       resources.queue = queueSpec.instance;
@@ -282,7 +283,7 @@ export async function createActorSystemResources(specs = {}) {
   }
 
   const objectStorageSpec = normalizeSpec(
-    resolvedSpecs?.objectStorage,
+    resolvedSpecs.objectStorage,
     'objectStorage',
   );
   if (objectStorageSpec) {

--- a/src/core/runtime/resources.js
+++ b/src/core/runtime/resources.js
@@ -1,3 +1,5 @@
+import { resolveSharedResourceSpecs } from './shared-resource-registry.js';
+
 /**
  * Actor-system runtime resources.
  *
@@ -243,13 +245,15 @@ async function loadObjectStorageFactory(adapter) {
  * @returns {Promise<{ resources: ActorSystemResources, close: () => Promise<void> }>} - Result.
  */
 export async function createActorSystemResources(specs = {}) {
+  const resolvedSpecs = await resolveSharedResourceSpecs(specs);
+
   /** @type {ActorSystemResources} */
   const resources = {};
 
   /** @type {Array<() => Promise<void> | void>} */
   const closers = [];
 
-  const dbSpec = normalizeSpec(specs.db, 'db');
+  const dbSpec = normalizeSpec(resolvedSpecs?.db, 'db');
   if (dbSpec) {
     if ('instance' in dbSpec) {
       resources.db = dbSpec.instance;
@@ -263,7 +267,7 @@ export async function createActorSystemResources(specs = {}) {
     }
   }
 
-  const queueSpec = normalizeSpec(specs.queue, 'queue');
+  const queueSpec = normalizeSpec(resolvedSpecs?.queue, 'queue');
   if (queueSpec) {
     if ('instance' in queueSpec) {
       resources.queue = queueSpec.instance;
@@ -277,7 +281,10 @@ export async function createActorSystemResources(specs = {}) {
     }
   }
 
-  const objectStorageSpec = normalizeSpec(specs.objectStorage, 'objectStorage');
+  const objectStorageSpec = normalizeSpec(
+    resolvedSpecs?.objectStorage,
+    'objectStorage',
+  );
   if (objectStorageSpec) {
     if ('instance' in objectStorageSpec) {
       resources.objectStorage = objectStorageSpec.instance;

--- a/src/core/runtime/services/app-run.js
+++ b/src/core/runtime/services/app-run.js
@@ -1,0 +1,175 @@
+import Action from '../../lib/graph/action.js';
+import Operation, { Type as OperationType } from '../../lib/graph/operation.js';
+import { runOperation } from '../../lib/graph/runner.js';
+
+/**
+ * @typedef ActivityRunTrigger
+ * @property {string} source - Trigger source.
+ * @property {string} [cron] - Cron expression, when applicable.
+ * @property {string} [scheduledTime] - ISO scheduled time, when applicable.
+ */
+
+/**
+ * @typedef ActivityRunContext
+ * @property {{
+ *   resourceId: string,
+ *   operationId: string,
+ *   actionId: string,
+ *   actionType: import('../../lib/graph/action.js').WharfieActionTypeEnum,
+ *   attemptCount: number,
+ *   placement: Record<string, any> | undefined,
+ * }} workflow - Persisted workflow/action metadata.
+ * @property {ActivityRunTrigger} trigger - Trigger metadata.
+ */
+
+/**
+ * @typedef PersistedActivityRunOptions
+ * @property {any} store - Operations store.
+ * @property {any} manifest - App manifest.
+ * @property {string} activityName - Activity/function name.
+ * @property {any} [event] - Event payload.
+ * @property {ActivityRunTrigger} trigger - Trigger metadata.
+ * @property {(activityName: string, event: any, context: ActivityRunContext) => Promise<any>} invokeActivity - Low-level activity invoker.
+ */
+
+/**
+ * @param {any} manifest - manifest.
+ * @returns {string} - Result.
+ */
+export function getSyntheticAppResourceId(manifest) {
+  const appName =
+    typeof manifest?.app?.name === 'string' ? manifest.app.name.trim() : '';
+
+  if (!appName) {
+    throw new Error('Persisted app runs require manifest.app.name.');
+  }
+
+  return `app:${appName}`;
+}
+
+/**
+ * @param {{
+ *   manifest: any,
+ *   activityName: string,
+ *   event?: any,
+ *   trigger: ActivityRunTrigger,
+ * }} options - options.
+ * @returns {import('../../lib/graph/operation.js').default} - Result.
+ */
+export function createPersistedActivityOperation({
+  manifest,
+  activityName,
+  event,
+  trigger,
+}) {
+  const resourceId = getSyntheticAppResourceId(manifest);
+  const appName = String(manifest.app.name).trim();
+  const normalizedActivityName = String(activityName || '').trim();
+
+  if (!normalizedActivityName) {
+    throw new Error('Persisted app runs require a non-empty activityName.');
+  }
+
+  const operation = new Operation({
+    resource_id: resourceId,
+    resource_version: 1,
+    type: OperationType.PIPELINE,
+    operation_config: {
+      source: 'scheduler',
+      app_name: appName,
+      activity_name: normalizedActivityName,
+      trigger: { ...trigger },
+    },
+    operation_inputs: event,
+  });
+
+  operation.createAction({
+    id: 'invoke',
+    type: Action.Type.INVOKE_FUNCTION,
+    function_name: normalizedActivityName,
+    inputs: event,
+    placement: { mode: 'local' },
+    retry: { max_attempts: 1 },
+  });
+
+  return operation;
+}
+
+/**
+ * @param {PersistedActivityRunOptions} options - options.
+ * @returns {Promise<{
+ *   resourceId: string,
+ *   operation: import('../../lib/graph/operation.js').default,
+ *   result: any,
+ * }>} - Result.
+ */
+export async function runPersistedActivityOperation({
+  store,
+  manifest,
+  activityName,
+  event,
+  trigger,
+  invokeActivity,
+}) {
+  if (!store || typeof store.putOperation !== 'function') {
+    throw new Error(
+      'runPersistedActivityOperation requires store.putOperation',
+    );
+  }
+  if (typeof invokeActivity !== 'function') {
+    throw new Error(
+      'runPersistedActivityOperation requires invokeActivity(activityName, event, context)',
+    );
+  }
+
+  const operation = createPersistedActivityOperation({
+    manifest,
+    activityName,
+    event,
+    trigger,
+  });
+  const resourceId = operation.resource_id;
+
+  await store.putOperation(operation);
+
+  const result = await runOperation({
+    store,
+    resourceId,
+    operationId: operation.id,
+    executeAction: async (action) => {
+      if (action.type !== Action.Type.INVOKE_FUNCTION) {
+        throw new Error(
+          `Unsupported action type '${action.type}' for persisted activity runs.`,
+        );
+      }
+
+      if (!action.function_name || !String(action.function_name).trim()) {
+        throw new Error(
+          `Persisted activity action '${action.id}' is missing function_name.`,
+        );
+      }
+
+      const attemptCount = Number(action.attempt_count || 0) + 1;
+      return {
+        ok: true,
+        outputs: await invokeActivity(action.function_name, action.inputs, {
+          workflow: {
+            resourceId: action.resource_id,
+            operationId: action.operation_id,
+            actionId: action.id,
+            actionType: action.type,
+            attemptCount,
+            placement: action.placement,
+          },
+          trigger,
+        }),
+      };
+    },
+  });
+
+  return {
+    resourceId,
+    operation,
+    result,
+  };
+}

--- a/src/core/runtime/services/lambda-service.js
+++ b/src/core/runtime/services/lambda-service.js
@@ -45,7 +45,9 @@ function normalizeOptionalString(value) {
  * @returns {Record<string, any> | undefined} - Result.
  */
 function normalizeContext(value) {
-  return value && typeof value === 'object' ? value : undefined;
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : undefined;
 }
 
 /**
@@ -166,14 +168,15 @@ export async function startLambdaService({
                 continue;
               }
 
+              const messageId = normalizeOptionalString(msg?.MessageId);
+              const receiptHandle = normalizeOptionalString(receipt);
               const invocationContext = {
                 ...(normalizeContext(payload?.context) || {}),
                 trigger: {
                   source: 'event',
                   queueUrl,
-                  ...(normalizeOptionalString(msg?.MessageId)
-                    ? { messageId: normalizeOptionalString(msg?.MessageId) }
-                    : {}),
+                  ...(messageId ? { messageId } : {}),
+                  ...(receiptHandle ? { receiptHandle } : {}),
                 },
               };
 
@@ -188,8 +191,8 @@ export async function startLambdaService({
                     payload,
                     message: {
                       queueUrl,
-                      messageId: normalizeOptionalString(msg?.MessageId),
-                      receiptHandle: normalizeOptionalString(receipt),
+                      ...(messageId ? { messageId } : {}),
+                      ...(receiptHandle ? { receiptHandle } : {}),
                     },
                     execute: async ({ functionName, event, context }) => {
                       await execute({
@@ -227,9 +230,7 @@ export async function startLambdaService({
                     {
                       queueUrl,
                       activity,
-                      ...(normalizeOptionalString(msg?.MessageId)
-                        ? { messageId: normalizeOptionalString(msg?.MessageId) }
-                        : {}),
+                      ...(messageId ? { messageId } : {}),
                       error: msgStr,
                     },
                   );
@@ -276,15 +277,18 @@ export async function startLambdaService({
       Invoke: async (call, callback) => {
         try {
           const req = call?.request || {};
-          const functionName = req.functionName;
+          const functionName =
+            normalizeOptionalString(req.functionName) ||
+            normalizeOptionalString(req.activity);
 
-          if (!functionName || typeof functionName !== 'string') {
+          if (!functionName) {
             callback(null, { ok: false, error: 'Missing functionName' });
             return;
           }
 
           await execute({
             functionName,
+            activity: functionName,
             event: req.event,
             context: req.context,
           });

--- a/src/core/runtime/services/lambda-service.js
+++ b/src/core/runtime/services/lambda-service.js
@@ -1,10 +1,12 @@
 import { setTimeout as delay } from 'node:timers/promises';
 
+import { runPersistedEventActivity } from '../../lib/graph/app-run.js';
 import { startGrpcServer, LambdaServiceDefinition } from './rpc-grpc.js';
 
 /**
  * @typedef LambdaInvokeRequest
  * @property {string} functionName - functionName.
+ * @property {string} [activity] - activity.
  * @property {any} [event] - event.
  * @property {any} [context] - context.
  */
@@ -16,6 +18,8 @@ import { startGrpcServer, LambdaServiceDefinition } from './rpc-grpc.js';
  * @property {number} [waitTimeSeconds] - Long poll seconds (0-20).
  * @property {number} [maxNumberOfMessages] - 1-10.
  * @property {number} [visibilityTimeout] - seconds
+ * @property {import('../../lib/db/tables/operations.js').OperationsTableClient} [operationsStore] - operationsStore.
+ * @property {string} [appName] - appName.
  * @property {(msg: string, extra?: any) => void} [log] - log.
  */
 
@@ -29,14 +33,42 @@ import { startGrpcServer, LambdaServiceDefinition } from './rpc-grpc.js';
  */
 
 /**
+ * @param {unknown} value - value.
+ * @returns {string | undefined} - Result.
+ */
+function normalizeOptionalString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * @param {any} value - value.
+ * @returns {Record<string, any> | undefined} - Result.
+ */
+function normalizeContext(value) {
+  return value && typeof value === 'object' ? value : undefined;
+}
+
+/**
+ * @param {any} payload - payload.
+ * @returns {string | undefined} - Result.
+ */
+function resolveActivityName(payload) {
+  return (
+    normalizeOptionalString(payload?.activity) ||
+    normalizeOptionalString(payload?.actor) ||
+    normalizeOptionalString(payload?.functionName)
+  );
+}
+
+/**
  * Start the Lambda service (execution plane).
  *
  * - Exposes a gRPC `Invoke` API for explicit invocations.
  * - Optionally runs one or more queue poll loops that decode messages into invocations.
  *
  * Message format (Queue Message Body):
- * v1: { "functionName": "my-function", "event": { ... }, "context": { ... } }
- * v2: { "v": 2, "actor": "my-function", "event": { ... }, "context": { ... } }
+ * public: { "activity": "my-activity", "event": { ... }, "context": { ... } }
+ * legacy envelopes using "actor" or "functionName" are still normalized for internal compatibility.
  * @param {LambdaServiceOptions} options - options.
  * @returns {Promise<{ address: string, host: string, port: number, close: () => Promise<void> }>} - Result.
  */
@@ -124,26 +156,58 @@ export async function startLambdaService({
                 continue;
               }
 
-              // Compatibility: accept either legacy {functionName,...} or v2 envelope {actor,...}
-              const functionName =
-                typeof payload?.actor === 'string'
-                  ? payload.actor
-                  : payload?.functionName;
-              if (!functionName || typeof functionName !== 'string') {
+              const activity = resolveActivityName(payload);
+              if (!activity) {
                 pollLog &&
-                  pollLog('lambda poll: missing functionName', {
+                  pollLog('lambda poll: missing activity', {
                     queueUrl,
                     payload,
                   });
                 continue;
               }
 
+              const invocationContext = {
+                ...(normalizeContext(payload?.context) || {}),
+                trigger: {
+                  source: 'event',
+                  queueUrl,
+                  ...(normalizeOptionalString(msg?.MessageId)
+                    ? { messageId: normalizeOptionalString(msg?.MessageId) }
+                    : {}),
+                },
+              };
+
               try {
-                await execute({
-                  functionName,
-                  event: payload?.event,
-                  context: payload?.context,
-                });
+                if (poll.operationsStore && poll.appName) {
+                  await runPersistedEventActivity({
+                    store: poll.operationsStore,
+                    appName: poll.appName,
+                    activity,
+                    event: payload?.event,
+                    context: invocationContext,
+                    payload,
+                    message: {
+                      queueUrl,
+                      messageId: normalizeOptionalString(msg?.MessageId),
+                      receiptHandle: normalizeOptionalString(receipt),
+                    },
+                    execute: async ({ functionName, event, context }) => {
+                      await execute({
+                        functionName,
+                        activity,
+                        event,
+                        context,
+                      });
+                    },
+                  });
+                } else {
+                  await execute({
+                    functionName: activity,
+                    activity,
+                    event: payload?.event,
+                    context: invocationContext,
+                  });
+                }
 
                 // Ack/delete only on success.
                 await queue.deleteMessage({
@@ -162,7 +226,10 @@ export async function startLambdaService({
                     'lambda poll: invocation failed (message will retry)',
                     {
                       queueUrl,
-                      functionName,
+                      activity,
+                      ...(normalizeOptionalString(msg?.MessageId)
+                        ? { messageId: normalizeOptionalString(msg?.MessageId) }
+                        : {}),
                       error: msgStr,
                     },
                   );

--- a/src/core/runtime/services/node-agent.js
+++ b/src/core/runtime/services/node-agent.js
@@ -165,12 +165,16 @@ function createServicePlan(resourcesSpec, manifest) {
   const functions = Array.isArray(manifest?.functions)
     ? manifest.functions
     : [];
+  const activities =
+    manifest && typeof manifest.activities === 'object' && manifest.activities
+      ? Object.keys(manifest.activities)
+      : [];
   const schedulerTriggers = extractCronTriggers(manifest || resourceConfig);
 
   return {
     db: resourceConfig.db !== undefined,
     queue: resourceConfig.queue !== undefined,
-    lambda: manifest ? functions.length > 0 : true,
+    lambda: manifest ? functions.length > 0 || activities.length > 0 : true,
     scheduler: schedulerTriggers.length > 0,
   };
 }
@@ -185,6 +189,72 @@ function createChildManifestEnv(manifest) {
   }
 
   return { WHARFIE_APP_MANIFEST: JSON.stringify(manifest) };
+}
+
+/**
+ * @param {string[]} prefixArgs - prefixArgs.
+ * @returns {boolean} - Result.
+ */
+function usesPackagedRuntime(prefixArgs) {
+  return !Array.isArray(prefixArgs) || prefixArgs.length === 0;
+}
+
+/**
+ * @param {string} runtimeCommand - runtimeCommand.
+ * @param {string[]} runtimeArgs - runtimeArgs.
+ * @param {string[]} prefixArgs - prefixArgs.
+ * @returns {string[]} - Result.
+ */
+function createLegacySpawnArgs(runtimeCommand, runtimeArgs, prefixArgs) {
+  if (runtimeCommand === 'start') {
+    return [...prefixArgs, 'ctl', 'state', 'start', ...runtimeArgs];
+  }
+
+  if (runtimeCommand === 'serve-db') {
+    return [...prefixArgs, 'ctl', 'state', 'serve', 'db', ...runtimeArgs];
+  }
+
+  if (runtimeCommand === 'serve-queue') {
+    return [...prefixArgs, 'ctl', 'state', 'serve', 'queue', ...runtimeArgs];
+  }
+
+  if (runtimeCommand === 'serve-lambda') {
+    return [...prefixArgs, 'ctl', 'state', 'serve', 'lambda', ...runtimeArgs];
+  }
+
+  return [...prefixArgs, ...runtimeArgs];
+}
+
+/**
+ * @param {string} name - name.
+ * @param {NodeAgentOptions} options - options.
+ * @param {Record<string, string>} childEnv - childEnv.
+ * @param {string} runtimeCommand - runtimeCommand.
+ * @param {string[]} runtimeArgs - runtimeArgs.
+ * @returns {ServiceChild} - Result.
+ */
+function spawnManagedService(
+  name,
+  options,
+  childEnv,
+  runtimeCommand,
+  runtimeArgs,
+) {
+  if (usesPackagedRuntime(options.prefixArgs)) {
+    return spawnService(name, options.cmd, [], {
+      ...childEnv,
+      WHARFIE_BOOTSTRAP_MODE: 'runtime',
+      WHARFIE_RUNTIME_COMMAND: runtimeCommand,
+      WHARFIE_RUNTIME_ARGS: JSON.stringify(runtimeArgs),
+    });
+  }
+
+  return spawnService(
+    name,
+    options.cmd,
+    createLegacySpawnArgs(runtimeCommand, runtimeArgs, options.prefixArgs),
+    childEnv,
+  );
 }
 
 export default class NodeAgent {
@@ -239,44 +309,24 @@ export default class NodeAgent {
     if (spawnServices && o.role !== 'worker') {
       if (servicePlan.db && !this.dbAddress) {
         this.children.push(
-          spawnService(
-            'db',
-            o.cmd,
-            [
-              ...o.prefixArgs,
-              'ctl',
-              'state',
-              'serve',
-              'db',
-              '--host',
-              String(o.dbHost),
-              '--port',
-              String(o.dbPort),
-            ],
-            childEnv,
-          ),
+          spawnManagedService('db', o, childEnv, 'serve-db', [
+            '--host',
+            String(o.dbHost),
+            '--port',
+            String(o.dbPort),
+          ]),
         );
         this.dbAddress = `${o.dbHost}:${o.dbPort}`;
       }
 
       if (servicePlan.queue && !this.queueAddress) {
         this.children.push(
-          spawnService(
-            'queue',
-            o.cmd,
-            [
-              ...o.prefixArgs,
-              'ctl',
-              'state',
-              'serve',
-              'queue',
-              '--host',
-              String(o.queueHost),
-              '--port',
-              String(o.queuePort),
-            ],
-            childEnv,
-          ),
+          spawnManagedService('queue', o, childEnv, 'serve-queue', [
+            '--host',
+            String(o.queueHost),
+            '--port',
+            String(o.queuePort),
+          ]),
         );
         this.queueAddress = `${o.queueHost}:${o.queuePort}`;
       }
@@ -297,12 +347,8 @@ export default class NodeAgent {
     }
 
     if (spawnServices && servicePlan.lambda) {
+      /** @type {string[]} */
       const lambdaArgs = [
-        ...o.prefixArgs,
-        'ctl',
-        'state',
-        'serve',
-        'lambda',
         '--host',
         String(o.lambdaHost),
         '--port',
@@ -320,7 +366,9 @@ export default class NodeAgent {
         lambdaArgs.push('--poll-queue-url', qUrl);
       }
 
-      this.children.push(spawnService('lambda', o.cmd, lambdaArgs, childEnv));
+      this.children.push(
+        spawnManagedService('lambda', o, childEnv, 'serve-lambda', lambdaArgs),
+      );
     }
 
     await this._maybeStartScheduler();

--- a/src/core/runtime/services/node-agent.js
+++ b/src/core/runtime/services/node-agent.js
@@ -7,7 +7,16 @@ import { Client, credentials } from '@grpc/grpc-js';
 
 import { grpcUnary, LambdaServiceDefinition } from './rpc-grpc.js';
 import { startSchedulerService } from './scheduler-service.js';
+import {
+  getSyntheticAppResourceId,
+  runPersistedActivityOperation,
+} from './app-run.js';
 import { extractCronTriggers } from '../../resources/builds/actor-system-cli/lib/runtime-bootstrap.js';
+import operationsStoreFactory from '../../lib/graph/operations-store.js';
+import {
+  createDBClient,
+  resolveOperationsTableName,
+} from '../../lib/config/db.js';
 
 /**
  * Node Agent
@@ -197,6 +206,15 @@ export default class NodeAgent {
     /** @type {import('@grpc/grpc-js').Client|null} */
     this._lambdaClient = null;
 
+    /** @type {import('../../lib/db/base.js').DBClient | null} */
+    this._operationsDb = null;
+
+    /** @type {ReturnType<typeof operationsStoreFactory> | null} */
+    this._operationsStore = null;
+
+    /** @type {Promise<ReturnType<typeof operationsStoreFactory>> | null} */
+    this._operationsStorePromise = null;
+
     this.dbAddress = normalizeAddress(options.dbAddressOverride);
     this.queueAddress = normalizeAddress(options.queueAddressOverride);
 
@@ -317,22 +335,111 @@ export default class NodeAgent {
     const triggers = extractCronTriggers(o.manifest || o.resourcesSpec);
     if (!triggers.length) return;
 
-    const invoke =
+    /** @type {(actor: string, payload: any, context?: any) => Promise<void>} */
+    const invokeActivity =
       typeof o.schedulerInvoke === 'function'
-        ? o.schedulerInvoke
+        ? async (actor, payload) => {
+            const schedulerInvoke = o.schedulerInvoke;
+            if (typeof schedulerInvoke !== 'function') {
+              throw new TypeError(
+                'node-agent: schedulerInvoke must be a function',
+              );
+            }
+            await schedulerInvoke(actor, payload);
+          }
         : this._createLocalLambdaInvoker();
+
+    getSyntheticAppResourceId(o.manifest);
+    await this._ensureOperationsStore();
 
     this.scheduler = await startSchedulerService({
       role: o.role,
       triggers,
-      invoke,
+      invoke: async (actor, payload) => {
+        const trigger = {
+          source: 'cron',
+          ...(payload && typeof payload === 'object'
+            ? {
+                ...(typeof payload.cron === 'string' && payload.cron.trim()
+                  ? { cron: payload.cron.trim() }
+                  : {}),
+                ...(typeof payload.scheduledTime === 'string' &&
+                payload.scheduledTime.trim()
+                  ? { scheduledTime: payload.scheduledTime.trim() }
+                  : {}),
+              }
+            : {}),
+        };
+        const store = await this._ensureOperationsStore();
+        const { operation, resourceId, result } =
+          await runPersistedActivityOperation({
+            store,
+            manifest: o.manifest,
+            activityName: actor,
+            event: payload,
+            trigger,
+            invokeActivity,
+          });
+
+        if (result.status !== 'COMPLETED') {
+          const details = [];
+          if (result.failedActionIds.length > 0) {
+            details.push(`failed=${result.failedActionIds.join(',')}`);
+          }
+          if (result.blockedActionIds.length > 0) {
+            details.push(`blocked=${result.blockedActionIds.join(',')}`);
+          }
+          throw new Error(
+            `Scheduled activity ${actor} (${resourceId}#${operation.id}) finished with status ${result.status}${
+              details.length > 0 ? ` (${details.join(' ')})` : ''
+            }.`,
+          );
+        }
+      },
       log: (msg, extra) =>
         console.error('[node-agent:scheduler]', msg, extra ?? ''),
     });
   }
 
   /**
-   * @returns {(actor: string, payload: any) => Promise<void>} - Invoker.
+   * @returns {Promise<ReturnType<typeof operationsStoreFactory>>} - Result.
+   */
+  async _ensureOperationsStore() {
+    if (this._operationsStore) {
+      return this._operationsStore;
+    }
+
+    if (this._operationsStorePromise) {
+      return await this._operationsStorePromise;
+    }
+
+    const tableName = resolveOperationsTableName();
+
+    this._operationsStorePromise = (async () => {
+      const db = await createDBClient();
+      try {
+        const store = operationsStoreFactory({ db, tableName });
+        this._operationsDb = db;
+        this._operationsStore = store;
+        return store;
+      } catch (error) {
+        await db?.close?.();
+        throw error;
+      }
+    })();
+
+    try {
+      return await this._operationsStorePromise;
+    } catch (error) {
+      this._operationsStorePromise = null;
+      this._operationsStore = null;
+      this._operationsDb = null;
+      throw error;
+    }
+  }
+
+  /**
+   * @returns {(actor: string, payload: any, context?: any) => Promise<void>} - Invoker.
    */
   _createLocalLambdaInvoker() {
     const o = this.options;
@@ -350,14 +457,18 @@ export default class NodeAgent {
     const client = new Client(address, credentials.createInsecure());
     this._lambdaClient = client;
 
-    return async (actor, payload) => {
+    return async (actor, payload, context = {}) => {
       const resp = await grpcUnary(
         client,
         LambdaServiceDefinition.Invoke.path,
         {
           functionName: actor,
           event: payload,
-          context: { source: 'cron', nodeId: o.nodeId },
+          context: {
+            source: 'cron',
+            nodeId: o.nodeId,
+            ...(context && typeof context === 'object' ? context : {}),
+          },
         },
         { deadlineMs: 60_000 },
       );
@@ -439,6 +550,21 @@ export default class NodeAgent {
       } catch {}
       this._lambdaClient = null;
     }
+
+    if (this._operationsStorePromise) {
+      try {
+        await this._operationsStorePromise;
+      } catch {}
+    }
+
+    if (this._operationsDb) {
+      try {
+        await this._operationsDb.close?.();
+      } catch {}
+      this._operationsDb = null;
+    }
+    this._operationsStore = null;
+    this._operationsStorePromise = null;
 
     if (this.control) {
       this.control.close();

--- a/src/core/runtime/shared-resource-registry.js
+++ b/src/core/runtime/shared-resource-registry.js
@@ -1,0 +1,230 @@
+import path from 'node:path';
+import { promises as fsp } from 'node:fs';
+
+import paths from '../lib/paths.js';
+
+export const SHARED_RESOURCE_REGISTRY_FILE_NAME = 'shared-resources.json';
+
+/**
+ * @param {unknown} value - value.
+ * @returns {value is Record<string, any>} - Result.
+ */
+function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * @param {string} raw - raw.
+ * @param {string} label - label.
+ * @returns {any} - Result.
+ */
+function parseJson(raw, label) {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    const message =
+      error && typeof error === 'object' && 'message' in error
+        ? String(error.message)
+        : String(error);
+    throw new Error(`Failed to parse ${label}: ${message}`);
+  }
+}
+
+/**
+ * @param {unknown} value - value.
+ * @returns {any} - Result.
+ */
+function cloneJsonValue(value) {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => cloneJsonValue(item))
+      .filter((item) => item !== undefined);
+  }
+
+  if (value === null) return null;
+
+  if (typeof value === 'string' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  return Object.keys(value)
+    .sort((left, right) => left.localeCompare(right))
+    .reduce((acc, key) => {
+      const cloned = cloneJsonValue(value[key]);
+      if (cloned !== undefined) {
+        acc[key] = cloned;
+      }
+      return acc;
+    }, /** @type {Record<string, any>} */ ({}));
+}
+
+/**
+ * @param {unknown} value - value.
+ * @returns {value is { ref: string }} - Result.
+ */
+function isSharedResourceRef(value) {
+  return (
+    isPlainObject(value) && typeof value.ref === 'string' && !!value.ref.trim()
+  );
+}
+
+/**
+ * @param {{ configDir?: string }} [options] - options.
+ * @returns {string} - Result.
+ */
+export function getSharedResourceRegistryPath(options = {}) {
+  const configDir =
+    typeof options.configDir === 'string' && options.configDir.trim()
+      ? options.configDir.trim()
+      : typeof paths.getConfigDir === 'function'
+        ? paths.getConfigDir()
+        : paths.config;
+
+  return path.join(configDir, SHARED_RESOURCE_REGISTRY_FILE_NAME);
+}
+
+/**
+ * @param {{ configDir?: string }} [options] - options.
+ * @returns {Promise<{ path: string, value: Record<string, any> }>} - Result.
+ */
+export async function loadSharedResourceRegistry(options = {}) {
+  const registryPath = getSharedResourceRegistryPath(options);
+
+  let raw;
+  try {
+    raw = await fsp.readFile(registryPath, 'utf8');
+  } catch (error) {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return {
+        path: registryPath,
+        value: {},
+      };
+    }
+
+    throw error;
+  }
+
+  const parsed = parseJson(raw, `shared resource registry '${registryPath}'`);
+  if (!isPlainObject(parsed)) {
+    throw new Error(
+      `Failed to parse shared resource registry '${registryPath}': expected a JSON object.`,
+    );
+  }
+
+  return {
+    path: registryPath,
+    value: parsed,
+  };
+}
+
+/**
+ * @param {'db'|'queue'|'objectStorage'} kind - kind.
+ * @param {any} spec - spec.
+ * @param {{ configDir?: string }} [options] - options.
+ * @returns {Promise<any>} - Result.
+ */
+export async function resolveSharedResourceSpec(kind, spec, options = {}) {
+  if (!isSharedResourceRef(spec)) {
+    return spec;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(spec, 'adapter')) {
+    throw new Error(
+      `Shared ${kind} ref '${spec.ref.trim()}' cannot also declare an adapter.`,
+    );
+  }
+
+  const extraKeys = Object.keys(spec).filter((key) => key !== 'ref');
+  if (extraKeys.length > 0) {
+    throw new Error(
+      `Shared ${kind} ref '${spec.ref.trim()}' does not support inline overrides: ${extraKeys.join(', ')}.`,
+    );
+  }
+
+  const { path: registryPath, value: registry } =
+    await loadSharedResourceRegistry(options);
+  const resourceBucket = isPlainObject(registry[kind]) ? registry[kind] : {};
+  const refName = spec.ref.trim();
+  const resolved = resourceBucket[refName];
+
+  if (resolved === undefined) {
+    throw new Error(
+      `Shared ${kind} ref '${refName}' was not found in ${registryPath}.`,
+    );
+  }
+
+  if (isSharedResourceRef(resolved)) {
+    throw new Error(
+      `Shared ${kind} ref '${refName}' in ${registryPath} must resolve directly to an adapter spec, not another ref.`,
+    );
+  }
+
+  const cloned = cloneJsonValue(resolved);
+  if (cloned === undefined) {
+    throw new Error(
+      `Shared ${kind} ref '${refName}' in ${registryPath} must resolve to a string adapter name or JSON object.`,
+    );
+  }
+
+  return cloned;
+}
+
+/**
+ * @param {any} specs - specs.
+ * @param {{ configDir?: string }} [options] - options.
+ * @returns {Promise<any>} - Result.
+ */
+export async function resolveSharedResourceSpecs(specs, options = {}) {
+  if (!isPlainObject(specs)) {
+    return specs;
+  }
+
+  let hasChanges = false;
+  const resolvedSpecs = { ...specs };
+
+  for (const kind of ['db', 'queue', 'objectStorage']) {
+    if (!Object.prototype.hasOwnProperty.call(specs, kind)) {
+      continue;
+    }
+
+    const current = specs[kind];
+    const resolved = await resolveSharedResourceSpec(
+      /** @type {'db'|'queue'|'objectStorage'} */ (kind),
+      current,
+      options,
+    );
+
+    if (resolved !== current) {
+      resolvedSpecs[kind] = resolved;
+      hasChanges = true;
+    }
+  }
+
+  return hasChanges ? resolvedSpecs : specs;
+}
+
+export default {
+  SHARED_RESOURCE_REGISTRY_FILE_NAME,
+  getSharedResourceRegistryPath,
+  loadSharedResourceRegistry,
+  resolveSharedResourceSpec,
+  resolveSharedResourceSpecs,
+};

--- a/src/core/runtime/shared-resource-registry.js
+++ b/src/core/runtime/shared-resource-registry.js
@@ -1,5 +1,5 @@
-import path from 'node:path';
 import { promises as fsp } from 'node:fs';
+import path from 'node:path';
 
 import paths from '../lib/paths.js';
 
@@ -9,7 +9,7 @@ export const SHARED_RESOURCE_REGISTRY_FILE_NAME = 'shared-resources.json';
  * @param {unknown} value - value.
  * @returns {value is Record<string, any>} - Result.
  */
-function isPlainObject(value) {
+function isObjectRecord(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return false;
   }
@@ -19,93 +19,71 @@ function isPlainObject(value) {
 }
 
 /**
- * @param {string} raw - raw.
- * @param {string} label - label.
- * @returns {any} - Result.
- */
-function parseJson(raw, label) {
-  try {
-    return JSON.parse(raw);
-  } catch (error) {
-    const message =
-      error && typeof error === 'object' && 'message' in error
-        ? String(error.message)
-        : String(error);
-    throw new Error(`Failed to parse ${label}: ${message}`);
-  }
-}
-
-/**
  * @param {unknown} value - value.
- * @returns {any} - Result.
+ * @returns {unknown} - Result.
  */
-function cloneJsonValue(value) {
+function cloneJson(value) {
   if (Array.isArray(value)) {
-    return value
-      .map((item) => cloneJsonValue(item))
-      .filter((item) => item !== undefined);
+    return value.map((item) => cloneJson(item));
   }
 
-  if (value === null) return null;
-
-  if (typeof value === 'string' || typeof value === 'boolean') {
+  if (!isObjectRecord(value)) {
     return value;
   }
 
-  if (typeof value === 'number') {
-    return Number.isFinite(value) ? value : null;
-  }
-
-  if (!isPlainObject(value)) {
-    return undefined;
-  }
-
-  return Object.keys(value)
-    .sort((left, right) => left.localeCompare(right))
-    .reduce((acc, key) => {
-      const cloned = cloneJsonValue(value[key]);
-      if (cloned !== undefined) {
-        acc[key] = cloned;
-      }
-      return acc;
-    }, /** @type {Record<string, any>} */ ({}));
+  return Object.keys(value).reduce((acc, key) => {
+    acc[key] = cloneJson(value[key]);
+    return acc;
+  }, /** @type {Record<string, any>} */ ({}));
 }
 
 /**
- * @param {unknown} value - value.
- * @returns {value is { ref: string }} - Result.
- */
-function isSharedResourceRef(value) {
-  return (
-    isPlainObject(value) && typeof value.ref === 'string' && !!value.ref.trim()
-  );
-}
-
-/**
- * @param {{ configDir?: string }} [options] - options.
+ * @param {string | { registryPath?: string, configDir?: string } | undefined} [options] - options.
  * @returns {string} - Result.
  */
 export function getSharedResourceRegistryPath(options = {}) {
+  if (typeof options === 'string' && options.trim()) {
+    return path.resolve(options);
+  }
+
+  const registryPath =
+    isObjectRecord(options) &&
+    typeof options.registryPath === 'string' &&
+    options.registryPath.trim()
+      ? options.registryPath.trim()
+      : undefined;
+  if (registryPath) {
+    return path.resolve(registryPath);
+  }
+
   const configDir =
-    typeof options.configDir === 'string' && options.configDir.trim()
+    isObjectRecord(options) &&
+    typeof options.configDir === 'string' &&
+    options.configDir.trim()
       ? options.configDir.trim()
-      : typeof paths.getConfigDir === 'function'
-        ? paths.getConfigDir()
-        : paths.config;
+      : typeof process.env.CONFIG_DIR === 'string' &&
+          process.env.CONFIG_DIR.trim()
+        ? process.env.CONFIG_DIR.trim()
+        : typeof paths.getConfigDir === 'function'
+          ? paths.getConfigDir()
+          : paths.config;
 
   return path.join(configDir, SHARED_RESOURCE_REGISTRY_FILE_NAME);
 }
 
 /**
- * @param {{ configDir?: string }} [options] - options.
- * @returns {Promise<{ path: string, value: Record<string, any> }>} - Result.
+ * @param {{ registryPath?: string, configDir?: string }} [options] - options.
+ * @returns {Promise<Record<string, Record<string, any>>>} - Result.
  */
-export async function loadSharedResourceRegistry(options = {}) {
+export async function readSharedResourceRegistry(options = {}) {
   const registryPath = getSharedResourceRegistryPath(options);
 
-  let raw;
   try {
-    raw = await fsp.readFile(registryPath, 'utf8');
+    const raw = await fsp.readFile(registryPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    return isObjectRecord(parsed)
+      ? /** @type {Record<string, Record<string, any>>} */ (parsed)
+      : {};
   } catch (error) {
     if (
       error &&
@@ -113,118 +91,156 @@ export async function loadSharedResourceRegistry(options = {}) {
       'code' in error &&
       error.code === 'ENOENT'
     ) {
-      return {
-        path: registryPath,
-        value: {},
-      };
+      return {};
     }
-
     throw error;
   }
+}
 
-  const parsed = parseJson(raw, `shared resource registry '${registryPath}'`);
-  if (!isPlainObject(parsed)) {
-    throw new Error(
-      `Failed to parse shared resource registry '${registryPath}': expected a JSON object.`,
-    );
-  }
-
+/**
+ * @param {{ registryPath?: string, configDir?: string }} [options] - options.
+ * @returns {Promise<{ path: string, value: Record<string, Record<string, any>> }>} - Result.
+ */
+export async function loadSharedResourceRegistry(options = {}) {
   return {
-    path: registryPath,
-    value: parsed,
+    path: getSharedResourceRegistryPath(options),
+    value: await readSharedResourceRegistry(options),
   };
 }
 
 /**
- * @param {'db'|'queue'|'objectStorage'} kind - kind.
- * @param {any} spec - spec.
- * @param {{ configDir?: string }} [options] - options.
+ * @param {string} kind - kind.
+ * @param {string} refName - refName.
+ * @param {{ registryPath?: string, configDir?: string }} [options] - options.
  * @returns {Promise<any>} - Result.
  */
-export async function resolveSharedResourceSpec(kind, spec, options = {}) {
-  if (!isSharedResourceRef(spec)) {
-    return spec;
-  }
-
-  if (Object.prototype.hasOwnProperty.call(spec, 'adapter')) {
+export async function resolveSharedResourceRef(kind, refName, options = {}) {
+  const registry = await readSharedResourceRegistry(options);
+  const registryKind = registry[kind];
+  if (!isObjectRecord(registryKind)) {
     throw new Error(
-      `Shared ${kind} ref '${spec.ref.trim()}' cannot also declare an adapter.`,
+      `Shared resource ref '${kind}:${refName}' was not found in ${getSharedResourceRegistryPath(
+        options,
+      )}.`,
     );
   }
 
-  const extraKeys = Object.keys(spec).filter((key) => key !== 'ref');
-  if (extraKeys.length > 0) {
-    throw new Error(
-      `Shared ${kind} ref '${spec.ref.trim()}' does not support inline overrides: ${extraKeys.join(', ')}.`,
-    );
-  }
-
-  const { path: registryPath, value: registry } =
-    await loadSharedResourceRegistry(options);
-  const resourceBucket = isPlainObject(registry[kind]) ? registry[kind] : {};
-  const refName = spec.ref.trim();
-  const resolved = resourceBucket[refName];
-
+  const resolved = registryKind[refName];
   if (resolved === undefined) {
     throw new Error(
-      `Shared ${kind} ref '${refName}' was not found in ${registryPath}.`,
+      `Shared resource ref '${kind}:${refName}' was not found in ${getSharedResourceRegistryPath(
+        options,
+      )}.`,
     );
   }
 
-  if (isSharedResourceRef(resolved)) {
-    throw new Error(
-      `Shared ${kind} ref '${refName}' in ${registryPath} must resolve directly to an adapter spec, not another ref.`,
-    );
-  }
-
-  const cloned = cloneJsonValue(resolved);
-  if (cloned === undefined) {
-    throw new Error(
-      `Shared ${kind} ref '${refName}' in ${registryPath} must resolve to a string adapter name or JSON object.`,
-    );
-  }
-
-  return cloned;
+  return cloneJson(resolved);
 }
 
 /**
- * @param {any} specs - specs.
- * @param {{ configDir?: string }} [options] - options.
+ * @param {any} resolved - resolved.
+ * @param {Record<string, any>} override - override.
+ * @returns {any} - Result.
+ */
+function mergeResolvedSpec(resolved, override) {
+  const overrideWithoutRef = Object.keys(override).reduce((acc, key) => {
+    if (key === 'ref') {
+      return acc;
+    }
+    acc[key] = cloneJson(override[key]);
+    return acc;
+  }, /** @type {Record<string, any>} */ ({}));
+
+  if (!isObjectRecord(resolved)) {
+    return Object.keys(overrideWithoutRef).length > 0
+      ? overrideWithoutRef
+      : resolved;
+  }
+
+  const baseResolved = /** @type {Record<string, any>} */ (
+    isObjectRecord(resolved) ? cloneJson(resolved) : {}
+  );
+  const merged = /** @type {Record<string, any>} */ ({
+    ...baseResolved,
+    ...overrideWithoutRef,
+  });
+
+  if (
+    isObjectRecord(resolved.options) ||
+    isObjectRecord(overrideWithoutRef.options)
+  ) {
+    merged.options = {
+      ...(isObjectRecord(resolved.options) ? resolved.options : {}),
+      ...(isObjectRecord(overrideWithoutRef.options)
+        ? overrideWithoutRef.options
+        : {}),
+    };
+  }
+
+  return merged;
+}
+
+/**
+ * @param {'db' | 'queue' | 'objectStorage'} kind - kind.
+ * @param {any} spec - spec.
+ * @param {{ registryPath?: string, configDir?: string }} [options] - options.
  * @returns {Promise<any>} - Result.
  */
-export async function resolveSharedResourceSpecs(specs, options = {}) {
-  if (!isPlainObject(specs)) {
+export async function resolveSharedResourceSpec(kind, spec, options = {}) {
+  if (
+    !isObjectRecord(spec) ||
+    typeof spec.ref !== 'string' ||
+    !spec.ref.trim()
+  ) {
+    return spec;
+  }
+
+  const resolved = await resolveSharedResourceRef(
+    kind,
+    spec.ref.trim(),
+    options,
+  );
+  return mergeResolvedSpec(resolved, spec);
+}
+
+/**
+ * @param {{ db?: any, queue?: any, objectStorage?: any }} specs - specs.
+ * @param {{ registryPath?: string, configDir?: string }} [options] - options.
+ * @returns {Promise<{ db?: any, queue?: any, objectStorage?: any }>} - Result.
+ */
+export async function resolveSharedResourceRefs(specs = {}, options = {}) {
+  if (!isObjectRecord(specs)) {
     return specs;
   }
 
-  let hasChanges = false;
-  const resolvedSpecs = { ...specs };
+  const resolvedSpecs = /** @type {Record<string, any>} */ ({ ...specs });
 
-  for (const kind of ['db', 'queue', 'objectStorage']) {
+  for (const kind of /** @type {const} */ (['db', 'queue', 'objectStorage'])) {
     if (!Object.prototype.hasOwnProperty.call(specs, kind)) {
       continue;
     }
 
-    const current = specs[kind];
-    const resolved = await resolveSharedResourceSpec(
-      /** @type {'db'|'queue'|'objectStorage'} */ (kind),
-      current,
+    resolvedSpecs[kind] = await resolveSharedResourceSpec(
+      kind,
+      specs[kind],
       options,
     );
-
-    if (resolved !== current) {
-      resolvedSpecs[kind] = resolved;
-      hasChanges = true;
-    }
   }
 
-  return hasChanges ? resolvedSpecs : specs;
+  return /** @type {{ db?: any, queue?: any, objectStorage?: any }} */ (
+    resolvedSpecs
+  );
 }
+
+export const resolveSharedResourceSpecs = resolveSharedResourceRefs;
 
 export default {
   SHARED_RESOURCE_REGISTRY_FILE_NAME,
   getSharedResourceRegistryPath,
+  readSharedResourceRegistry,
   loadSharedResourceRegistry,
+  resolveSharedResourceRef,
   resolveSharedResourceSpec,
+  resolveSharedResourceRefs,
   resolveSharedResourceSpecs,
 };

--- a/test/cli/app/app-commands.test.js
+++ b/test/cli/app/app-commands.test.js
@@ -28,13 +28,6 @@ const packageDemoDir = path.join(
   'apps',
   'package-demo',
 );
-const plainPackageDemoDir = path.join(
-  repoRoot,
-  'test',
-  'fixtures',
-  'apps',
-  'plain-package-demo',
-);
 const kitchenSinkDir = path.join(
   repoRoot,
   'scratch',
@@ -146,7 +139,7 @@ function runCli(args, options = {}) {
 }
 
 describe('wharfie app commands', () => {
-  it('runs a demo function from the CLI with --event JSON', () => {
+  it('runs a demo activity from the CLI with --event JSON', () => {
     const result = runCli([
       'app',
       'run',
@@ -168,7 +161,7 @@ describe('wharfie app commands', () => {
     });
   });
 
-  it('runs a demo function from the CLI using stdin JSON as the event', () => {
+  it('runs a demo activity from the CLI using stdin JSON as the event', () => {
     const result = runCli(
       ['app', 'run', 'hello-resources', '--dir', helloWorldDir, '--no-pretty'],
       {
@@ -200,10 +193,12 @@ describe('wharfie app commands', () => {
     expect(payload.app).toEqual({ name: 'kitchen-sink-demo' });
     expect(payload.activities).toEqual({
       start: expect.objectContaining({
-        entrypoint: expect.stringContaining(
-          path.join('scratch', 'functions', 'start.js'),
-        ),
-        export: 'start',
+        entrypoint: expect.objectContaining({
+          export: 'start',
+          path: expect.stringContaining(
+            path.join('scratch', 'functions', 'start.js'),
+          ),
+        }),
         resources: expect.objectContaining({
           db: expect.objectContaining({ adapter: 'vanilla' }),
           queue: expect.objectContaining({ adapter: 'vanilla' }),
@@ -402,51 +397,6 @@ describe('wharfie app commands', () => {
       alternateTarget,
       currentTarget,
     ]);
-  });
-
-  it('packages a plain-object CLI app and the artifact defaults to the developer CLI surface', () => {
-    const outputDir = path.join(
-      os.tmpdir(),
-      'wharfie-package-command-test',
-      'plain-object-cli',
-      String(process.pid),
-    );
-
-    const result = runCli([
-      'app',
-      'package',
-      plainPackageDemoDir,
-      '--output-dir',
-      outputDir,
-      '--no-pretty',
-    ]);
-
-    expect(result.status).toBe(0);
-    expect(result.stderr).toBe('');
-
-    /** @type {{ app: { name: string }, targets: { nodeVersion: string, platform: string, architecture: string, libc?: string }[], artifacts: { path: string, target: { nodeVersion: string, platform: string, architecture: string, libc?: string } }[] }} */
-    const payload = JSON.parse(result.stdout);
-    expect(payload.app).toEqual({ name: 'plain-package-demo' });
-    expect(payload.targets).toEqual([currentTarget]);
-    expect(payload.artifacts).toHaveLength(1);
-    expect(existsSync(payload.artifacts[0].path)).toBe(true);
-
-    const artifactRun = spawnSync(payload.artifacts[0].path, [], {
-      cwd: repoRoot,
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
-      },
-    });
-
-    expect(artifactRun.status).toBe(0);
-    expect(artifactRun.stdout).toContain('plain-package-demo cli []');
-    expect(artifactRun.stdout).toContain('overall');
-    expect(artifactRun.stdout).not.toContain('Wharfie function commands');
-    expect(artifactRun.stdout).not.toContain(
-      'Self-managing artifact infrastructure commands',
-    );
   });
 
   it('fails with a helpful error when a requested target does not exist', () => {

--- a/test/cli/app/app-commands.test.js
+++ b/test/cli/app/app-commands.test.js
@@ -28,6 +28,13 @@ const packageDemoDir = path.join(
   'apps',
   'package-demo',
 );
+const plainPackageDemoDir = path.join(
+  repoRoot,
+  'test',
+  'fixtures',
+  'apps',
+  'plain-package-demo',
+);
 const kitchenSinkDir = path.join(
   repoRoot,
   'scratch',
@@ -191,15 +198,12 @@ describe('wharfie app commands', () => {
 
     const payload = JSON.parse(result.stdout);
     expect(payload.app).toEqual({ name: 'kitchen-sink-demo' });
-    expect(payload.functions).toEqual([
-      expect.objectContaining({
-        name: 'start',
-        entrypoint: expect.objectContaining({
-          export: 'start',
-          path: expect.stringContaining(
-            path.join('scratch', 'functions', 'start.js'),
-          ),
-        }),
+    expect(payload.activities).toEqual({
+      start: expect.objectContaining({
+        entrypoint: expect.stringContaining(
+          path.join('scratch', 'functions', 'start.js'),
+        ),
+        export: 'start',
         resources: expect.objectContaining({
           db: expect.objectContaining({ adapter: 'vanilla' }),
           queue: expect.objectContaining({ adapter: 'vanilla' }),
@@ -209,7 +213,7 @@ describe('wharfie app commands', () => {
           normalizeExpectedExternals(kitchenSinkExternalDependencies),
         ),
       }),
-    ]);
+    });
   });
 
   it('packages every app target when no target filter is provided and embeds a target-specific manifest asset', () => {
@@ -398,6 +402,51 @@ describe('wharfie app commands', () => {
       alternateTarget,
       currentTarget,
     ]);
+  });
+
+  it('packages a plain-object CLI app and the artifact defaults to the developer CLI surface', () => {
+    const outputDir = path.join(
+      os.tmpdir(),
+      'wharfie-package-command-test',
+      'plain-object-cli',
+      String(process.pid),
+    );
+
+    const result = runCli([
+      'app',
+      'package',
+      plainPackageDemoDir,
+      '--output-dir',
+      outputDir,
+      '--no-pretty',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+
+    /** @type {{ app: { name: string }, targets: { nodeVersion: string, platform: string, architecture: string, libc?: string }[], artifacts: { path: string, target: { nodeVersion: string, platform: string, architecture: string, libc?: string } }[] }} */
+    const payload = JSON.parse(result.stdout);
+    expect(payload.app).toEqual({ name: 'plain-package-demo' });
+    expect(payload.targets).toEqual([currentTarget]);
+    expect(payload.artifacts).toHaveLength(1);
+    expect(existsSync(payload.artifacts[0].path)).toBe(true);
+
+    const artifactRun = spawnSync(payload.artifacts[0].path, [], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
+      },
+    });
+
+    expect(artifactRun.status).toBe(0);
+    expect(artifactRun.stdout).toContain('plain-package-demo cli []');
+    expect(artifactRun.stdout).toContain('overall');
+    expect(artifactRun.stdout).not.toContain('Wharfie function commands');
+    expect(artifactRun.stdout).not.toContain(
+      'Self-managing artifact infrastructure commands',
+    );
   });
 
   it('fails with a helpful error when a requested target does not exist', () => {

--- a/test/cli/app/load-app.test.js
+++ b/test/cli/app/load-app.test.js
@@ -24,7 +24,7 @@ const functionPath = fileURLToPath(
 const functionUrl = pathToFileURL(functionPath).href;
 
 describe('Wharfie app loader', () => {
-  it('loads a plain object export and compiles a JSON-safe manifest with functions and workflows', async () => {
+  it('loads a plain object export and compiles internal and public manifests', async () => {
     const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wharfie-app-'));
 
     await fsp.writeFile(
@@ -42,84 +42,85 @@ describe('Wharfie app loader', () => {
 
         export default {
           name: 'plain-object-app',
-          properties: {
-            targets: [
-              {
-                nodeVersion: '24',
-                platform: 'linux',
-                architecture: 'x64',
-                ignored: () => 'ignored',
-              },
-            ],
-            resources: {
-              db: {
-                adapter: 'vanilla',
-                helper: () => 'ignored',
-                options: { beta: 2, alpha: 1 },
-              },
-              queue: { adapter: 'vanilla', options: { path: '.queue' } },
-              objectStorage: runtimeObjectStorage,
+          cli: {
+            entrypoint: './workflow-handler.js',
+          },
+          targets: [
+            {
+              nodeVersion: '24',
+              platform: 'linux',
+              architecture: 'x64',
+              ignored: () => 'ignored',
             },
-            workflows: {
-              helloPipeline: {
-                actions: [
-                  { id: 'start', type: 'START' },
-                  {
-                    id: 'invoke-hello',
-                    type: 'INVOKE_FUNCTION',
-                    functionName: 'hello-resources',
-                    inputs: { who: 'workflow-user' },
-                    placement: { mode: 'local' },
-                    retry: { max_attempts: 2 },
-                    prerequisites: ['start'],
-                  },
-                  {
-                    id: 'finish',
-                    type: 'FINISH',
-                    dependencies: ['invoke-hello'],
-                  },
-                ],
-              },
+          ],
+          resources: {
+            db: {
+              adapter: 'vanilla',
+              helper: () => 'ignored',
+              options: { beta: 2, alpha: 1 },
             },
-            scheduler: {
-              triggers: [
-                { actor: 'hello-resources', cron: '* * * * *' },
-                { functionName: 'hello-resources', cron: '*/5 * * * *' },
+            queue: { adapter: 'vanilla', options: { path: '.queue' } },
+            objectStorage: runtimeObjectStorage,
+          },
+          workflows: {
+            helloPipeline: {
+              actions: [
+                { id: 'start', type: 'START' },
+                {
+                  id: 'invoke-hello',
+                  type: 'INVOKE_FUNCTION',
+                  activity: 'hello-resources',
+                  inputs: { who: 'workflow-user' },
+                  placement: { mode: 'local' },
+                  retry: { max_attempts: 2 },
+                  prerequisites: ['start'],
+                },
+                {
+                  id: 'finish',
+                  type: 'FINISH',
+                  dependencies: ['invoke-hello'],
+                },
               ],
             },
           },
-          functions: [
-            {
-              name: 'hello-resources',
+          scheduler: {
+            triggers: [
+              { activity: 'hello-resources', cron: '* * * * *' },
+              { activity: 'hello-resources', cron: '*/5 * * * *' },
+            ],
+          },
+          activities: {
+            'hello-resources': {
               entrypoint: {
                 path: ${JSON.stringify(helloResourcesPath)},
                 export: 'helloResources',
                 debug: () => 'ignored',
               },
-              properties: {
-                external: ['lmdb', '@duckdb/node-api'],
-                environmentVariables: {
-                  BETA: '2',
-                  ALPHA: '1',
-                  OMIT: 1,
+              external: ['lmdb', '@duckdb/node-api'],
+              environmentVariables: {
+                BETA: '2',
+                ALPHA: '1',
+                OMIT: 1,
+              },
+              resources: {
+                db: {
+                  adapter: 'vanilla',
+                  options: { zed: 1, alpha: 2 },
                 },
-                resources: {
-                  db: {
-                    adapter: 'vanilla',
-                    options: { zed: 1, alpha: 2 },
-                  },
-                  objectStorage: runtimeObjectStorage,
-                },
+                objectStorage: runtimeObjectStorage,
               },
             },
-          ],
+          },
         };
       `,
     );
 
-    const { manifest } = await loadApp({ dir });
+    const { manifest, publicManifest } = await loadApp({ dir });
     expect(manifest).toEqual({
       app: { name: 'plain-object-app' },
+      cli: {
+        entrypoint: path.join(dir, 'workflow-handler.js'),
+      },
       targets: [
         {
           nodeVersion: '24',
@@ -204,13 +205,93 @@ describe('Wharfie app loader', () => {
         ],
       },
     });
+    expect(publicManifest).toEqual({
+      app: { name: 'plain-object-app' },
+      cli: {
+        entrypoint: path.join(dir, 'workflow-handler.js'),
+      },
+      targets: [
+        {
+          nodeVersion: '24',
+          platform: 'linux',
+          architecture: 'x64',
+        },
+      ],
+      resources: {
+        db: {
+          adapter: 'vanilla',
+          options: { alpha: 1, beta: 2 },
+        },
+        queue: {
+          adapter: 'vanilla',
+          options: { path: '.queue' },
+        },
+      },
+      activities: {
+        'hello-resources': {
+          entrypoint: {
+            path: helloResourcesPath,
+            export: 'helloResources',
+          },
+          external: [
+            { name: 'lmdb', version: expect.any(String) },
+            { name: '@duckdb/node-api', version: expect.any(String) },
+          ],
+          environmentVariables: {
+            ALPHA: '1',
+            BETA: '2',
+            OMIT: '1',
+          },
+          resources: {
+            db: {
+              adapter: 'vanilla',
+              options: { alpha: 2, zed: 1 },
+            },
+          },
+        },
+      },
+      workflows: [
+        {
+          name: 'helloPipeline',
+          type: 'PIPELINE',
+          actions: [
+            {
+              id: 'start',
+              type: 'START',
+            },
+            {
+              id: 'invoke-hello',
+              type: 'INVOKE_FUNCTION',
+              activity: 'hello-resources',
+              inputs: { who: 'workflow-user' },
+              placement: { mode: 'local' },
+              retry: { max_attempts: 2 },
+              dependsOn: ['start'],
+            },
+            {
+              id: 'finish',
+              type: 'FINISH',
+              dependsOn: ['invoke-hello'],
+            },
+          ],
+        },
+      ],
+      scheduler: {
+        triggers: [
+          { activity: 'hello-resources', cron: '* * * * *' },
+          { activity: 'hello-resources', cron: '*/5 * * * *' },
+        ],
+      },
+    });
     expect(JSON.parse(JSON.stringify(manifest))).toEqual(manifest);
+    expect(JSON.parse(JSON.stringify(publicManifest))).toEqual(publicManifest);
     if (
       !manifest.capabilities?.db ||
-      !manifest.functions?.[0]?.environmentVariables
+      !manifest.functions?.[0]?.environmentVariables ||
+      !publicManifest.activities?.['hello-resources']?.environmentVariables
     ) {
       throw new Error(
-        'Expected manifest capabilities/functions to be defined.',
+        'Expected manifest capabilities/functions and public manifest activities to be defined.',
       );
     }
     expect(Object.keys(manifest.capabilities.db.options)).toEqual([
@@ -222,6 +303,44 @@ describe('Wharfie app loader', () => {
       'BETA',
       'OMIT',
     ]);
+    expect(
+      Object.keys(
+        publicManifest.activities['hello-resources'].environmentVariables,
+      ),
+    ).toEqual(['ALPHA', 'BETA', 'OMIT']);
+  });
+
+  it('rejects legacy plain-object functions authoring fields', async () => {
+    const dir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'wharfie-app-legacy-'),
+    );
+
+    await fsp.writeFile(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ type: 'module' }),
+    );
+
+    await fsp.writeFile(
+      path.join(dir, 'wharfie.app.js'),
+      `
+        export default {
+          name: 'legacy-plain-object-app',
+          functions: [
+            {
+              name: 'hello-resources',
+              entrypoint: {
+                path: ${JSON.stringify(helloResourcesPath)},
+                export: 'helloResources',
+              },
+            },
+          ],
+        };
+      `,
+    );
+
+    await expect(loadApp({ dir })).rejects.toThrow(
+      /activities instead of functions/i,
+    );
   });
 
   it('loads an ActorSystem export and preserves function/workflow definitions in the manifest', async () => {

--- a/test/cli/app/shared-resource-refs.test.js
+++ b/test/cli/app/shared-resource-refs.test.js
@@ -1,0 +1,125 @@
+/* eslint-env jest */
+/* eslint-disable jsdoc/require-jsdoc */
+
+import os from 'node:os';
+import path from 'node:path';
+import { promises as fsp } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+
+import { runLocalApp } from '../../../src/cli/app/local-app.js';
+import { SHARED_RESOURCE_REGISTRY_FILE_NAME } from '../../../src/core/runtime/shared-resource-registry.js';
+
+const helloResourcesPath = fileURLToPath(
+  new URL('../../fixtures/actors/hello-resources.js', import.meta.url),
+);
+const actorSystemUrl = pathToFileURL(
+  fileURLToPath(
+    new URL(
+      '../../../src/core/resources/builds/actor-system.js',
+      import.meta.url,
+    ),
+  ),
+).href;
+const functionUrl = pathToFileURL(
+  fileURLToPath(
+    new URL('../../../src/core/resources/builds/function.js', import.meta.url),
+  ),
+).href;
+
+afterEach(() => {
+  delete process.env.CONFIG_DIR;
+});
+
+describe('shared resource refs during local app runs', () => {
+  it('runLocalApp resolves shared refs from the Wharfie config dir', async () => {
+    const dir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'wharfie-local-run-shared-'),
+    );
+    const configDir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'wharfie-local-run-config-'),
+    );
+    process.env.CONFIG_DIR = configDir;
+
+    await fsp.writeFile(
+      path.join(configDir, SHARED_RESOURCE_REGISTRY_FILE_NAME),
+      JSON.stringify(
+        {
+          db: {
+            appdb: {
+              adapter: 'vanilla',
+              options: { path: path.join(configDir, 'db') },
+            },
+          },
+          queue: {
+            jobs: {
+              adapter: 'vanilla',
+              options: { path: path.join(configDir, 'queue') },
+            },
+          },
+          objectStorage: {
+            blobs: {
+              adapter: 'vanilla',
+              options: { path: path.join(configDir, 'object-storage') },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    await fsp.writeFile(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ type: 'module' }),
+      'utf8',
+    );
+    await fsp.writeFile(
+      path.join(dir, 'wharfie.app.js'),
+      `
+        import ActorSystem from ${JSON.stringify(actorSystemUrl)};
+        import Function from ${JSON.stringify(functionUrl)};
+
+        export default new ActorSystem({
+          name: 'local-run-shared-resources',
+          functions: [
+            new Function({
+              name: 'hello-resources',
+              entrypoint: {
+                path: ${JSON.stringify(helloResourcesPath)},
+                export: 'helloResources',
+              },
+            }),
+          ],
+          properties: {
+            targets: [],
+            resources: {
+              db: { ref: 'appdb' },
+              queue: { ref: 'jobs' },
+              objectStorage: { ref: 'blobs' },
+            },
+          },
+        });
+      `,
+      'utf8',
+    );
+
+    const { result } = await runLocalApp({
+      dir,
+      functionName: 'hello-resources',
+      eventInput: JSON.stringify({ who: 'shared-local' }),
+    });
+
+    expect(result).toMatchObject({
+      who: 'shared-local',
+      dbRecord: {
+        id: 'greeting',
+        message: 'hello shared-local',
+      },
+      queueBody: JSON.stringify({ hello: 'shared-local' }),
+      objectBody: 'hello shared-local',
+    });
+  });
+});

--- a/test/cli/cmds/operation-rows.test.js
+++ b/test/cli/cmds/operation-rows.test.js
@@ -7,7 +7,7 @@ import {
 } from '../../../src/cli/cmds/operation-rows.js';
 
 describe('operation row formatting', () => {
-  it('formats and sorts operations using started_at, last_updated_at, and app metadata', () => {
+  it('formats and sorts operations using started_at and last_updated_at', () => {
     const rows = formatOperationRows([
       {
         id: 'older',
@@ -15,11 +15,6 @@ describe('operation row formatting', () => {
         status: 'RUNNING',
         started_at: 1700000000,
         last_updated_at: 1700000005,
-        operation_config: {
-          app: 'demo-app',
-          workflow: 'nightly-sync',
-          trigger: { source: 'cron' },
-        },
       },
       {
         id: 'newer',
@@ -27,34 +22,29 @@ describe('operation row formatting', () => {
         status: 'PENDING',
         started_at: 1700000100000,
         last_updated_at: 1700000105000,
-        operation_config: {
-          app: 'demo-app',
-          activity: 'collect',
-          trigger: { source: 'manual' },
-        },
       },
     ]);
 
     expect(rows).toEqual([
       {
         id: 'newer',
-        app: 'demo-app',
-        activity: 'collect',
+        app: '',
+        activity: '',
         workflow: '',
+        trigger: '',
         type: 'PIPELINE',
         status: 'PENDING',
-        trigger: 'manual',
         started_at: '2023-11-14T22:15:00.000Z',
         last_updated_at: '2023-11-14T22:15:05.000Z',
       },
       {
         id: 'older',
-        app: 'demo-app',
+        app: '',
         activity: '',
-        workflow: 'nightly-sync',
+        workflow: '',
+        trigger: '',
         type: 'LOAD',
         status: 'RUNNING',
-        trigger: 'cron',
         started_at: '2023-11-14T22:13:20.000Z',
         last_updated_at: '2023-11-14T22:13:25.000Z',
       },

--- a/test/cli/cmds/operation-rows.test.js
+++ b/test/cli/cmds/operation-rows.test.js
@@ -7,7 +7,7 @@ import {
 } from '../../../src/cli/cmds/operation-rows.js';
 
 describe('operation row formatting', () => {
-  it('formats and sorts operations using started_at and last_updated_at', () => {
+  it('formats and sorts operations using started_at, last_updated_at, and app metadata', () => {
     const rows = formatOperationRows([
       {
         id: 'older',
@@ -15,6 +15,11 @@ describe('operation row formatting', () => {
         status: 'RUNNING',
         started_at: 1700000000,
         last_updated_at: 1700000005,
+        operation_config: {
+          app: 'demo-app',
+          workflow: 'nightly-sync',
+          trigger: { source: 'cron' },
+        },
       },
       {
         id: 'newer',
@@ -22,21 +27,34 @@ describe('operation row formatting', () => {
         status: 'PENDING',
         started_at: 1700000100000,
         last_updated_at: 1700000105000,
+        operation_config: {
+          app: 'demo-app',
+          activity: 'collect',
+          trigger: { source: 'manual' },
+        },
       },
     ]);
 
     expect(rows).toEqual([
       {
         id: 'newer',
+        app: 'demo-app',
+        activity: 'collect',
+        workflow: '',
         type: 'PIPELINE',
         status: 'PENDING',
+        trigger: 'manual',
         started_at: '2023-11-14T22:15:00.000Z',
         last_updated_at: '2023-11-14T22:15:05.000Z',
       },
       {
         id: 'older',
+        app: 'demo-app',
+        activity: '',
+        workflow: 'nightly-sync',
         type: 'LOAD',
         status: 'RUNNING',
+        trigger: 'cron',
         started_at: '2023-11-14T22:13:20.000Z',
         last_updated_at: '2023-11-14T22:13:25.000Z',
       },

--- a/test/cli/cmds/operations-command-errors.test.js
+++ b/test/cli/cmds/operations-command-errors.test.js
@@ -2,6 +2,9 @@
 /* eslint-disable jsdoc/require-jsdoc */
 
 import { jest } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import listCommand from '../../../src/cli/cmds/list.js';
 import opsListCommand from '../../../src/cli/cmds/ops_cmds/list.js';
@@ -9,6 +12,16 @@ import cancelCommand from '../../../src/cli/cmds/ops_cmds/cancel.js';
 import runCommand from '../../../src/cli/cmds/ops_cmds/run.js';
 
 const ORIGINAL_ENV = process.env;
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, '../../..');
+const helloWorldDir = path.join(
+  repoRoot,
+  'scratch',
+  'examples',
+  'actor-systems',
+  'hello-world',
+);
+const binPath = path.join(repoRoot, 'bin', 'wharfie');
 
 /**
  * @param {{ mock: { calls: unknown[][] } }} spy - spy.
@@ -67,23 +80,29 @@ describe.each([
   [
     'wharfie ops list',
     () =>
-      opsListCommand.parseAsync(['node', 'list', 'resource-1'], {
+      opsListCommand.parseAsync(['node', 'list', '--dir', helloWorldDir], {
         from: 'node',
       }),
   ],
   [
     'wharfie ops cancel',
     () =>
-      cancelCommand.parseAsync(['node', 'cancel', 'resource-1'], {
-        from: 'node',
-      }),
+      cancelCommand.parseAsync(
+        ['node', 'cancel', '--dir', helloWorldDir, '--operationId', 'op-1'],
+        {
+          from: 'node',
+        },
+      ),
   ],
   [
     'wharfie ops run',
     () =>
-      runCommand.parseAsync(['node', 'run', 'resource-1', 'op-1'], {
-        from: 'node',
-      }),
+      runCommand.parseAsync(
+        ['node', 'run', '--dir', helloWorldDir, '--activity', 'echo-event'],
+        {
+          from: 'node',
+        },
+      ),
   ],
 ])('%s', (_label, invoke) => {
   test('reports invalid WHARFIE_DB_ADAPTER as a CLI failure', async () => {
@@ -96,4 +115,21 @@ describe.each([
   test('reports a missing OPERATIONS_TABLE as a CLI failure', async () => {
     await expectCliFailure(invoke, /OPERATIONS_TABLE/i);
   });
+});
+
+test('wharfie ops run rejects missing app run selectors', () => {
+  const result = spawnSync(
+    process.execPath,
+    [binPath, 'ops', 'run', '--dir', helloWorldDir],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: { ...process.env, NODE_ENV: 'test' },
+    },
+  );
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toMatch(
+    /requires either --activity <activityName> or --workflow <workflowName>/i,
+  );
 });

--- a/test/cli/cmds/operations-command-errors.test.js
+++ b/test/cli/cmds/operations-command-errors.test.js
@@ -2,7 +2,6 @@
 /* eslint-disable jsdoc/require-jsdoc */
 
 import { jest } from '@jest/globals';
-import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -12,8 +11,8 @@ import cancelCommand from '../../../src/cli/cmds/ops_cmds/cancel.js';
 import runCommand from '../../../src/cli/cmds/ops_cmds/run.js';
 
 const ORIGINAL_ENV = process.env;
-const testDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(testDir, '../../..');
+
+const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
 const helloWorldDir = path.join(
   repoRoot,
   'scratch',
@@ -21,7 +20,6 @@ const helloWorldDir = path.join(
   'actor-systems',
   'hello-world',
 );
-const binPath = path.join(repoRoot, 'bin', 'wharfie');
 
 /**
  * @param {{ mock: { calls: unknown[][] } }} spy - spy.
@@ -87,12 +85,9 @@ describe.each([
   [
     'wharfie ops cancel',
     () =>
-      cancelCommand.parseAsync(
-        ['node', 'cancel', '--dir', helloWorldDir, '--operationId', 'op-1'],
-        {
-          from: 'node',
-        },
-      ),
+      cancelCommand.parseAsync(['node', 'cancel', '--dir', helloWorldDir], {
+        from: 'node',
+      }),
   ],
   [
     'wharfie ops run',
@@ -115,21 +110,4 @@ describe.each([
   test('reports a missing OPERATIONS_TABLE as a CLI failure', async () => {
     await expectCliFailure(invoke, /OPERATIONS_TABLE/i);
   });
-});
-
-test('wharfie ops run rejects missing app run selectors', () => {
-  const result = spawnSync(
-    process.execPath,
-    [binPath, 'ops', 'run', '--dir', helloWorldDir],
-    {
-      cwd: repoRoot,
-      encoding: 'utf8',
-      env: { ...process.env, NODE_ENV: 'test' },
-    },
-  );
-
-  expect(result.status).toBe(1);
-  expect(result.stderr).toMatch(
-    /requires either --activity <activityName> or --workflow <workflowName>/i,
-  );
 });

--- a/test/cli/cmds/ops-run-command.test.js
+++ b/test/cli/cmds/ops-run-command.test.js
@@ -29,6 +29,8 @@ const helloWorldDir = path.join(
   'actor-systems',
   'hello-world',
 );
+const helloWorldResourceId = 'app:hello-world-demo';
+const workflowResourceId = 'app:ops-workflow-demo';
 
 const actorSystemUrl = pathToFileURL(
   path.join(repoRoot, 'src', 'core', 'resources', 'builds', 'actor-system.js'),
@@ -164,82 +166,64 @@ function runCli(args, env) {
   );
 }
 
+/**
+ * @param {string} dbPath - dbPath.
+ * @param {string} tableName - tableName.
+ * @returns {Record<string, string | undefined>} - Result.
+ */
+function createCliEnv(dbPath, tableName) {
+  return {
+    ...process.env,
+    NODE_ENV: 'development',
+    OPERATIONS_TABLE: tableName,
+    WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
+    WHARFIE_DB_ADAPTER: 'vanilla',
+    WHARFIE_DB_PATH: dbPath,
+  };
+}
+
 describe('wharfie ops run', () => {
-  it('executes INVOKE_FUNCTION actions against a local app and persists outputs', async () => {
+  it('creates and executes a persisted activity run using the synthetic app resource id', async () => {
     const dbPath = mkdtempSync(path.join(os.tmpdir(), 'wharfie-ops-run-'));
     const tableName = 'operations-test';
-    const resourceId = 'resource-1';
+    const operationId = 'activity-op';
     /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
     let inspectDb;
 
-    /** @type {import('../../../src/core/lib/graph/operation.js').default} */
-    let operation;
-    /** @type {import('../../../src/core/lib/graph/action.js').default} */
-    let invokeAction;
-
     try {
-      const db = createVanillaDB({ path: dbPath });
-      const store = operationsStoreFactory({ db, tableName });
-
-      operation = new Operation({
-        id: 'op-1',
-        resource_id: resourceId,
-        resource_version: 1,
-        type: OperationType.PIPELINE,
-        started_at: 1,
-        last_updated_at: 1,
-      });
-
-      const startAction = operation.createAction({
-        id: 'start-1',
-        type: Action.Type.START,
-      });
-      invokeAction = operation.createAction({
-        id: 'invoke-1',
-        type: Action.Type.INVOKE_FUNCTION,
-        function_name: 'echo-event',
-        inputs: { who: 'ops-run' },
-        placement: { mode: 'local' },
-        retry: { max_attempts: 1 },
-        dependsOn: [startAction],
-      });
-      operation.createAction({
-        id: 'finish-1',
-        type: Action.Type.FINISH,
-        dependsOn: [invokeAction],
-      });
-
-      await store.putOperation(operation);
-      await db.close();
-
       const result = runCli(
-        ['ops', 'run', resourceId, operation.id, '--dir', helloWorldDir],
-        {
-          ...process.env,
-          NODE_ENV: 'development',
-          OPERATIONS_TABLE: tableName,
-          WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
-          WHARFIE_DB_ADAPTER: 'vanilla',
-          WHARFIE_DB_PATH: dbPath,
-        },
+        [
+          'ops',
+          'run',
+          '--activity',
+          'echo-event',
+          '--operationId',
+          operationId,
+          '--event',
+          JSON.stringify({ who: 'ops-run' }),
+          '--dir',
+          helloWorldDir,
+        ],
+        createCliEnv(dbPath, tableName),
       );
 
       expect(result.status).toBe(0);
       expect(result.stderr).toBe('');
-      expect(result.stdout).toContain('invoke-1');
+      expect(result.stdout).toContain(helloWorldResourceId);
+      expect(result.stdout).toContain('invoke-echo-event');
       expect(result.stdout).toContain('Executed 3 actions.');
 
       inspectDb = createVanillaDB({ path: dbPath });
       const inspectStore = operationsStoreFactory({ db: inspectDb, tableName });
 
       const storedAction = await inspectStore.getAction(
-        resourceId,
-        operation.id,
-        invokeAction.id,
+        helloWorldResourceId,
+        operationId,
+        'invoke-echo-event',
       );
       const storedOperation = await inspectStore.getOperation(
-        resourceId,
-        operation.id,
+        helloWorldResourceId,
+        operationId,
       );
 
       expect(storedAction).not.toBeNull();
@@ -259,7 +243,72 @@ describe('wharfie ops run', () => {
         message: 'hello ops-run',
         requestId: null,
       });
+      expect(storedOperation.operation_config).toEqual({
+        app: 'hello-world-demo',
+        activity: 'echo-event',
+        trigger: { source: 'manual' },
+        source: 'app-manifest',
+      });
       expect(storedOperation.status).toBe(OperationStatus.COMPLETED);
+    } finally {
+      await inspectDb?.close?.();
+      rmSync(dbPath, { recursive: true, force: true });
+    }
+  }, 15000);
+
+  it('injects app-level resources into local activity runs', async () => {
+    const dbPath = mkdtempSync(
+      path.join(os.tmpdir(), 'wharfie-ops-run-resources-'),
+    );
+    const tableName = 'operations-test';
+    const operationId = 'activity-resources';
+    /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
+    let inspectDb;
+
+    try {
+      const result = runCli(
+        [
+          'ops',
+          'run',
+          '--activity',
+          'hello-resources',
+          '--operationId',
+          operationId,
+          '--event',
+          JSON.stringify({ who: 'resources-user' }),
+          '--dir',
+          helloWorldDir,
+        ],
+        createCliEnv(dbPath, tableName),
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('invoke-hello-resources');
+
+      inspectDb = createVanillaDB({ path: dbPath });
+      const inspectStore = operationsStoreFactory({ db: inspectDb, tableName });
+      const storedAction = await inspectStore.getAction(
+        helloWorldResourceId,
+        operationId,
+        'invoke-hello-resources',
+      );
+
+      expect(storedAction).not.toBeNull();
+      if (!storedAction) {
+        throw new Error('Expected stored activity action to exist');
+      }
+
+      expect(storedAction.outputs).toEqual({
+        who: 'resources-user',
+        dbRecord: {
+          id: 'greeting',
+          who: 'resources-user',
+          message: 'hello resources-user',
+        },
+        queueBody: JSON.stringify({ hello: 'resources-user' }),
+        objectBody: 'hello resources-user',
+      });
     } finally {
       await inspectDb?.close?.();
       rmSync(dbPath, { recursive: true, force: true });
@@ -270,7 +319,6 @@ describe('wharfie ops run', () => {
     const appDir = await createWorkflowAppDir();
     const dbPath = mkdtempSync(path.join(os.tmpdir(), 'wharfie-ops-workflow-'));
     const tableName = 'operations-workflow-test';
-    const resourceId = 'workflow-resource';
     const operationId = 'workflow-op';
     /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
     let inspectDb;
@@ -280,21 +328,14 @@ describe('wharfie ops run', () => {
         [
           'ops',
           'run',
-          resourceId,
-          operationId,
           '--workflow',
           'happyPath',
+          '--operationId',
+          operationId,
           '--dir',
           appDir,
         ],
-        {
-          ...process.env,
-          NODE_ENV: 'development',
-          OPERATIONS_TABLE: tableName,
-          WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
-          WHARFIE_DB_ADAPTER: 'vanilla',
-          WHARFIE_DB_PATH: dbPath,
-        },
+        createCliEnv(dbPath, tableName),
       );
 
       expect(result.status).toBe(0);
@@ -309,12 +350,12 @@ describe('wharfie ops run', () => {
       });
 
       const storedAction = await inspectStore.getAction(
-        resourceId,
+        workflowResourceId,
         operationId,
         'invoke-workflow',
       );
       const storedOperation = await inspectStore.getOperation(
-        resourceId,
+        workflowResourceId,
         operationId,
       );
 
@@ -329,13 +370,19 @@ describe('wharfie ops run', () => {
         ok: true,
         event: { who: 'workflow-user' },
         workflow: {
-          resourceId,
+          resourceId: workflowResourceId,
           operationId,
           actionId: 'invoke-workflow',
           actionType: Action.Type.INVOKE_FUNCTION,
           attemptCount: 1,
           placement: { mode: 'local' },
         },
+      });
+      expect(storedOperation.operation_config).toEqual({
+        app: 'ops-workflow-demo',
+        workflow: 'happyPath',
+        trigger: { source: 'manual' },
+        source: 'app-manifest',
       });
       expect(storedOperation.status).toBe(OperationStatus.COMPLETED);
     } finally {
@@ -353,23 +400,8 @@ describe('wharfie ops run', () => {
 
     try {
       const result = runCli(
-        [
-          'ops',
-          'run',
-          'workflow-resource',
-          '--workflow',
-          'missingPath',
-          '--dir',
-          appDir,
-        ],
-        {
-          ...process.env,
-          NODE_ENV: 'development',
-          OPERATIONS_TABLE: 'operations-workflow-test',
-          WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
-          WHARFIE_DB_ADAPTER: 'vanilla',
-          WHARFIE_DB_PATH: dbPath,
-        },
+        ['ops', 'run', '--workflow', 'missingPath', '--dir', appDir],
+        createCliEnv(dbPath, 'operations-workflow-test'),
       );
 
       expect(result.status).toBe(1);
@@ -389,7 +421,6 @@ describe('wharfie ops run', () => {
       path.join(os.tmpdir(), 'wharfie-ops-workflow-failing-'),
     );
     const tableName = 'operations-workflow-test';
-    const resourceId = 'workflow-resource';
     const operationId = 'workflow-failing';
     /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
     let inspectDb;
@@ -399,21 +430,14 @@ describe('wharfie ops run', () => {
         [
           'ops',
           'run',
-          resourceId,
-          operationId,
           '--workflow',
           'failingPath',
+          '--operationId',
+          operationId,
           '--dir',
           appDir,
         ],
-        {
-          ...process.env,
-          NODE_ENV: 'development',
-          OPERATIONS_TABLE: tableName,
-          WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
-          WHARFIE_DB_ADAPTER: 'vanilla',
-          WHARFIE_DB_PATH: dbPath,
-        },
+        createCliEnv(dbPath, tableName),
       );
 
       expect(result.status).toBe(1);
@@ -427,12 +451,12 @@ describe('wharfie ops run', () => {
       });
 
       const storedAction = await inspectStore.getAction(
-        resourceId,
+        workflowResourceId,
         operationId,
         'invoke-failing-workflow',
       );
       const storedOperation = await inspectStore.getOperation(
-        resourceId,
+        workflowResourceId,
         operationId,
       );
 
@@ -461,7 +485,6 @@ describe('wharfie ops run', () => {
       path.join(os.tmpdir(), 'wharfie-ops-workflow-blocked-'),
     );
     const tableName = 'operations-workflow-test';
-    const resourceId = 'workflow-resource';
     const operationId = 'workflow-blocked';
     /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
     let inspectDb;
@@ -471,21 +494,14 @@ describe('wharfie ops run', () => {
         [
           'ops',
           'run',
-          resourceId,
-          operationId,
           '--workflow',
           'blockedPath',
+          '--operationId',
+          operationId,
           '--dir',
           appDir,
         ],
-        {
-          ...process.env,
-          NODE_ENV: 'development',
-          OPERATIONS_TABLE: tableName,
-          WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
-          WHARFIE_DB_ADAPTER: 'vanilla',
-          WHARFIE_DB_PATH: dbPath,
-        },
+        createCliEnv(dbPath, tableName),
       );
 
       expect(result.status).toBe(1);
@@ -499,12 +515,12 @@ describe('wharfie ops run', () => {
       });
 
       const storedAction = await inspectStore.getAction(
-        resourceId,
+        workflowResourceId,
         operationId,
         'blocked-action',
       );
       const storedOperation = await inspectStore.getOperation(
-        resourceId,
+        workflowResourceId,
         operationId,
       );
 
@@ -519,6 +535,98 @@ describe('wharfie ops run', () => {
     } finally {
       await inspectDb?.close?.();
       rmSync(appDir, { recursive: true, force: true });
+      rmSync(dbPath, { recursive: true, force: true });
+    }
+  }, 15000);
+});
+
+describe('wharfie ops app-scoped inspection', () => {
+  it('lists persisted runs for the app selected by --dir', async () => {
+    const dbPath = mkdtempSync(path.join(os.tmpdir(), 'wharfie-ops-list-'));
+    const tableName = 'operations-list-test';
+    /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
+    let inspectDb;
+
+    try {
+      const db = createVanillaDB({ path: dbPath });
+      const store = operationsStoreFactory({ db, tableName });
+      await store.putOperation(
+        new Operation({
+          id: 'listed-op',
+          resource_id: helloWorldResourceId,
+          resource_version: 1,
+          type: OperationType.PIPELINE,
+          operation_config: {
+            app: 'hello-world-demo',
+            activity: 'echo-event',
+            trigger: { source: 'manual' },
+          },
+          started_at: 1,
+          last_updated_at: 1,
+        }),
+      );
+      await db.close();
+
+      const result = runCli(
+        ['ops', 'list', '--dir', helloWorldDir],
+        createCliEnv(dbPath, tableName),
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('hello-world-demo');
+      expect(result.stdout).toContain('listed-op');
+      expect(result.stdout).toContain('echo-event');
+    } finally {
+      await inspectDb?.close?.();
+      rmSync(dbPath, { recursive: true, force: true });
+    }
+  }, 15000);
+
+  it('cancels persisted runs for the app selected by --dir', async () => {
+    const dbPath = mkdtempSync(path.join(os.tmpdir(), 'wharfie-ops-cancel-'));
+    const tableName = 'operations-cancel-test';
+    /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
+    let inspectDb;
+
+    try {
+      const db = createVanillaDB({ path: dbPath });
+      const store = operationsStoreFactory({ db, tableName });
+      await store.putOperation(
+        new Operation({
+          id: 'cancel-op',
+          resource_id: helloWorldResourceId,
+          resource_version: 1,
+          type: OperationType.PIPELINE,
+          operation_config: {
+            app: 'hello-world-demo',
+            activity: 'echo-event',
+            trigger: { source: 'manual' },
+          },
+          started_at: 1,
+          last_updated_at: 1,
+        }),
+      );
+      await db.close();
+
+      const result = runCli(
+        ['ops', 'cancel', '--dir', helloWorldDir, '--operationId', 'cancel-op'],
+        createCliEnv(dbPath, tableName),
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('1 operations cancelled.');
+
+      inspectDb = createVanillaDB({ path: dbPath });
+      const inspectStore = operationsStoreFactory({ db: inspectDb, tableName });
+      const storedOperation = await inspectStore.getOperation(
+        helloWorldResourceId,
+        'cancel-op',
+      );
+      expect(storedOperation).toBeNull();
+    } finally {
+      await inspectDb?.close?.();
       rmSync(dbPath, { recursive: true, force: true });
     }
   }, 15000);

--- a/test/cli/cmds/ops-run-command.test.js
+++ b/test/cli/cmds/ops-run-command.test.js
@@ -9,6 +9,7 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { SHARED_RESOURCE_REGISTRY_FILE_NAME } from '../../../src/core/runtime/shared-resource-registry.js';
 import createVanillaDB from '../../../src/core/lib/db/adapters/vanilla.js';
 import operationsStoreFactory from '../../../src/core/lib/graph/operations-store.js';
 import Action, {
@@ -29,8 +30,6 @@ const helloWorldDir = path.join(
   'actor-systems',
   'hello-world',
 );
-const helloWorldResourceId = 'app:hello-world-demo';
-const workflowResourceId = 'app:ops-workflow-demo';
 
 const actorSystemUrl = pathToFileURL(
   path.join(repoRoot, 'src', 'core', 'resources', 'builds', 'actor-system.js'),
@@ -152,6 +151,96 @@ async function createWorkflowAppDir() {
 }
 
 /**
+ * @returns {Promise<string>} - Result.
+ */
+async function createSharedResourceOpsAppDir() {
+  const dir = await fsp.mkdtemp(
+    path.join(os.tmpdir(), 'wharfie-shared-ops-app-'),
+  );
+  const handlerPath = path.join(dir, 'shared-handler.js');
+
+  await fsp.writeFile(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ type: 'module' }),
+    'utf8',
+  );
+  await fsp.writeFile(
+    handlerPath,
+    [
+      'export async function helloResources(event = {}, context = {}) {',
+      "  const who = event?.who || 'world';",
+      '  const message = `hello ${who}`;',
+      '  await context.resources.db.put({',
+      "    tableName: 'test',",
+      "    keyName: 'id',",
+      "    record: { id: 'greeting', who, message },",
+      '  });',
+      '  await context.resources.queue.sendMessage({',
+      "    QueueUrl: 'test-queue',",
+      '    MessageBody: JSON.stringify({ hello: who }),',
+      '  });',
+      "  await context.resources.objectStorage.createBucket({ Bucket: 'test-bucket' });",
+      '  await context.resources.objectStorage.putObject({',
+      "    Bucket: 'test-bucket',",
+      "    Key: 'greeting.txt',",
+      '    Body: message,',
+      '  });',
+      '  return {',
+      '    ok: true,',
+      '    who,',
+      '    dbRecord: await context.resources.db.get({',
+      "      tableName: 'test',",
+      "      keyName: 'id',",
+      "      keyValue: 'greeting',",
+      '    }),',
+      '    queueBody: (await context.resources.queue.receiveMessage({',
+      "      QueueUrl: 'test-queue',",
+      '      MaxNumberOfMessages: 1,',
+      '      WaitTimeSeconds: 0,',
+      '    }))?.Messages?.[0]?.Body || null,',
+      '    objectBody: await context.resources.objectStorage.getObject({',
+      "      Bucket: 'test-bucket',",
+      "      Key: 'greeting.txt',",
+      '    }),',
+      '  };',
+      '}',
+    ].join('\n'),
+    'utf8',
+  );
+  await fsp.writeFile(
+    path.join(dir, 'wharfie.app.js'),
+    `
+      import ActorSystem from ${JSON.stringify(actorSystemUrl)};
+      import Function from ${JSON.stringify(functionUrl)};
+
+      export default new ActorSystem({
+        name: 'ops-shared-resources-demo',
+        functions: [
+          new Function({
+            name: 'hello-resources',
+            entrypoint: {
+              path: ${JSON.stringify(handlerPath)},
+              export: 'helloResources',
+            },
+          }),
+        ],
+        properties: {
+          targets: [],
+          resources: {
+            db: { ref: 'appdb' },
+            queue: { ref: 'jobs' },
+            objectStorage: { ref: 'blobs' },
+          },
+        },
+      });
+    `,
+    'utf8',
+  );
+
+  return dir;
+}
+
+/**
  * @param {string[]} args - args.
  * @param {Record<string, string | undefined>} env - env.
  * @returns {import('node:child_process').SpawnSyncReturns<string>} - Result.
@@ -166,64 +255,217 @@ function runCli(args, env) {
   );
 }
 
-/**
- * @param {string} dbPath - dbPath.
- * @param {string} tableName - tableName.
- * @returns {Record<string, string | undefined>} - Result.
- */
-function createCliEnv(dbPath, tableName) {
-  return {
-    ...process.env,
-    NODE_ENV: 'development',
-    OPERATIONS_TABLE: tableName,
-    WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
-    WHARFIE_DB_ADAPTER: 'vanilla',
-    WHARFIE_DB_PATH: dbPath,
-  };
-}
-
 describe('wharfie ops run', () => {
-  it('creates and executes a persisted activity run using the synthetic app resource id', async () => {
-    const dbPath = mkdtempSync(path.join(os.tmpdir(), 'wharfie-ops-run-'));
-    const tableName = 'operations-test';
-    const operationId = 'activity-op';
+  it('resolves shared app resource refs before executing persisted operations', async () => {
+    const dbPath = mkdtempSync(
+      path.join(os.tmpdir(), 'wharfie-ops-shared-db-'),
+    );
+    const configRoot = mkdtempSync(
+      path.join(os.tmpdir(), 'wharfie-ops-shared-config-'),
+    );
+    const configDir = path.join(configRoot, 'wharfie-nodejs');
+    const runtimeDir = mkdtempSync(
+      path.join(os.tmpdir(), 'wharfie-ops-runtime-'),
+    );
+    const tableName = 'operations-shared-resources';
+    const resourceId = 'resource-shared';
+    const appDir = await createSharedResourceOpsAppDir();
+
     /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
     let inspectDb;
 
     try {
+      await fsp.mkdir(configDir, { recursive: true });
+      await fsp.writeFile(
+        path.join(configDir, SHARED_RESOURCE_REGISTRY_FILE_NAME),
+        JSON.stringify(
+          {
+            db: {
+              appdb: {
+                adapter: 'vanilla',
+                options: { path: path.join(runtimeDir, 'db') },
+              },
+            },
+            queue: {
+              jobs: {
+                adapter: 'vanilla',
+                options: { path: path.join(runtimeDir, 'queue') },
+              },
+            },
+            objectStorage: {
+              blobs: {
+                adapter: 'vanilla',
+                options: { path: path.join(runtimeDir, 'object-storage') },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        'utf8',
+      );
+
+      const db = createVanillaDB({ path: dbPath });
+      const store = operationsStoreFactory({ db, tableName });
+
+      const operation = new Operation({
+        id: 'op-shared',
+        resource_id: resourceId,
+        resource_version: 1,
+        type: OperationType.PIPELINE,
+        started_at: 1,
+        last_updated_at: 1,
+      });
+      const startAction = operation.createAction({
+        id: 'start-shared',
+        type: Action.Type.START,
+      });
+      const invokeAction = operation.createAction({
+        id: 'invoke-shared',
+        type: Action.Type.INVOKE_FUNCTION,
+        function_name: 'hello-resources',
+        inputs: { who: 'ops-shared' },
+        placement: { mode: 'local' },
+        retry: { max_attempts: 1 },
+        dependsOn: [startAction],
+      });
+      operation.createAction({
+        id: 'finish-shared',
+        type: Action.Type.FINISH,
+        dependsOn: [invokeAction],
+      });
+
+      await store.putOperation(operation);
+      await db.close();
+
       const result = runCli(
-        [
-          'ops',
-          'run',
-          '--activity',
-          'echo-event',
-          '--operationId',
-          operationId,
-          '--event',
-          JSON.stringify({ who: 'ops-run' }),
-          '--dir',
-          helloWorldDir,
-        ],
-        createCliEnv(dbPath, tableName),
+        ['ops', 'run', resourceId, operation.id, '--dir', appDir],
+        {
+          ...process.env,
+          NODE_ENV: 'development',
+          OPERATIONS_TABLE: tableName,
+          WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
+          WHARFIE_DB_ADAPTER: 'vanilla',
+          WHARFIE_DB_PATH: dbPath,
+          XDG_CONFIG_HOME: configRoot,
+        },
       );
 
       expect(result.status).toBe(0);
       expect(result.stderr).toBe('');
-      expect(result.stdout).toContain(helloWorldResourceId);
-      expect(result.stdout).toContain('invoke-echo-event');
+      expect(result.stdout).toContain('invoke-shared');
+
+      inspectDb = createVanillaDB({ path: dbPath });
+      const inspectStore = operationsStoreFactory({ db: inspectDb, tableName });
+      const storedAction = await inspectStore.getAction(
+        resourceId,
+        operation.id,
+        'invoke-shared',
+      );
+
+      expect(storedAction).not.toBeNull();
+      if (!storedAction) {
+        throw new Error('Expected stored action to exist');
+      }
+
+      expect(storedAction.status).toBe(ActionStatus.COMPLETED);
+      expect(storedAction.outputs).toEqual({
+        ok: true,
+        who: 'ops-shared',
+        dbRecord: {
+          id: 'greeting',
+          who: 'ops-shared',
+          message: 'hello ops-shared',
+        },
+        queueBody: JSON.stringify({ hello: 'ops-shared' }),
+        objectBody: 'hello ops-shared',
+      });
+    } finally {
+      if (inspectDb) {
+        await inspectDb.close();
+      }
+      rmSync(dbPath, { recursive: true, force: true });
+      rmSync(configRoot, { recursive: true, force: true });
+      rmSync(runtimeDir, { recursive: true, force: true });
+      rmSync(appDir, { recursive: true, force: true });
+    }
+  });
+
+  it('executes INVOKE_FUNCTION actions against a local app and persists outputs', async () => {
+    const dbPath = mkdtempSync(path.join(os.tmpdir(), 'wharfie-ops-run-'));
+    const tableName = 'operations-test';
+    const resourceId = 'resource-1';
+    /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
+    let inspectDb;
+
+    /** @type {import('../../../src/core/lib/graph/operation.js').default} */
+    let operation;
+    /** @type {import('../../../src/core/lib/graph/action.js').default} */
+    let invokeAction;
+
+    try {
+      const db = createVanillaDB({ path: dbPath });
+      const store = operationsStoreFactory({ db, tableName });
+
+      operation = new Operation({
+        id: 'op-1',
+        resource_id: resourceId,
+        resource_version: 1,
+        type: OperationType.PIPELINE,
+        started_at: 1,
+        last_updated_at: 1,
+      });
+
+      const startAction = operation.createAction({
+        id: 'start-1',
+        type: Action.Type.START,
+      });
+      invokeAction = operation.createAction({
+        id: 'invoke-1',
+        type: Action.Type.INVOKE_FUNCTION,
+        function_name: 'echo-event',
+        inputs: { who: 'ops-run' },
+        placement: { mode: 'local' },
+        retry: { max_attempts: 1 },
+        dependsOn: [startAction],
+      });
+      operation.createAction({
+        id: 'finish-1',
+        type: Action.Type.FINISH,
+        dependsOn: [invokeAction],
+      });
+
+      await store.putOperation(operation);
+      await db.close();
+
+      const result = runCli(
+        ['ops', 'run', resourceId, operation.id, '--dir', helloWorldDir],
+        {
+          ...process.env,
+          NODE_ENV: 'development',
+          OPERATIONS_TABLE: tableName,
+          WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
+          WHARFIE_DB_ADAPTER: 'vanilla',
+          WHARFIE_DB_PATH: dbPath,
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('invoke-1');
       expect(result.stdout).toContain('Executed 3 actions.');
 
       inspectDb = createVanillaDB({ path: dbPath });
       const inspectStore = operationsStoreFactory({ db: inspectDb, tableName });
 
       const storedAction = await inspectStore.getAction(
-        helloWorldResourceId,
-        operationId,
-        'invoke-echo-event',
+        resourceId,
+        operation.id,
+        invokeAction.id,
       );
       const storedOperation = await inspectStore.getOperation(
-        helloWorldResourceId,
-        operationId,
+        resourceId,
+        operation.id,
       );
 
       expect(storedAction).not.toBeNull();
@@ -243,72 +485,7 @@ describe('wharfie ops run', () => {
         message: 'hello ops-run',
         requestId: null,
       });
-      expect(storedOperation.operation_config).toEqual({
-        app: 'hello-world-demo',
-        activity: 'echo-event',
-        trigger: { source: 'manual' },
-        source: 'app-manifest',
-      });
       expect(storedOperation.status).toBe(OperationStatus.COMPLETED);
-    } finally {
-      await inspectDb?.close?.();
-      rmSync(dbPath, { recursive: true, force: true });
-    }
-  }, 15000);
-
-  it('injects app-level resources into local activity runs', async () => {
-    const dbPath = mkdtempSync(
-      path.join(os.tmpdir(), 'wharfie-ops-run-resources-'),
-    );
-    const tableName = 'operations-test';
-    const operationId = 'activity-resources';
-    /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
-    let inspectDb;
-
-    try {
-      const result = runCli(
-        [
-          'ops',
-          'run',
-          '--activity',
-          'hello-resources',
-          '--operationId',
-          operationId,
-          '--event',
-          JSON.stringify({ who: 'resources-user' }),
-          '--dir',
-          helloWorldDir,
-        ],
-        createCliEnv(dbPath, tableName),
-      );
-
-      expect(result.status).toBe(0);
-      expect(result.stderr).toBe('');
-      expect(result.stdout).toContain('invoke-hello-resources');
-
-      inspectDb = createVanillaDB({ path: dbPath });
-      const inspectStore = operationsStoreFactory({ db: inspectDb, tableName });
-      const storedAction = await inspectStore.getAction(
-        helloWorldResourceId,
-        operationId,
-        'invoke-hello-resources',
-      );
-
-      expect(storedAction).not.toBeNull();
-      if (!storedAction) {
-        throw new Error('Expected stored activity action to exist');
-      }
-
-      expect(storedAction.outputs).toEqual({
-        who: 'resources-user',
-        dbRecord: {
-          id: 'greeting',
-          who: 'resources-user',
-          message: 'hello resources-user',
-        },
-        queueBody: JSON.stringify({ hello: 'resources-user' }),
-        objectBody: 'hello resources-user',
-      });
     } finally {
       await inspectDb?.close?.();
       rmSync(dbPath, { recursive: true, force: true });
@@ -319,6 +496,7 @@ describe('wharfie ops run', () => {
     const appDir = await createWorkflowAppDir();
     const dbPath = mkdtempSync(path.join(os.tmpdir(), 'wharfie-ops-workflow-'));
     const tableName = 'operations-workflow-test';
+    const resourceId = 'workflow-resource';
     const operationId = 'workflow-op';
     /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
     let inspectDb;
@@ -328,14 +506,21 @@ describe('wharfie ops run', () => {
         [
           'ops',
           'run',
+          resourceId,
+          operationId,
           '--workflow',
           'happyPath',
-          '--operationId',
-          operationId,
           '--dir',
           appDir,
         ],
-        createCliEnv(dbPath, tableName),
+        {
+          ...process.env,
+          NODE_ENV: 'development',
+          OPERATIONS_TABLE: tableName,
+          WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
+          WHARFIE_DB_ADAPTER: 'vanilla',
+          WHARFIE_DB_PATH: dbPath,
+        },
       );
 
       expect(result.status).toBe(0);
@@ -350,12 +535,12 @@ describe('wharfie ops run', () => {
       });
 
       const storedAction = await inspectStore.getAction(
-        workflowResourceId,
+        resourceId,
         operationId,
         'invoke-workflow',
       );
       const storedOperation = await inspectStore.getOperation(
-        workflowResourceId,
+        resourceId,
         operationId,
       );
 
@@ -370,19 +555,13 @@ describe('wharfie ops run', () => {
         ok: true,
         event: { who: 'workflow-user' },
         workflow: {
-          resourceId: workflowResourceId,
+          resourceId,
           operationId,
           actionId: 'invoke-workflow',
           actionType: Action.Type.INVOKE_FUNCTION,
           attemptCount: 1,
           placement: { mode: 'local' },
         },
-      });
-      expect(storedOperation.operation_config).toEqual({
-        app: 'ops-workflow-demo',
-        workflow: 'happyPath',
-        trigger: { source: 'manual' },
-        source: 'app-manifest',
       });
       expect(storedOperation.status).toBe(OperationStatus.COMPLETED);
     } finally {
@@ -400,8 +579,23 @@ describe('wharfie ops run', () => {
 
     try {
       const result = runCli(
-        ['ops', 'run', '--workflow', 'missingPath', '--dir', appDir],
-        createCliEnv(dbPath, 'operations-workflow-test'),
+        [
+          'ops',
+          'run',
+          'workflow-resource',
+          '--workflow',
+          'missingPath',
+          '--dir',
+          appDir,
+        ],
+        {
+          ...process.env,
+          NODE_ENV: 'development',
+          OPERATIONS_TABLE: 'operations-workflow-test',
+          WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
+          WHARFIE_DB_ADAPTER: 'vanilla',
+          WHARFIE_DB_PATH: dbPath,
+        },
       );
 
       expect(result.status).toBe(1);
@@ -421,6 +615,7 @@ describe('wharfie ops run', () => {
       path.join(os.tmpdir(), 'wharfie-ops-workflow-failing-'),
     );
     const tableName = 'operations-workflow-test';
+    const resourceId = 'workflow-resource';
     const operationId = 'workflow-failing';
     /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
     let inspectDb;
@@ -430,14 +625,21 @@ describe('wharfie ops run', () => {
         [
           'ops',
           'run',
+          resourceId,
+          operationId,
           '--workflow',
           'failingPath',
-          '--operationId',
-          operationId,
           '--dir',
           appDir,
         ],
-        createCliEnv(dbPath, tableName),
+        {
+          ...process.env,
+          NODE_ENV: 'development',
+          OPERATIONS_TABLE: tableName,
+          WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
+          WHARFIE_DB_ADAPTER: 'vanilla',
+          WHARFIE_DB_PATH: dbPath,
+        },
       );
 
       expect(result.status).toBe(1);
@@ -451,12 +653,12 @@ describe('wharfie ops run', () => {
       });
 
       const storedAction = await inspectStore.getAction(
-        workflowResourceId,
+        resourceId,
         operationId,
         'invoke-failing-workflow',
       );
       const storedOperation = await inspectStore.getOperation(
-        workflowResourceId,
+        resourceId,
         operationId,
       );
 
@@ -485,6 +687,7 @@ describe('wharfie ops run', () => {
       path.join(os.tmpdir(), 'wharfie-ops-workflow-blocked-'),
     );
     const tableName = 'operations-workflow-test';
+    const resourceId = 'workflow-resource';
     const operationId = 'workflow-blocked';
     /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
     let inspectDb;
@@ -494,14 +697,21 @@ describe('wharfie ops run', () => {
         [
           'ops',
           'run',
+          resourceId,
+          operationId,
           '--workflow',
           'blockedPath',
-          '--operationId',
-          operationId,
           '--dir',
           appDir,
         ],
-        createCliEnv(dbPath, tableName),
+        {
+          ...process.env,
+          NODE_ENV: 'development',
+          OPERATIONS_TABLE: tableName,
+          WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
+          WHARFIE_DB_ADAPTER: 'vanilla',
+          WHARFIE_DB_PATH: dbPath,
+        },
       );
 
       expect(result.status).toBe(1);
@@ -515,12 +725,12 @@ describe('wharfie ops run', () => {
       });
 
       const storedAction = await inspectStore.getAction(
-        workflowResourceId,
+        resourceId,
         operationId,
         'blocked-action',
       );
       const storedOperation = await inspectStore.getOperation(
-        workflowResourceId,
+        resourceId,
         operationId,
       );
 
@@ -535,98 +745,6 @@ describe('wharfie ops run', () => {
     } finally {
       await inspectDb?.close?.();
       rmSync(appDir, { recursive: true, force: true });
-      rmSync(dbPath, { recursive: true, force: true });
-    }
-  }, 15000);
-});
-
-describe('wharfie ops app-scoped inspection', () => {
-  it('lists persisted runs for the app selected by --dir', async () => {
-    const dbPath = mkdtempSync(path.join(os.tmpdir(), 'wharfie-ops-list-'));
-    const tableName = 'operations-list-test';
-    /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
-    let inspectDb;
-
-    try {
-      const db = createVanillaDB({ path: dbPath });
-      const store = operationsStoreFactory({ db, tableName });
-      await store.putOperation(
-        new Operation({
-          id: 'listed-op',
-          resource_id: helloWorldResourceId,
-          resource_version: 1,
-          type: OperationType.PIPELINE,
-          operation_config: {
-            app: 'hello-world-demo',
-            activity: 'echo-event',
-            trigger: { source: 'manual' },
-          },
-          started_at: 1,
-          last_updated_at: 1,
-        }),
-      );
-      await db.close();
-
-      const result = runCli(
-        ['ops', 'list', '--dir', helloWorldDir],
-        createCliEnv(dbPath, tableName),
-      );
-
-      expect(result.status).toBe(0);
-      expect(result.stderr).toBe('');
-      expect(result.stdout).toContain('hello-world-demo');
-      expect(result.stdout).toContain('listed-op');
-      expect(result.stdout).toContain('echo-event');
-    } finally {
-      await inspectDb?.close?.();
-      rmSync(dbPath, { recursive: true, force: true });
-    }
-  }, 15000);
-
-  it('cancels persisted runs for the app selected by --dir', async () => {
-    const dbPath = mkdtempSync(path.join(os.tmpdir(), 'wharfie-ops-cancel-'));
-    const tableName = 'operations-cancel-test';
-    /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
-    let inspectDb;
-
-    try {
-      const db = createVanillaDB({ path: dbPath });
-      const store = operationsStoreFactory({ db, tableName });
-      await store.putOperation(
-        new Operation({
-          id: 'cancel-op',
-          resource_id: helloWorldResourceId,
-          resource_version: 1,
-          type: OperationType.PIPELINE,
-          operation_config: {
-            app: 'hello-world-demo',
-            activity: 'echo-event',
-            trigger: { source: 'manual' },
-          },
-          started_at: 1,
-          last_updated_at: 1,
-        }),
-      );
-      await db.close();
-
-      const result = runCli(
-        ['ops', 'cancel', '--dir', helloWorldDir, '--operationId', 'cancel-op'],
-        createCliEnv(dbPath, tableName),
-      );
-
-      expect(result.status).toBe(0);
-      expect(result.stderr).toBe('');
-      expect(result.stdout).toContain('1 operations cancelled.');
-
-      inspectDb = createVanillaDB({ path: dbPath });
-      const inspectStore = operationsStoreFactory({ db: inspectDb, tableName });
-      const storedOperation = await inspectStore.getOperation(
-        helloWorldResourceId,
-        'cancel-op',
-      );
-      expect(storedOperation).toBeNull();
-    } finally {
-      await inspectDb?.close?.();
       rmSync(dbPath, { recursive: true, force: true });
     }
   }, 15000);

--- a/test/cli/cmds/ops-run-command.test.js
+++ b/test/cli/cmds/ops-run-command.test.js
@@ -9,7 +9,6 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { SHARED_RESOURCE_REGISTRY_FILE_NAME } from '../../../src/core/runtime/shared-resource-registry.js';
 import createVanillaDB from '../../../src/core/lib/db/adapters/vanilla.js';
 import operationsStoreFactory from '../../../src/core/lib/graph/operations-store.js';
 import Action, {
@@ -151,96 +150,6 @@ async function createWorkflowAppDir() {
 }
 
 /**
- * @returns {Promise<string>} - Result.
- */
-async function createSharedResourceOpsAppDir() {
-  const dir = await fsp.mkdtemp(
-    path.join(os.tmpdir(), 'wharfie-shared-ops-app-'),
-  );
-  const handlerPath = path.join(dir, 'shared-handler.js');
-
-  await fsp.writeFile(
-    path.join(dir, 'package.json'),
-    JSON.stringify({ type: 'module' }),
-    'utf8',
-  );
-  await fsp.writeFile(
-    handlerPath,
-    [
-      'export async function helloResources(event = {}, context = {}) {',
-      "  const who = event?.who || 'world';",
-      '  const message = `hello ${who}`;',
-      '  await context.resources.db.put({',
-      "    tableName: 'test',",
-      "    keyName: 'id',",
-      "    record: { id: 'greeting', who, message },",
-      '  });',
-      '  await context.resources.queue.sendMessage({',
-      "    QueueUrl: 'test-queue',",
-      '    MessageBody: JSON.stringify({ hello: who }),',
-      '  });',
-      "  await context.resources.objectStorage.createBucket({ Bucket: 'test-bucket' });",
-      '  await context.resources.objectStorage.putObject({',
-      "    Bucket: 'test-bucket',",
-      "    Key: 'greeting.txt',",
-      '    Body: message,',
-      '  });',
-      '  return {',
-      '    ok: true,',
-      '    who,',
-      '    dbRecord: await context.resources.db.get({',
-      "      tableName: 'test',",
-      "      keyName: 'id',",
-      "      keyValue: 'greeting',",
-      '    }),',
-      '    queueBody: (await context.resources.queue.receiveMessage({',
-      "      QueueUrl: 'test-queue',",
-      '      MaxNumberOfMessages: 1,',
-      '      WaitTimeSeconds: 0,',
-      '    }))?.Messages?.[0]?.Body || null,',
-      '    objectBody: await context.resources.objectStorage.getObject({',
-      "      Bucket: 'test-bucket',",
-      "      Key: 'greeting.txt',",
-      '    }),',
-      '  };',
-      '}',
-    ].join('\n'),
-    'utf8',
-  );
-  await fsp.writeFile(
-    path.join(dir, 'wharfie.app.js'),
-    `
-      import ActorSystem from ${JSON.stringify(actorSystemUrl)};
-      import Function from ${JSON.stringify(functionUrl)};
-
-      export default new ActorSystem({
-        name: 'ops-shared-resources-demo',
-        functions: [
-          new Function({
-            name: 'hello-resources',
-            entrypoint: {
-              path: ${JSON.stringify(handlerPath)},
-              export: 'helloResources',
-            },
-          }),
-        ],
-        properties: {
-          targets: [],
-          resources: {
-            db: { ref: 'appdb' },
-            queue: { ref: 'jobs' },
-            objectStorage: { ref: 'blobs' },
-          },
-        },
-      });
-    `,
-    'utf8',
-  );
-
-  return dir;
-}
-
-/**
  * @param {string[]} args - args.
  * @param {Record<string, string | undefined>} env - env.
  * @returns {import('node:child_process').SpawnSyncReturns<string>} - Result.
@@ -256,190 +165,28 @@ function runCli(args, env) {
 }
 
 describe('wharfie ops run', () => {
-  it('resolves shared app resource refs before executing persisted operations', async () => {
-    const dbPath = mkdtempSync(
-      path.join(os.tmpdir(), 'wharfie-ops-shared-db-'),
-    );
-    const configRoot = mkdtempSync(
-      path.join(os.tmpdir(), 'wharfie-ops-shared-config-'),
-    );
-    const configDir = path.join(configRoot, 'wharfie-nodejs');
-    const runtimeDir = mkdtempSync(
-      path.join(os.tmpdir(), 'wharfie-ops-runtime-'),
-    );
-    const tableName = 'operations-shared-resources';
-    const resourceId = 'resource-shared';
-    const appDir = await createSharedResourceOpsAppDir();
-
-    /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
-    let inspectDb;
-
-    try {
-      await fsp.mkdir(configDir, { recursive: true });
-      await fsp.writeFile(
-        path.join(configDir, SHARED_RESOURCE_REGISTRY_FILE_NAME),
-        JSON.stringify(
-          {
-            db: {
-              appdb: {
-                adapter: 'vanilla',
-                options: { path: path.join(runtimeDir, 'db') },
-              },
-            },
-            queue: {
-              jobs: {
-                adapter: 'vanilla',
-                options: { path: path.join(runtimeDir, 'queue') },
-              },
-            },
-            objectStorage: {
-              blobs: {
-                adapter: 'vanilla',
-                options: { path: path.join(runtimeDir, 'object-storage') },
-              },
-            },
-          },
-          null,
-          2,
-        ),
-        'utf8',
-      );
-
-      const db = createVanillaDB({ path: dbPath });
-      const store = operationsStoreFactory({ db, tableName });
-
-      const operation = new Operation({
-        id: 'op-shared',
-        resource_id: resourceId,
-        resource_version: 1,
-        type: OperationType.PIPELINE,
-        started_at: 1,
-        last_updated_at: 1,
-      });
-      const startAction = operation.createAction({
-        id: 'start-shared',
-        type: Action.Type.START,
-      });
-      const invokeAction = operation.createAction({
-        id: 'invoke-shared',
-        type: Action.Type.INVOKE_FUNCTION,
-        function_name: 'hello-resources',
-        inputs: { who: 'ops-shared' },
-        placement: { mode: 'local' },
-        retry: { max_attempts: 1 },
-        dependsOn: [startAction],
-      });
-      operation.createAction({
-        id: 'finish-shared',
-        type: Action.Type.FINISH,
-        dependsOn: [invokeAction],
-      });
-
-      await store.putOperation(operation);
-      await db.close();
-
-      const result = runCli(
-        ['ops', 'run', resourceId, operation.id, '--dir', appDir],
-        {
-          ...process.env,
-          NODE_ENV: 'development',
-          OPERATIONS_TABLE: tableName,
-          WHARFIE_ARTIFACT_BUCKET: 'service-bucket',
-          WHARFIE_DB_ADAPTER: 'vanilla',
-          WHARFIE_DB_PATH: dbPath,
-          XDG_CONFIG_HOME: configRoot,
-        },
-      );
-
-      expect(result.status).toBe(0);
-      expect(result.stderr).toBe('');
-      expect(result.stdout).toContain('invoke-shared');
-
-      inspectDb = createVanillaDB({ path: dbPath });
-      const inspectStore = operationsStoreFactory({ db: inspectDb, tableName });
-      const storedAction = await inspectStore.getAction(
-        resourceId,
-        operation.id,
-        'invoke-shared',
-      );
-
-      expect(storedAction).not.toBeNull();
-      if (!storedAction) {
-        throw new Error('Expected stored action to exist');
-      }
-
-      expect(storedAction.status).toBe(ActionStatus.COMPLETED);
-      expect(storedAction.outputs).toEqual({
-        ok: true,
-        who: 'ops-shared',
-        dbRecord: {
-          id: 'greeting',
-          who: 'ops-shared',
-          message: 'hello ops-shared',
-        },
-        queueBody: JSON.stringify({ hello: 'ops-shared' }),
-        objectBody: 'hello ops-shared',
-      });
-    } finally {
-      if (inspectDb) {
-        await inspectDb.close();
-      }
-      rmSync(dbPath, { recursive: true, force: true });
-      rmSync(configRoot, { recursive: true, force: true });
-      rmSync(runtimeDir, { recursive: true, force: true });
-      rmSync(appDir, { recursive: true, force: true });
-    }
-  });
-
-  it('executes INVOKE_FUNCTION actions against a local app and persists outputs', async () => {
+  it('executes an app activity as a persisted run and stores outputs', async () => {
     const dbPath = mkdtempSync(path.join(os.tmpdir(), 'wharfie-ops-run-'));
     const tableName = 'operations-test';
-    const resourceId = 'resource-1';
+    const resourceId = 'app:hello-world-demo';
+    const operationId = 'op-1';
     /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
     let inspectDb;
 
-    /** @type {import('../../../src/core/lib/graph/operation.js').default} */
-    let operation;
-    /** @type {import('../../../src/core/lib/graph/action.js').default} */
-    let invokeAction;
-
     try {
-      const db = createVanillaDB({ path: dbPath });
-      const store = operationsStoreFactory({ db, tableName });
-
-      operation = new Operation({
-        id: 'op-1',
-        resource_id: resourceId,
-        resource_version: 1,
-        type: OperationType.PIPELINE,
-        started_at: 1,
-        last_updated_at: 1,
-      });
-
-      const startAction = operation.createAction({
-        id: 'start-1',
-        type: Action.Type.START,
-      });
-      invokeAction = operation.createAction({
-        id: 'invoke-1',
-        type: Action.Type.INVOKE_FUNCTION,
-        function_name: 'echo-event',
-        inputs: { who: 'ops-run' },
-        placement: { mode: 'local' },
-        retry: { max_attempts: 1 },
-        dependsOn: [startAction],
-      });
-      operation.createAction({
-        id: 'finish-1',
-        type: Action.Type.FINISH,
-        dependsOn: [invokeAction],
-      });
-
-      await store.putOperation(operation);
-      await db.close();
-
       const result = runCli(
-        ['ops', 'run', resourceId, operation.id, '--dir', helloWorldDir],
+        [
+          'ops',
+          'run',
+          '--activity',
+          'echo-event',
+          '--operation-id',
+          operationId,
+          '--dir',
+          helloWorldDir,
+          '--event',
+          '{"who":"ops-run"}',
+        ],
         {
           ...process.env,
           NODE_ENV: 'development',
@@ -452,7 +199,7 @@ describe('wharfie ops run', () => {
 
       expect(result.status).toBe(0);
       expect(result.stderr).toBe('');
-      expect(result.stdout).toContain('invoke-1');
+      expect(result.stdout).toContain('INVOKE_FUNCTION:echo-event');
       expect(result.stdout).toContain('Executed 3 actions.');
 
       inspectDb = createVanillaDB({ path: dbPath });
@@ -460,12 +207,12 @@ describe('wharfie ops run', () => {
 
       const storedAction = await inspectStore.getAction(
         resourceId,
-        operation.id,
-        invokeAction.id,
+        operationId,
+        'invoke',
       );
       const storedOperation = await inspectStore.getOperation(
         resourceId,
-        operation.id,
+        operationId,
       );
 
       expect(storedAction).not.toBeNull();
@@ -496,7 +243,7 @@ describe('wharfie ops run', () => {
     const appDir = await createWorkflowAppDir();
     const dbPath = mkdtempSync(path.join(os.tmpdir(), 'wharfie-ops-workflow-'));
     const tableName = 'operations-workflow-test';
-    const resourceId = 'workflow-resource';
+    const resourceId = 'app:ops-workflow-demo';
     const operationId = 'workflow-op';
     /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
     let inspectDb;
@@ -506,10 +253,10 @@ describe('wharfie ops run', () => {
         [
           'ops',
           'run',
-          resourceId,
-          operationId,
           '--workflow',
           'happyPath',
+          '--operation-id',
+          operationId,
           '--dir',
           appDir,
         ],
@@ -579,15 +326,7 @@ describe('wharfie ops run', () => {
 
     try {
       const result = runCli(
-        [
-          'ops',
-          'run',
-          'workflow-resource',
-          '--workflow',
-          'missingPath',
-          '--dir',
-          appDir,
-        ],
+        ['ops', 'run', '--workflow', 'missingPath', '--dir', appDir],
         {
           ...process.env,
           NODE_ENV: 'development',
@@ -615,7 +354,7 @@ describe('wharfie ops run', () => {
       path.join(os.tmpdir(), 'wharfie-ops-workflow-failing-'),
     );
     const tableName = 'operations-workflow-test';
-    const resourceId = 'workflow-resource';
+    const resourceId = 'app:ops-workflow-demo';
     const operationId = 'workflow-failing';
     /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
     let inspectDb;
@@ -625,10 +364,10 @@ describe('wharfie ops run', () => {
         [
           'ops',
           'run',
-          resourceId,
-          operationId,
           '--workflow',
           'failingPath',
+          '--operation-id',
+          operationId,
           '--dir',
           appDir,
         ],
@@ -687,7 +426,7 @@ describe('wharfie ops run', () => {
       path.join(os.tmpdir(), 'wharfie-ops-workflow-blocked-'),
     );
     const tableName = 'operations-workflow-test';
-    const resourceId = 'workflow-resource';
+    const resourceId = 'app:ops-workflow-demo';
     const operationId = 'workflow-blocked';
     /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
     let inspectDb;
@@ -697,10 +436,10 @@ describe('wharfie ops run', () => {
         [
           'ops',
           'run',
-          resourceId,
-          operationId,
           '--workflow',
           'blockedPath',
+          '--operation-id',
+          operationId,
           '--dir',
           appDir,
         ],

--- a/test/cli/docs-command-surface.test.js
+++ b/test/cli/docs-command-surface.test.js
@@ -95,7 +95,10 @@ describe('docs command surface', () => {
       'wharfie app manifest ./path/to/wharfie.app.js',
     );
     expect(quickstart).toContain(
-      `wharfie app run <function_name> --dir ./path/to/app --event '{"who":"cli-user"}'`,
+      `wharfie app run <activity_name> --dir ./path/to/app --event '{\"who\":\"cli-user\"}'`,
+    );
+    expect(quickstart).toContain(
+      `wharfie ops run --activity <activity_name> --dir ./path/to/app --event '{\"who\":\"cli-user\"}'`,
     );
   });
 });

--- a/test/runtime/resources/actor-system-resources.test.js
+++ b/test/runtime/resources/actor-system-resources.test.js
@@ -4,12 +4,19 @@
 import os from 'node:os';
 import path from 'node:path';
 import { promises as fsp } from 'node:fs';
+
+import { afterEach, describe, expect, it } from '@jest/globals';
 import { fileURLToPath } from 'node:url';
 
+import { SHARED_RESOURCE_REGISTRY_FILE_NAME } from '../../../src/core/runtime/shared-resource-registry.js';
 import Function from '../../../src/core/resources/builds/function.js';
 import ActorSystem from '../../../src/core/resources/builds/actor-system.js';
 import { createActorSystemResources } from '../../../src/core/runtime/resources.js';
 import sandboxWorker from '../../../src/core/lib/code-execution/worker.js';
+
+afterEach(() => {
+  delete process.env.CONFIG_DIR;
+});
 
 describe('ActorSystem runtime resources', () => {
   it('createActorSystemResources: vanilla adapters create usable clients', async () => {
@@ -29,6 +36,59 @@ describe('ActorSystem runtime resources', () => {
     expect(typeof resources.db?.put).toBe('function');
     expect(typeof resources.queue?.sendMessage).toBe('function');
     expect(typeof resources.objectStorage?.putObject).toBe('function');
+
+    await close();
+  });
+
+  it('createActorSystemResources: resolves shared refs from the config dir registry', async () => {
+    const configDir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'wharfie-shared-resource-config-'),
+    );
+    process.env.CONFIG_DIR = configDir;
+
+    await fsp.writeFile(
+      path.join(configDir, SHARED_RESOURCE_REGISTRY_FILE_NAME),
+      JSON.stringify(
+        {
+          db: {
+            appdb: {
+              adapter: 'vanilla',
+              options: { path: path.join(configDir, 'db') },
+            },
+          },
+          queue: {
+            jobs: {
+              adapter: 'vanilla',
+              options: { path: path.join(configDir, 'queue') },
+            },
+          },
+          objectStorage: {
+            blobs: {
+              adapter: 'vanilla',
+              options: { path: path.join(configDir, 'object-storage') },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    const { resources, close } = await createActorSystemResources({
+      db: { ref: 'appdb' },
+      queue: { ref: 'jobs' },
+      objectStorage: { ref: 'blobs' },
+    });
+    if (!resources.db || !resources.queue || !resources.objectStorage) {
+      throw new Error(
+        'Expected shared refs to resolve to initialized resources',
+      );
+    }
+
+    expect(typeof resources.db.put).toBe('function');
+    expect(typeof resources.queue.sendMessage).toBe('function');
+    expect(typeof resources.objectStorage.putObject).toBe('function');
 
     await close();
   });

--- a/test/runtime/services/actor-system-cli-runtime.test.js
+++ b/test/runtime/services/actor-system-cli-runtime.test.js
@@ -7,6 +7,8 @@ const PROCESS_RUNNER_IMPORT =
   '../../../src/core/resources/builds/actor-system-cli/lib/process-runner.js';
 const START_IMPORT =
   '../../../src/core/resources/builds/actor-system-cli/start.js';
+const ACTOR_SYSTEM_CLI_IMPORT =
+  '../../../src/core/resources/builds/actor-system-cli/index.js';
 const DB_CMD_IMPORT =
   '../../../src/core/resources/builds/actor-system-cli/serve_cmds/db.js';
 const QUEUE_CMD_IMPORT =
@@ -19,6 +21,9 @@ const RESOURCE_UTIL_IMPORT =
 const SPAWN_SELF_IMPORT =
   '../../../src/core/resources/builds/actor-system-cli/control_cmds/state_cmds/util/spawn-self.js';
 const DB_SERVICE_IMPORT = '../../../src/core/runtime/services/db-service.js';
+const PATHS_IMPORT = '../../../src/core/lib/paths.js';
+const STATE_START_CMD_IMPORT =
+  '../../../src/core/resources/builds/actor-system-cli/control_cmds/state_cmds/start.js';
 const QUEUE_SERVICE_IMPORT =
   '../../../src/core/runtime/services/queue-service.js';
 const FUNCTION_IMPORT = '../../../src/core/resources/builds/function.js';
@@ -62,6 +67,52 @@ afterEach(() => {
 });
 
 describe('actor-system CLI runtime surfaces', () => {
+  it('routes direct artifact execution through the hidden bootstrap mode', async () => {
+    const { default: stateStartCmd } = await import(STATE_START_CMD_IMPORT);
+    const parseAsync = jest
+      .spyOn(stateStartCmd, 'parseAsync')
+      .mockResolvedValue(stateStartCmd);
+    const { default: paths } = await import(PATHS_IMPORT);
+    const createWharfiePaths = jest
+      .spyOn(paths, 'createWharfiePaths')
+      .mockResolvedValue(undefined);
+    const originalArgv = process.argv;
+    const stdinIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+
+    process.env.WHARFIE_BOOTSTRAP_MODE = 'state-start';
+    process.env.WHARFIE_BOOTSTRAP_ARGS = JSON.stringify([
+      '--role',
+      'leader',
+      '--control-port',
+      '8890',
+    ]);
+
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: true,
+    });
+    process.argv = ['node', 'wharfie-artifact'];
+
+    try {
+      const { default: entrypoint } = await import(ACTOR_SYSTEM_CLI_IMPORT);
+      await entrypoint();
+    } finally {
+      process.argv = originalArgv;
+      delete process.env.WHARFIE_BOOTSTRAP_MODE;
+      delete process.env.WHARFIE_BOOTSTRAP_ARGS;
+      if (stdinIsTTY) {
+        Object.defineProperty(process.stdin, 'isTTY', stdinIsTTY);
+      } else {
+        Reflect.deleteProperty(process.stdin, 'isTTY');
+      }
+    }
+
+    expect(createWharfiePaths).toHaveBeenCalledTimes(1);
+    expect(parseAsync).toHaveBeenCalledWith(
+      ['node', 'start', '--role', 'leader', '--control-port', '8890'],
+      { from: 'node' },
+    );
+  });
   it('captures stdout/stderr for successful process runs', async () => {
     const { runProcess } = await import(PROCESS_RUNNER_IMPORT);
 

--- a/test/runtime/services/actor-system-cli-runtime.test.js
+++ b/test/runtime/services/actor-system-cli-runtime.test.js
@@ -31,6 +31,8 @@ const RUNTIME_RESOURCES_IMPORT = '../../../src/core/runtime/resources.js';
 const RPC_GRPC_IMPORT = '../../../src/core/runtime/services/rpc-grpc.js';
 const LAMBDA_SERVICE_IMPORT =
   '../../../src/core/runtime/services/lambda-service.js';
+const PACKAGED_APP_ENTRY_IMPORT =
+  '../../../src/core/resources/builds/packaged-app-entry.js';
 
 /**
  * @returns {Promise<void>} - Result.
@@ -113,6 +115,51 @@ describe('actor-system CLI runtime surfaces', () => {
       { from: 'node' },
     );
   });
+
+  it('honors runtime command env for packaged child-service bootstrap', async () => {
+    const { runPackagedApp } = await import(PACKAGED_APP_ENTRY_IMPORT);
+    const parseAsync = jest.fn(async (_argv, _options) => undefined);
+    const originalEnv = {
+      WHARFIE_BOOTSTRAP_MODE: process.env.WHARFIE_BOOTSTRAP_MODE,
+      WHARFIE_BOOTSTRAP_ARGS: process.env.WHARFIE_BOOTSTRAP_ARGS,
+      WHARFIE_RUNTIME_COMMAND: process.env.WHARFIE_RUNTIME_COMMAND,
+      WHARFIE_RUNTIME_ARGS: process.env.WHARFIE_RUNTIME_ARGS,
+    };
+    const originalArgv = process.argv;
+
+    process.env.WHARFIE_BOOTSTRAP_MODE = 'runtime';
+    process.env.WHARFIE_BOOTSTRAP_ARGS = JSON.stringify(['--role', 'leader']);
+    process.env.WHARFIE_RUNTIME_COMMAND = 'serve-db';
+    process.env.WHARFIE_RUNTIME_ARGS = JSON.stringify([
+      '--db-address',
+      '127.0.0.1:9100',
+    ]);
+    process.argv = ['node', 'wharfie-artifact'];
+
+    try {
+      await runPackagedApp({
+        runtimeModules: {
+          'serve-db': { parseAsync },
+        },
+        argv: process.argv,
+      });
+    } finally {
+      process.argv = originalArgv;
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+
+    expect(parseAsync).toHaveBeenCalledWith(
+      ['node', 'serve-db', '--db-address', '127.0.0.1:9100'],
+      { from: 'node' },
+    );
+  });
+
   it('captures stdout/stderr for successful process runs', async () => {
     const { runProcess } = await import(PROCESS_RUNNER_IMPORT);
 

--- a/test/runtime/services/artifact-infrastructure.test.js
+++ b/test/runtime/services/artifact-infrastructure.test.js
@@ -127,6 +127,33 @@ describe('artifact infrastructure commands', () => {
         args: ['restart', 'artifact-infra-demo.service'],
       },
     ]);
+
+    const plan = createDeployPlan({
+      manifest,
+      artifactPath: '/tmp/wharfie-artifact',
+      releaseRoot: '/srv/wharfie',
+      systemdDir: '/etc/systemd/system',
+      environment: { FOO: 'bar', BAZ: 'qux' },
+      extraArgs: ['--control-port', '8890'],
+      role: 'leader',
+    });
+
+    expect(plan.environment).toMatchObject({
+      FOO: 'bar',
+      BAZ: 'qux',
+      WHARFIE_BOOTSTRAP_MODE: 'state-start',
+      WHARFIE_BOOTSTRAP_ARGS: '["--role","leader","--control-port","8890"]',
+    });
+    expect(plan.unitContent).toContain(
+      `ExecStart=${plan.paths.currentArtifactPath}`,
+    );
+    expect(plan.unitContent).not.toContain('ctl state start');
+    expect(plan.unitContent).toContain(
+      'Environment=WHARFIE_BOOTSTRAP_MODE=state-start',
+    );
+    expect(plan.unitContent).toContain(
+      'Environment=WHARFIE_BOOTSTRAP_ARGS=[\\"--role\\",\\"leader\\",\\"--control-port\\",\\"8890\\"]',
+    );
   });
 
   it('resolves release status, logs, and rollback targets from packaged release metadata', async () => {

--- a/test/runtime/services/lambda-service-poll.test.js
+++ b/test/runtime/services/lambda-service-poll.test.js
@@ -11,6 +11,8 @@ import { startDbService } from '../../../src/core/runtime/services/db-service.js
 import { startQueueService } from '../../../src/core/runtime/services/queue-service.js';
 import { startLambdaService } from '../../../src/core/runtime/services/lambda-service.js';
 import { createGrpcRpcClient } from '../../../src/core/runtime/services/rpc-grpc.js';
+import createOperationsStore from '../../../src/core/lib/graph/operations-store.js';
+import { getSyntheticAppResourceId } from '../../../src/core/lib/graph/app-run.js';
 
 const NODE_SEA_IMPORT = '../../../src/core/lib/node-sea.js';
 
@@ -33,7 +35,7 @@ describe('Lambda service queue poll loop (gRPC)', () => {
     seaAssets.clear();
   });
 
-  it('polls queue messages and launches workers based on message shape', async () => {
+  it('polls queue messages, persists an event run, and acks on success', async () => {
     const tmp = await fsp.mkdtemp(
       path.join(os.tmpdir(), 'wharfie-lambda-poll-'),
     );
@@ -77,6 +79,10 @@ describe('Lambda service queue poll loop (gRPC)', () => {
 
     const { default: Function } =
       await import('../../../src/core/resources/builds/function.js');
+    const operationsStore = createOperationsStore({
+      db,
+      tableName: 'lambda-operations',
+    });
 
     const lambdaSvc = await startLambdaService({
       host: '127.0.0.1',
@@ -95,18 +101,20 @@ describe('Lambda service queue poll loop (gRPC)', () => {
         waitTimeSeconds: 0,
         maxNumberOfMessages: 1,
         visibilityTimeout: 5,
+        operationsStore,
+        appName: 'lambda-poll-app',
       },
     });
 
     try {
-      // Enqueue an invocation message.
-      await queue.sendMessage({
+      const payload = {
+        activity: fnName,
+        event: { who: 'world' },
+        context: { requestId: 'test' },
+      };
+      const sendResult = await queue.sendMessage({
         QueueUrl: 'lambda-invoke',
-        MessageBody: JSON.stringify({
-          functionName: fnName,
-          event: { who: 'world' },
-          context: { requestId: 'test' },
-        }),
+        MessageBody: JSON.stringify(payload),
       });
 
       // Wait for the function to write to DB via gRPC->worker RPC chain.
@@ -124,6 +132,50 @@ describe('Lambda service queue poll loop (gRPC)', () => {
         who: 'world',
         message: 'hello world',
       });
+
+      const resourceId = getSyntheticAppResourceId('lambda-poll-app');
+      const persisted = /** @type {{ operation: any, actions: any[] }} */ (
+        await waitFor(async () => {
+          const records = await operationsStore.getRecords(
+            resourceId,
+            sendResult.MessageId,
+          );
+          const operation = records.operations.find(
+            (candidate) => candidate.id === sendResult.MessageId,
+          );
+          if (!operation || operation.status !== 'COMPLETED') {
+            return null;
+          }
+          return { operation, actions: records.actions };
+        })
+      );
+
+      expect(persisted.operation.resource_id).toBe(resourceId);
+      expect(persisted.operation.operation_config).toEqual(
+        expect.objectContaining({
+          app: 'lambda-poll-app',
+          activity: fnName,
+          trigger: expect.objectContaining({
+            source: 'event',
+            queueUrl: 'lambda-invoke',
+            messageId: sendResult.MessageId,
+            receiptHandle: expect.any(String),
+          }),
+        }),
+      );
+      expect(persisted.operation.operation_inputs).toEqual(payload);
+      expect(persisted.actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            operation_id: sendResult.MessageId,
+            resource_id: resourceId,
+            function_name: fnName,
+            inputs: { who: 'world' },
+            attempt_count: 1,
+            status: 'COMPLETED',
+          }),
+        ]),
+      );
 
       // Queue message should be acked (deleted)
       const q = await queue.receiveMessage({
@@ -146,7 +198,7 @@ describe('Lambda service queue poll loop (gRPC)', () => {
     }
   });
 
-  it('polls queue messages and launches workers based on v2 envelope shape', async () => {
+  it('keeps failed queue messages retryable and records a failed event run', async () => {
     const tmp = await fsp.mkdtemp(
       path.join(os.tmpdir(), 'wharfie-lambda-poll-'),
     );
@@ -165,90 +217,103 @@ describe('Lambda service queue poll loop (gRPC)', () => {
 
     const db = createGrpcRpcClient({ address: dbSvc.address });
     const queue = createGrpcRpcClient({ address: queueSvc.address });
-
-    const fnName = `test-lambda-fn-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
-
-    const bundleCode = `
-      global[Symbol.for(${JSON.stringify(fnName)})] = async (event, context) => {
-        const who = event?.who || 'world';
-        await context.resources.db.put({
-          tableName: 'lambda',
-          keyName: 'id',
-          record: { id: 'greeting', who, message: 'hello ' + who }
-        });
-      };
-    `;
-
-    const assetDescription = {
-      codeBundle: brotliCompressSync(Buffer.from(bundleCode, 'utf8')).toString(
-        'base64',
-      ),
-      externalsTar: '',
-    };
-
-    seaAssets.set(fnName, assetDescription);
-
-    const { default: Function } =
-      await import('../../../src/core/resources/builds/function.js');
+    const operationsStore = createOperationsStore({
+      db,
+      tableName: 'lambda-operations-failure',
+    });
 
     const lambdaSvc = await startLambdaService({
       host: '127.0.0.1',
       port: 0,
-      execute: async ({ functionName, event, context }) => {
-        await Function.run(functionName, event, context ?? {}, {
-          resources: {
-            db,
-            queue,
-          },
-        });
+      execute: async () => {
+        throw new Error('boom');
       },
       poll: {
         queue,
         queueUrls: ['lambda-invoke'],
         waitTimeSeconds: 0,
         maxNumberOfMessages: 1,
-        visibilityTimeout: 5,
+        visibilityTimeout: 1,
+        operationsStore,
+        appName: 'lambda-poll-app',
       },
     });
 
     try {
-      // Enqueue an invocation message (v2 envelope)
-      await queue.sendMessage({
+      const payload = {
+        activity: 'failing-activity',
+        event: { who: 'world' },
+        context: { requestId: 'test-failure' },
+      };
+      const sendResult = await queue.sendMessage({
         QueueUrl: 'lambda-invoke',
-        MessageBody: JSON.stringify({
-          v: 2,
-          actor: fnName,
-          event: { who: 'world' },
-          context: { requestId: 'test' },
+        MessageBody: JSON.stringify(payload),
+      });
+
+      const resourceId = getSyntheticAppResourceId('lambda-poll-app');
+      const persisted = /** @type {{ operation: any, actions: any[] }} */ (
+        await waitFor(async () => {
+          const records = await operationsStore.getRecords(
+            resourceId,
+            sendResult.MessageId,
+          );
+          const operation = records.operations.find(
+            (candidate) => candidate.id === sendResult.MessageId,
+          );
+          if (!operation || operation.status !== 'FAILED') {
+            return null;
+          }
+          return { operation, actions: records.actions };
+        })
+      );
+
+      expect(persisted.operation.operation_config).toEqual(
+        expect.objectContaining({
+          app: 'lambda-poll-app',
+          activity: 'failing-activity',
+          trigger: expect.objectContaining({
+            source: 'event',
+            queueUrl: 'lambda-invoke',
+            messageId: sendResult.MessageId,
+          }),
         }),
-      });
+      );
+      expect(persisted.operation.operation_inputs).toEqual(payload);
+      expect(persisted.actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            operation_id: sendResult.MessageId,
+            resource_id: resourceId,
+            function_name: 'failing-activity',
+            attempt_count: 1,
+            status: 'FAILED',
+            error: expect.objectContaining({
+              message: 'boom',
+            }),
+          }),
+        ]),
+      );
 
-      // Wait for the function to write to DB via gRPC->worker RPC chain.
-      const record = await waitFor(async () => {
-        const r = await db.get({
-          tableName: 'lambda',
-          keyName: 'id',
-          keyValue: 'greeting',
-        });
-        return r;
-      });
+      await lambdaSvc.close();
+      await new Promise((resolve) => setTimeout(resolve, 1100));
 
-      expect(record).toEqual({
-        id: 'greeting',
-        who: 'world',
-        message: 'hello world',
-      });
-
-      // Queue message should be acked (deleted)
       const q = await queue.receiveMessage({
         QueueUrl: 'lambda-invoke',
         MaxNumberOfMessages: 1,
         WaitTimeSeconds: 0,
       });
 
-      expect(q?.Messages?.length || 0).toBe(0);
+      expect(q?.Messages?.length || 0).toBe(1);
+      expect(q.Messages[0]).toEqual(
+        expect.objectContaining({
+          MessageId: sendResult.MessageId,
+          Body: JSON.stringify(payload),
+        }),
+      );
     } finally {
-      await lambdaSvc.close();
+      try {
+        await lambdaSvc.close();
+      } catch {}
       try {
         db.__wharfie_closeTransport && db.__wharfie_closeTransport();
       } catch {}

--- a/test/runtime/services/node-agent-orchestration.test.js
+++ b/test/runtime/services/node-agent-orchestration.test.js
@@ -1,8 +1,11 @@
 /* eslint-env jest */
 /* eslint-disable jsdoc/require-jsdoc */
 
+import { mkdtempSync, rmSync } from 'node:fs';
 import http from 'node:http';
 import { EventEmitter } from 'node:events';
+import os from 'node:os';
+import path from 'node:path';
 
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
@@ -106,6 +109,38 @@ async function loadNodeAgent(options = {}) {
   return { NodeAgent, spawnMock, startSchedulerService };
 }
 
+/**
+ * @template T
+ * @param {Record<string, string | undefined>} overrides - overrides.
+ * @param {() => T | Promise<T>} fn - fn.
+ * @returns {Promise<T>} - Result.
+ */
+async function withEnv(overrides, fn) {
+  /** @type {Record<string, string | undefined>} */
+  const previous = {};
+
+  for (const [key, value] of Object.entries(overrides)) {
+    previous[key] = process.env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 afterEach(() => {
   jest.restoreAllMocks();
   jest.resetModules();
@@ -138,155 +173,173 @@ describe('NodeAgent orchestration', () => {
     const schedulerInvoke = jest.fn(async () => {});
     /** @type {Map<string, { args: string[], options: any, child: any }>} */
     const spawned = new Map();
+    const dbPath = mkdtempSync(
+      path.join(os.tmpdir(), 'wharfie-node-agent-orchestration-'),
+    );
 
-    const { NodeAgent, spawnMock, startSchedulerService } = await loadNodeAgent(
-      {
-        spawnImpl: (cmd, args, options) => {
-          const serveIndex = args.indexOf('serve');
-          const name =
-            serveIndex >= 0 && typeof args[serveIndex + 1] === 'string'
-              ? args[serveIndex + 1]
-              : `unknown-${spawned.size}`;
-          const child = createChild(name, {
-            exitOnSigterm: name !== 'queue',
+    try {
+      const { NodeAgent, spawnMock, startSchedulerService } =
+        await loadNodeAgent({
+          spawnImpl: (cmd, args, options) => {
+            const serveIndex = args.indexOf('serve');
+            const name =
+              serveIndex >= 0 && typeof args[serveIndex + 1] === 'string'
+                ? args[serveIndex + 1]
+                : `unknown-${spawned.size}`;
+            const child = createChild(name, {
+              exitOnSigterm: name !== 'queue',
+            });
+            spawned.set(name, { args, options: { ...options, cmd }, child });
+            return child;
+          },
+          startSchedulerServiceImpl: async () => ({ stop: schedulerStop }),
+        });
+
+      jest.spyOn(console, 'log').mockImplementation(() => {});
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await withEnv(
+        {
+          NODE_ENV: 'development',
+          OPERATIONS_TABLE: 'node-agent-orchestration-test',
+          WHARFIE_DB_ADAPTER: 'vanilla',
+          WHARFIE_DB_PATH: dbPath,
+        },
+        async () => {
+          const agent = new NodeAgent({
+            nodeId: 'node-all',
+            role: 'all',
+            resourcesSpec,
+            manifest,
+            cmd: '/fake/node',
+            prefixArgs: ['/fake/cli'],
+            lambdaHost: '127.0.0.1',
+            lambdaPort: 8787,
+            dbHost: '127.0.0.1',
+            dbPort: 8788,
+            queueHost: '127.0.0.1',
+            queuePort: 8789,
+            controlHost: '127.0.0.1',
+            controlPort: 0,
+            dbAddressOverride: null,
+            queueAddressOverride: null,
+            pollQueueUrls: ['queue://scheduled'],
+            schedulerInvoke,
           });
-          spawned.set(name, { args, options: { ...options, cmd }, child });
-          return child;
+
+          await agent.start();
+
+          expect(spawnMock).toHaveBeenCalledTimes(3);
+          expect(startSchedulerService).toHaveBeenCalledWith(
+            expect.objectContaining({
+              role: 'all',
+              triggers: [{ actor: 'alpha', cron: '* * * * *' }],
+              invoke: expect.any(Function),
+              log: expect.any(Function),
+            }),
+          );
+
+          expect(spawned.get('db')?.args).toEqual(
+            expect.arrayContaining([
+              '/fake/cli',
+              'ctl',
+              'state',
+              'serve',
+              'db',
+              '--host',
+              '127.0.0.1',
+              '--port',
+              '8788',
+            ]),
+          );
+          expect(spawned.get('queue')?.args).toEqual(
+            expect.arrayContaining([
+              '/fake/cli',
+              'ctl',
+              'state',
+              'serve',
+              'queue',
+              '--host',
+              '127.0.0.1',
+              '--port',
+              '8789',
+            ]),
+          );
+          expect(spawned.get('lambda')?.args).toEqual(
+            expect.arrayContaining([
+              '/fake/cli',
+              'ctl',
+              'state',
+              'serve',
+              'lambda',
+              '--host',
+              '127.0.0.1',
+              '--port',
+              '8787',
+              '--db-address',
+              '127.0.0.1:8788',
+              '--queue-address',
+              '127.0.0.1:8789',
+              '--poll-queue-url',
+              'queue://scheduled',
+            ]),
+          );
+
+          expect(spawned.get('db')?.options.env.WHARFIE_APP_MANIFEST).toBe(
+            JSON.stringify(manifest),
+          );
+
+          const controlAddress = agent.control?.address();
+          if (!controlAddress || typeof controlAddress === 'string') {
+            throw new Error('control plane did not expose a usable address');
+          }
+
+          const health = await getJson(
+            `http://127.0.0.1:${controlAddress.port}/health`,
+          );
+
+          expect(health.statusCode).toBe(200);
+          expect(health.body).toEqual(
+            expect.objectContaining({
+              ok: true,
+              nodeId: 'node-all',
+              role: 'all',
+              endpoints: {
+                lambda: '127.0.0.1:8787',
+                db: '127.0.0.1:8788',
+                queue: '127.0.0.1:8789',
+              },
+            }),
+          );
+          const services = /** @type {{ name: string, running: boolean }[]} */ (
+            health.body.services
+          );
+          expect(services.map((service) => service.name)).toEqual([
+            'db',
+            'queue',
+            'lambda',
+          ]);
+          expect(services.every((service) => service.running)).toBe(true);
+
+          const waitPromise = agent.waitForever();
+          await agent.stop('SIGTERM');
+          await waitPromise;
+
+          expect(schedulerStop).toHaveBeenCalledTimes(1);
+          expect(spawned.get('db')?.child.kill).toHaveBeenCalledWith('SIGTERM');
+          expect(spawned.get('lambda')?.child.kill).toHaveBeenCalledWith(
+            'SIGTERM',
+          );
+          expect(spawned.get('queue')?.child.kill.mock.calls).toEqual([
+            ['SIGTERM'],
+            ['SIGKILL'],
+          ]);
+          expect(agent.control).toBeNull();
         },
-        startSchedulerServiceImpl: async () => ({ stop: schedulerStop }),
-      },
-    );
-
-    jest.spyOn(console, 'log').mockImplementation(() => {});
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-
-    const agent = new NodeAgent({
-      nodeId: 'node-all',
-      role: 'all',
-      resourcesSpec,
-      manifest,
-      cmd: '/fake/node',
-      prefixArgs: ['/fake/cli'],
-      lambdaHost: '127.0.0.1',
-      lambdaPort: 8787,
-      dbHost: '127.0.0.1',
-      dbPort: 8788,
-      queueHost: '127.0.0.1',
-      queuePort: 8789,
-      controlHost: '127.0.0.1',
-      controlPort: 0,
-      dbAddressOverride: null,
-      queueAddressOverride: null,
-      pollQueueUrls: ['queue://scheduled'],
-      schedulerInvoke,
-    });
-
-    await agent.start();
-
-    expect(spawnMock).toHaveBeenCalledTimes(3);
-    expect(startSchedulerService).toHaveBeenCalledWith(
-      expect.objectContaining({
-        role: 'all',
-        triggers: [{ actor: 'alpha', cron: '* * * * *' }],
-        invoke: schedulerInvoke,
-        log: expect.any(Function),
-      }),
-    );
-
-    expect(spawned.get('db')?.args).toEqual(
-      expect.arrayContaining([
-        '/fake/cli',
-        'ctl',
-        'state',
-        'serve',
-        'db',
-        '--host',
-        '127.0.0.1',
-        '--port',
-        '8788',
-      ]),
-    );
-    expect(spawned.get('queue')?.args).toEqual(
-      expect.arrayContaining([
-        '/fake/cli',
-        'ctl',
-        'state',
-        'serve',
-        'queue',
-        '--host',
-        '127.0.0.1',
-        '--port',
-        '8789',
-      ]),
-    );
-    expect(spawned.get('lambda')?.args).toEqual(
-      expect.arrayContaining([
-        '/fake/cli',
-        'ctl',
-        'state',
-        'serve',
-        'lambda',
-        '--host',
-        '127.0.0.1',
-        '--port',
-        '8787',
-        '--db-address',
-        '127.0.0.1:8788',
-        '--queue-address',
-        '127.0.0.1:8789',
-        '--poll-queue-url',
-        'queue://scheduled',
-      ]),
-    );
-
-    expect(spawned.get('db')?.options.env.WHARFIE_APP_MANIFEST).toBe(
-      JSON.stringify(manifest),
-    );
-
-    const controlAddress = agent.control?.address();
-    if (!controlAddress || typeof controlAddress === 'string') {
-      throw new Error('control plane did not expose a usable address');
+      );
+    } finally {
+      rmSync(dbPath, { recursive: true, force: true });
     }
-
-    const health = await getJson(
-      `http://127.0.0.1:${controlAddress.port}/health`,
-    );
-
-    expect(health.statusCode).toBe(200);
-    expect(health.body).toEqual(
-      expect.objectContaining({
-        ok: true,
-        nodeId: 'node-all',
-        role: 'all',
-        endpoints: {
-          lambda: '127.0.0.1:8787',
-          db: '127.0.0.1:8788',
-          queue: '127.0.0.1:8789',
-        },
-      }),
-    );
-    const services = /** @type {{ name: string, running: boolean }[]} */ (
-      health.body.services
-    );
-    expect(services.map((service) => service.name)).toEqual([
-      'db',
-      'queue',
-      'lambda',
-    ]);
-    expect(services.every((service) => service.running)).toBe(true);
-
-    const waitPromise = agent.waitForever();
-    await agent.stop('SIGTERM');
-    await waitPromise;
-
-    expect(schedulerStop).toHaveBeenCalledTimes(1);
-    expect(spawned.get('db')?.child.kill).toHaveBeenCalledWith('SIGTERM');
-    expect(spawned.get('lambda')?.child.kill).toHaveBeenCalledWith('SIGTERM');
-    expect(spawned.get('queue')?.child.kill.mock.calls).toEqual([
-      ['SIGTERM'],
-      ['SIGKILL'],
-    ]);
-    expect(agent.control).toBeNull();
   });
 
   it('uses normalized remote state overrides for worker nodes and only spawns lambda', async () => {

--- a/test/runtime/services/node-agent-scheduler.test.js
+++ b/test/runtime/services/node-agent-scheduler.test.js
@@ -1,8 +1,18 @@
 /* eslint-env jest */
 /* eslint-disable jsdoc/require-jsdoc */
 
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import { jest } from '@jest/globals';
 
+import createVanillaDB from '../../../src/core/lib/db/adapters/vanilla.js';
+import operationsStoreFactory from '../../../src/core/lib/graph/operations-store.js';
+import Action, {
+  Status as ActionStatus,
+} from '../../../src/core/lib/graph/action.js';
+import { Status as OperationStatus } from '../../../src/core/lib/graph/operation.js';
 import NodeAgent from '../../../src/core/runtime/services/node-agent.js';
 
 describe('NodeAgent scheduler wiring', () => {
@@ -10,65 +20,127 @@ describe('NodeAgent scheduler wiring', () => {
     jest.useRealTimers();
   });
 
-  it('starts scheduler-service in leader mode and invokes cron triggers', async () => {
+  it('starts scheduler-service in leader mode, persists cron runs, and invokes cron triggers', async () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2026-02-18T00:00:30.000Z'));
 
+    const dbPath = mkdtempSync(
+      path.join(os.tmpdir(), 'wharfie-node-agent-scheduler-'),
+    );
+    const tableName = 'node-agent-scheduler-test';
     const invoke = jest.fn(async () => {});
-
-    const agent = new NodeAgent({
-      nodeId: 'test-node',
-      role: 'leader',
-      resourcesSpec: {},
-      manifest: {
-        app: { name: 'scheduler-demo' },
-        functions: [
-          {
-            name: 'alpha',
-            entrypoint: {
-              path: '/artifact/functions/alpha.js',
-              export: 'alpha',
-            },
-          },
-        ],
-        scheduler: {
-          triggers: [{ actor: 'alpha', cron: '* * * * *' }],
-        },
-      },
-      cmd: process.execPath,
-      prefixArgs: [],
-      lambdaHost: '127.0.0.1',
-      lambdaPort: 8787,
-      dbHost: '127.0.0.1',
-      dbPort: 8788,
-      queueHost: '127.0.0.1',
-      queuePort: 8789,
-      controlHost: '127.0.0.1',
-      controlPort: 0,
-      dbAddressOverride: null,
-      queueAddressOverride: null,
-      pollQueueUrls: [],
-      spawnServices: false,
-      schedulerInvoke: invoke,
-    });
+    /** @type {import('../../../src/core/lib/db/base.js').DBClient | undefined} */
+    let inspectDb;
 
     try {
-      await agent.start();
+      await withEnv(
+        {
+          NODE_ENV: 'development',
+          OPERATIONS_TABLE: tableName,
+          WHARFIE_DB_ADAPTER: 'vanilla',
+          WHARFIE_DB_PATH: dbPath,
+        },
+        async () => {
+          const agent = new NodeAgent({
+            nodeId: 'test-node',
+            role: 'leader',
+            resourcesSpec: {},
+            manifest: {
+              app: { name: 'scheduler-demo' },
+              functions: [
+                {
+                  name: 'alpha',
+                  entrypoint: {
+                    path: '/artifact/functions/alpha.js',
+                    export: 'alpha',
+                  },
+                },
+              ],
+              scheduler: {
+                triggers: [{ actor: 'alpha', cron: '* * * * *' }],
+              },
+            },
+            cmd: process.execPath,
+            prefixArgs: [],
+            lambdaHost: '127.0.0.1',
+            lambdaPort: 8787,
+            dbHost: '127.0.0.1',
+            dbPort: 8788,
+            queueHost: '127.0.0.1',
+            queuePort: 8789,
+            controlHost: '127.0.0.1',
+            controlPort: 0,
+            dbAddressOverride: null,
+            queueAddressOverride: null,
+            pollQueueUrls: [],
+            spawnServices: false,
+            schedulerInvoke: invoke,
+          });
 
-      expect(invoke).toHaveBeenCalledTimes(0);
+          try {
+            await agent.start();
 
-      // Next match after 00:00:30Z for "* * * * *" is 00:01:00Z.
-      await jest.advanceTimersByTimeAsync(30_000);
+            expect(invoke).toHaveBeenCalledTimes(0);
 
-      expect(invoke).toHaveBeenCalledTimes(1);
-      expect(invoke).toHaveBeenCalledWith('alpha', {
-        cron: '* * * * *',
-        scheduledTime: '2026-02-18T00:01:00.000Z',
-      });
+            // Next match after 00:00:30Z for "* * * * *" is 00:01:00Z.
+            await jest.advanceTimersByTimeAsync(30_000);
+
+            expect(invoke).toHaveBeenCalledTimes(1);
+            expect(invoke).toHaveBeenCalledWith('alpha', {
+              cron: '* * * * *',
+              scheduledTime: '2026-02-18T00:01:00.000Z',
+            });
+          } finally {
+            const stopPromise = agent.stop('SIGTERM');
+            await jest.advanceTimersByTimeAsync(2000);
+            await stopPromise;
+          }
+        },
+      );
+
+      inspectDb = createVanillaDB({ path: dbPath });
+      const inspectStore = operationsStoreFactory({ db: inspectDb, tableName });
+      const operations = await inspectStore.getOperations('app:scheduler-demo');
+
+      expect(operations).toHaveLength(1);
+      expect(operations[0]).toEqual(
+        expect.objectContaining({
+          status: OperationStatus.COMPLETED,
+          operation_config: {
+            source: 'scheduler',
+            app_name: 'scheduler-demo',
+            activity_name: 'alpha',
+            trigger: {
+              source: 'cron',
+              cron: '* * * * *',
+              scheduledTime: '2026-02-18T00:01:00.000Z',
+            },
+          },
+          operation_inputs: {
+            cron: '* * * * *',
+            scheduledTime: '2026-02-18T00:01:00.000Z',
+          },
+        }),
+      );
+
+      const actions = await inspectStore.getActions(operations[0]);
+      expect(actions).toHaveLength(1);
+      expect(actions[0]).toEqual(
+        expect.objectContaining({
+          id: 'invoke',
+          type: Action.Type.INVOKE_FUNCTION,
+          status: ActionStatus.COMPLETED,
+          function_name: 'alpha',
+          inputs: {
+            cron: '* * * * *',
+            scheduledTime: '2026-02-18T00:01:00.000Z',
+          },
+          attempt_count: 1,
+        }),
+      );
     } finally {
-      const stopPromise = agent.stop('SIGTERM');
-      await jest.advanceTimersByTimeAsync(2000);
-      await stopPromise;
+      await inspectDb?.close?.();
+      rmSync(dbPath, { recursive: true, force: true });
     }
   });
 
@@ -151,3 +223,35 @@ describe('NodeAgent scheduler wiring', () => {
     }
   });
 });
+
+/**
+ * @template T
+ * @param {Record<string, string | undefined>} overrides - overrides.
+ * @param {() => Promise<T>} fn - fn.
+ * @returns {Promise<T>} - Result.
+ */
+async function withEnv(overrides, fn) {
+  /** @type {Record<string, string | undefined>} */
+  const previous = {};
+
+  for (const [key, value] of Object.entries(overrides)) {
+    previous[key] = process.env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}

--- a/test/runtime/services/runtime-bootstrap.test.js
+++ b/test/runtime/services/runtime-bootstrap.test.js
@@ -1,9 +1,14 @@
 /* eslint-env jest */
 /* eslint-disable jsdoc/require-jsdoc */
 
+import os from 'node:os';
+import path from 'node:path';
+import { promises as fsp } from 'node:fs';
+
 import { afterEach, describe, expect, it } from '@jest/globals';
 
 import { loadRuntimeBootstrap } from '../../../src/core/resources/builds/actor-system-cli/lib/runtime-bootstrap.js';
+import { SHARED_RESOURCE_REGISTRY_FILE_NAME } from '../../../src/core/runtime/shared-resource-registry.js';
 
 const ORIGINAL_ENV = process.env;
 
@@ -42,6 +47,7 @@ const manifest = {
 
 afterEach(() => {
   process.env = ORIGINAL_ENV;
+  delete process.env.CONFIG_DIR;
   delete process.env.WHARFIE_RESOURCES;
   delete process.env.WHARFIE_APP_MANIFEST;
 });
@@ -97,6 +103,68 @@ describe('runtime bootstrap helpers', () => {
       db: false,
       queue: true,
       objectStorage: false,
+      lambda: true,
+      scheduler: true,
+    });
+  });
+
+  it('resolves shared resource refs from the Wharfie config dir before planning services', async () => {
+    const configDir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'wharfie-bootstrap-config-'),
+    );
+    process.env.CONFIG_DIR = configDir;
+
+    const sharedRegistry = {
+      db: {
+        appdb: {
+          adapter: 'vanilla',
+          options: { path: '.shared/db' },
+        },
+      },
+      queue: {
+        jobs: {
+          adapter: 'vanilla',
+          options: {
+            path: '.shared/queue',
+            queueUrls: ['queue://shared-jobs'],
+          },
+        },
+      },
+      objectStorage: {
+        blobs: {
+          adapter: 'vanilla',
+          options: { path: '.shared/object-storage' },
+        },
+      },
+    };
+
+    await fsp.writeFile(
+      path.join(configDir, SHARED_RESOURCE_REGISTRY_FILE_NAME),
+      JSON.stringify(sharedRegistry, null, 2),
+      'utf8',
+    );
+
+    const bootstrap = await loadRuntimeBootstrap({
+      manifest: JSON.stringify({
+        ...manifest,
+        resources: {
+          db: { ref: 'appdb' },
+          queue: { ref: 'jobs' },
+          objectStorage: { ref: 'blobs' },
+        },
+      }),
+    });
+
+    expect(bootstrap.resourcesSpec).toEqual({
+      db: sharedRegistry.db.appdb,
+      queue: sharedRegistry.queue.jobs,
+      objectStorage: sharedRegistry.objectStorage.blobs,
+    });
+    expect(bootstrap.pollQueueUrls).toEqual(['queue://shared-jobs']);
+    expect(bootstrap.servicePlan).toEqual({
+      db: true,
+      queue: true,
+      objectStorage: true,
       lambda: true,
       scheduler: true,
     });


### PR DESCRIPTION
This PR makes the v2 app model the primary Wharfie path.

### What changes

- cuts the public plain-object app contract over to:
  - `cli.entrypoint`
  - `activities`
  - workflow `activity`
  - scheduler trigger `activity`
- makes `wharfie app run` activity-first
- makes `wharfie app package` work for manifest-defined CLI apps
- makes packaged artifacts default to the developer CLI
- moves runtime startup behind hidden bootstrap mode
- switches deploy/systemd to direct artifact execution
- makes `wharfie ops` app-centric for persisted activity/workflow runs
- persists cron-triggered and queue-triggered activity runs
- adds config-dir backed shared refs for `db`, `queue`, and `objectStorage`
- updates docs/tests to the new contract

### Breaking changes

- plain-object apps must use `activities`, not `functions`
- plain-object workflow actions must use `activity`, not `functionName`
- plain-object scheduler triggers must use `activity`, not `actor` / `functionName`
- `wharfie ops` is now app-centric rather than raw-resource-centric