### PR TITLE
Define the Wharfie project reset

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,126 @@
+# Wharfie project charter
+
+**Status:** active project reset · **Last updated:** 2026-07-16
+
+## One sentence
+
+Wharfie is a local-first TypeScript application runtime that turns an ordinary CLI into a portable executable, then lets that same application become a durable, observable service across trusted machines without an architectural rewrite.
+
+## Why Wharfie exists
+
+LLMs make it cheap to express intent as working local software. They do not make that software durable, deployable, observable, or safe to evolve. A useful program often ends with the coding session that created it, or has to be rewritten around containers, infrastructure definitions, schedulers, and a hosted control plane before it can continue unattended.
+
+Wharfie closes that authoring-to-operation gap. It carries an operator-approved program beyond a laptop or chat session by preserving concrete, inspectable state:
+
+- immutable application revisions;
+- declared activities, workflows, schedules, and runtime capabilities;
+- durable run and invocation state;
+- attempts and externally visible effects;
+- deployment, ownership, and node state; and
+- operator decisions such as approvals, retries, upgrades, and rollbacks.
+
+Wharfie does not preserve an abstract "will" or a chat transcript. It preserves executable behavior and the legible history required to understand and evolve that behavior.
+
+## North-star experience
+
+A developer should be able to:
+
+1. Write a normal TypeScript CLI and run it locally with ordinary argv, stdio, and exit semantics.
+2. Mark named operations as durable activities and compose them into workflows or schedules.
+3. Package the application as one approachable executable that does not require Node, a container runtime, Kubernetes, or a hosted orchestration service on the target machine.
+4. Give that executable credentials through a provider's normal credential chain and preview the narrow runtime substrate it needs.
+5. Deploy it as a persistent service, close the laptop, and let the declared work continue.
+6. Return later with the same executable to inspect revisions, runs, attempts, effects, logs, and node health; intervene when necessary; and upgrade or roll back explicitly.
+7. Add trusted nodes when placement, capacity, or recovery requires them.
+
+Local and single-node operation require no external Wharfie control plane. Automatic coordinator replacement in the initial mesh design does require a linearizable durable store. A later mesh milestone—not the initial product proof—will validate worker and coordinator recovery across two nodes.
+
+## Product model
+
+- **Application:** the developer-owned CLI plus its declared operational behavior.
+- **Revision:** an immutable logical version of application behavior, configuration, and locked inputs. A revision owns target-specific artifacts, and runs pin the revision.
+- **Artifact:** a content-addressed executable or component payload for one target that belongs to a revision. "One executable" means one file for the selected target, not one binary that runs on every platform.
+- **Activity:** a named, serializable unit of work. This is the durable execution and placement boundary.
+- **Workflow:** durable coordination of activity invocations.
+- **Run:** one requested or triggered execution of application behavior.
+- **Invocation:** one logical activity execution within a run, stable across retries.
+- **Attempt:** one physical execution of an invocation under a lease and fencing token.
+- **Effect:** an operation routed through Wharfie's managed effect API, recorded under a stable identity with declared and substantiated replay properties. It can be pure or externally visible.
+- **Node:** a trusted machine enrolled in a deployment and authorized to run its permitted application revisions.
+- **Coordinator:** the authoritative lease holder that schedules and reconciles work for the current epoch.
+- **Capability:** a portable resource, property, or semantic guarantee that a node or deployment can provide and an application or activity can require, such as application state, fenced control state, artifact storage, ingress, identity, or a hardware feature. Placement constraints are predicates over advertised capabilities.
+- **Deployment:** the binding between an application revision, a deployment profile, fulfilled capabilities, and enrolled nodes.
+
+These are the public concepts. Existing actors, resources, graphs, and provider adapters are implementation material to reuse only where they support this model cleanly.
+
+## Scope
+
+Wharfie should provide:
+
+- a TypeScript/Node authoring and control-plane model;
+- a normal local CLI experience before any deployment is required;
+- a portable, self-hosting executable distribution, currently built with Node SEA;
+- durable single-node execution with an inspectable run, invocation, attempt, and effect ledger;
+- schedules, workflows, retries, cancellation, intervention, and recovery;
+- a trusted-node mesh with explicit enrollment, capability-aware placement, and fenced leases;
+- one authoritative, fenced coordinator initially, with durable state outside its process and a robust replacement path;
+- capability fulfillment for the finite substrate required to run Wharfie applications;
+- standard plan, deploy, inspect, upgrade, rollback, and destroy operations under an explicit reserved operator namespace that cannot silently take over developer CLI commands; and
+- machine-readable CLI output so humans, scripts, and coding agents can operate the same system.
+
+## Deliberate boundaries
+
+Wharfie is not:
+
+- a continuation of the v1 Athena/table framework;
+- a general cloud infrastructure-as-code system;
+- a trustless, Byzantine, or internet-scale peer-to-peer mesh;
+- a hosted orchestration service requirement;
+- a general multi-language application framework or build system;
+- an agent framework, prompt store, or chat-session persistence layer; or
+- a promise that arbitrary user code physically executes exactly once.
+
+Breaking changes are expected during the reset. There are no current downstream users to preserve, so the repository should optimize for a coherent eventual design and fast learning rather than compatibility with v1 or incidental internal APIs.
+
+## Key semantics
+
+### Trusted mesh and coordinator recovery
+
+All enrolled nodes are trusted. The first distributed design has one coordinator that is authoritative at the durable-store boundary, not one irreplaceable coordinator machine. A partitioned process can continue believing it is leader and issuing messages, so correctness cannot depend on stopping stale processes. Coordination state lives outside the coordinator process. Lease acquisition, renewal, and epoch increment are linearizable conditional operations using store-authoritative expiry. Every scheduling decision and commit carries the coordinator epoch, and each attempt additionally carries a per-invocation generation; storage rejects stale fencing values. A replacement coordinator reconstructs state from the durable ledger and safely reschedules unfinished work.
+
+Automatic failover initially depends on a provider-backed linearizable store. Local development may use SQLite or LMDB, but a local-only store cannot provide automatic failover after loss of its host. A later peer-quorum store can remove that provider dependency without changing the public model.
+
+### Committed outcomes and effects
+
+An invocation has at most one authoritative terminal outcome; once resolved, it has exactly one. Retryable runnable work uses at-least-once dispatch and can have overlapping physical attempts around failures. Only the current fenced attempt can commit Wharfie-managed state.
+
+Wharfie can make an external exactly-once claim only for operations routed through a managed effect adapter whose destination atomically enforces the effect identity with the business mutation. Managed operations declare substantiated properties such as `pure`, `idempotent`, or `transactional`; without a supported replay guarantee they are `unsafe`. These properties need not be mutually exclusive. Direct SDK calls from trusted in-process code are unmanaged. An in-process handler therefore defaults to `unsafe` after it begins unless its author opts into a substantiated replay-safe contract. An interrupted unsafe operation puts its invocation into a durable, blocked `uncertain` state; reconciliation must establish its result or create a distinct compensating invocation, never silently retry it or rewrite an already committed outcome.
+
+### Capability fulfillment
+
+Applications declare portable needs. Deployment profiles map those needs to AWS, another provider, SSH-accessible hosts, or local resources. Wharfie creates and reconciles only resources that implement first-class Wharfie capabilities. Provider-native application infrastructure remains application code or external IaC.
+
+Provisioning must use normal credential chains, preview mutations, distinguish managed resources from external references, record ownership receipts, bootstrap narrowly scoped runtime identities, and destroy only resources Wharfie owns.
+
+### Language boundary
+
+TypeScript/Node is the only initial authoring and orchestration model. Activity handlers default to in-process JavaScript, which may use target-specific Node-API dependencies. A versioned serializable boundary leaves room for WASI/WASM and persistent subprocess workers. Component effects are host-mediated; components do not receive coordinator or provider credentials. Wharfie packages validated outputs; it does not compile arbitrary language ecosystems.
+
+## Design principles
+
+1. **Continuity over machinery.** The product is the smooth path from local CLI to durable service; SEA, cloud resources, and mesh coordination support that path.
+2. **Local first, progressively durable.** A user should gain value before creating an account or deployment.
+3. **One artifact, one operator surface.** The application executable should remain the primary way to run, deploy, inspect, and evolve itself.
+4. **Explicit durable truth.** Revisions, leases, attempts, effects, ownership, and operator actions are data, not inference from logs.
+5. **Honest failure semantics.** Prefer `uncertain` and reconciliation to a false exactly-once claim.
+6. **Narrow portable abstractions.** Keep provider and language details behind finite contracts.
+7. **Delete migration scaffolding.** Reuse good v2 code, but do not preserve obsolete concepts merely because they already exist.
+8. **Agent legibility.** Deterministic builds, schemas, JSON output, small public concepts, and auditable state should make the system easy for both humans and coding agents to understand.
+
+## Success test
+
+Wharfie is worth building while it can answer yes to this question:
+
+> Can someone create a small CLI in a coding session, deploy it durably to a clean cloud account in minutes, close the session, return later to understand exactly what happened, and safely evolve it without learning a second application architecture?
+
+See [ROADMAP.md](ROADMAP.md) for the delivery sequence and [the architecture decision log](docs/architecture/decisions/README.md) for the decisions that constrain it.

--- a/README.md
+++ b/README.md
@@ -7,76 +7,49 @@
 </h1>
 
 <p align="center">
-  <a href="https://discord.gg/QEbzFUsR"><img src="https://img.shields.io/discord/1131550721142161408" alt="discord"></a>
   <a href="https://github.com/wharfie/wharfie/actions/workflows/ci.yml"><img src="https://github.com/wharfie/wharfie/actions/workflows/ci.yml/badge.svg" alt="Wharfie CI"></a>
 </p>
 
-Wharfie is an experimental table-oriented data application framework built ontop of [AWS Athena](https://aws.amazon.com/athena/). Designed to be fast to develop, confident to modify and cheap to run.
+> **Project reset:** Wharfie is experimental and is intentionally abandoning its v1 Athena/table APIs. Breaking changes are expected while the new application model is made coherent.
 
-Unlike most data tools, Wharfie has ZERO fixed infrastructure costs. Money is only spent when data is processed. Costs are also proportional to the size of the data processed, averaging around $5 per terabyte. Wharfie can tell you how much it will cost to run your application before you run it, and also can make sure that it will output what you expect before you spend time waiting for it to run.
+Wharfie is a local-first TypeScript application runtime that turns an ordinary CLI into a portable executable, then lets that same application become a durable, observable service across trusted machines without an architectural rewrite.
 
-Wharfie can work with data sizes ranging from bytes to petabytes. There are no looming performance cliffs that require a platform switch.
+The product goal is continuity:
 
-Wharfie is serverless and relies entirely on managed AWS services. There's no need for performance tuning or an on-call rotation to keep Wharfie running. When Wharfie breaks, it's usually because of upstream outages, which when resolved, unblock Wharfie from reprocessing and catching up to a functional state.
+1. Write and run a normal CLI locally.
+2. Mark named operations as durable activities.
+3. Package the application as one approachable executable.
+4. Promote it to a persistent service on one machine.
+5. Add schedules, workflows, retries, and durable state.
+6. Enroll more trusted nodes when placement or resilience requires them.
+7. Inspect, intervene in, update, and roll back the application through the same executable.
 
-When defining tables with Wharfie, you only need to statically define your table structure or the query used to materialize, and Wharfie takes care of the rest.
+No separate service rewrite, preinstalled Node runtime, Dockerfile, Kubernetes cluster, or hosted orchestration service should be required on the target machine.
 
-"The Rest" includes:
+Local and single-node use should require no external Wharfie control plane. The initial automatic coordinator-failover design does depend on a linearizable durable store.
 
-- Registering new partitions
-- Converting compression and data formats
-- Repartitioning
-- Managing schema changes
+The repository contains useful v2 runtime and Node SEA packaging foundations, but its release wiring and several implementation paths are still being consolidated. It is not ready for production use.
 
-### ⚡️ Quickstart
+## Start here
 
-#### Install
+- [Project charter](PROJECT.md) — the canonical problem, scope, public concepts, boundaries, and success test.
+- [Architecture decisions](docs/architecture/decisions/README.md) — accepted constraints on trusted nodes, coordination, provisioning, effects, and language boundaries.
+- [Roadmap](ROADMAP.md) — the live ordered cleanup and implementation plan.
+- [July 2026 checkpoint](llm/checkpoints/2026-07-16-project-reset.md) — immutable historical evidence of the pre-reset state and conversation handoff.
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/wharfie/wharfie/master/install.sh | bash
-```
+The charter and accepted decisions are authoritative; the roadmap is expected to evolve, and dated checkpoints are historical snapshots. Older material under `docs/` and `llm/design/` describes prior iterations and can be stale.
 
-For Windows:
+## Current development checks
 
-```ps1
-iex (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/wharfie/wharfie/master/install.ps1" -UseBasicParsing).Content
-```
-
-#### Example
-
-```bash
-wharfie config
-wharfie init my_project
-wharfie app manifest ./apps/wharfie-v1
-```
-
-The current ESM CLI ships these top-level commands: `config`, `init`, `app`, `ops`, `list`, and `build-self`.
-The legacy `deployment`, `project`, and `utils` command groups have been removed from the repo.
-
-### Reference
-
-[docs.wharfie.dev](docs.wharfie.dev)
-
-### Operation DAG inspection/execution (v2)
-
-The `wharfie ops` command group exposes local, provider-neutral tooling for inspecting and executing persisted operation DAGs.
+Use the pinned versions in `package.json` (currently Node 24.13.1 and npm 11.12.0), install dependencies, and run:
 
 ```bash
-wharfie ops list <resourceId>
-wharfie ops cancel <resourceId> --operationId <operationId>
-wharfie ops run <resourceId> <operationId>
+npm run test:ci
 ```
 
-DB selection is explicit via env vars (default: `vanilla`):
+Current source is organized as follows:
 
-```bash
-export WHARFIE_DB_ADAPTER=vanilla   # or lmdb|dynamodb
-export WHARFIE_DB_PATH=/path/to/db
-```
-
-### Repository layout
-
-- `src/cli/` contains the shipped CLI entrypoint and commands.
-- `src/core/` contains runtime code, with `actors/`, `resources/`, and `runtime/` split out from the shared `lib/` subsystems.
-- `apps/` contains buildable reference apps and dogfood manifests.
-- `llm/` contains local design docs and prompt templates.
+- `src/cli/` — the current developer and operator CLI implementation.
+- `src/core/` — runtime, durable graph, resource, provider, and packaging foundations.
+- `apps/` — buildable reference and dogfood applications; v1 content is scheduled for removal.
+- `llm/` — design notes, prompt templates, and dated project checkpoints.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,137 @@
+# Wharfie roadmap
+
+**Status:** project reset in progress · **Last updated:** 2026-07-16
+
+This roadmap orders work by the shortest path to the experience in [PROJECT.md](PROJECT.md). It is intentionally willing to remove v1 behavior and break internal APIs. Each milestone should end in an executable proof, not only new abstractions.
+
+## Working rules
+
+- Optimize for the intended design; there are no known downstream users or compatibility requirements.
+- Keep `master` recoverable and tests meaningful while deleting obsolete code aggressively.
+- Prefer a narrow end-to-end path over parallel partial frameworks.
+- Treat Node SEA as the first packaging backend, not the permanent public abstraction.
+- Require explicit durable semantics at every network or side-effect boundary.
+- Pause for review before broad destructive GitHub cleanup or a major public-model rewrite.
+
+## Milestone 0 — preserve and reset
+
+**Goal:** make the new direction durable before removing old work.
+
+- [x] Inventory local and remote refs, pull requests, issues, tests, release wiring, and major implementation paths.
+- [x] Preserve every live remote branch tip under annotated `archive/2026-07-16/remote/...` tags on GitHub.
+- [x] Preserve the unpublished local `master` tip and old stash with local archive tags.
+- [x] Write the project charter and non-goals.
+- [x] Record the initial architecture decisions.
+- [x] Store a dated restart checkpoint in the repository.
+- [ ] Review and merge the reset documentation.
+
+**Exit:** a fresh maintainer or coding session can explain what Wharfie is, what it is not, what state was preserved, and what work comes next.
+
+## Milestone 1 — remove ambiguity and loose ends
+
+**Goal:** leave one honest codebase and one honest tracker.
+
+### Repository and tracker
+
+- [ ] Classify every non-default branch and open PR as absorb, supersede, or delete; link each decision to its archive tag.
+- [ ] Reconcile the three unpublished local `master` commits and `jvd/pr4` against the new charter.
+- [ ] Close stale PRs with a short preservation and supersession note.
+- [ ] Classify every open issue as roadmap work, useful research, or obsolete; label/milestone the first two and close the rest.
+- [ ] Remove stale project-board, release, and documentation promises.
+
+### Codebase
+
+- [ ] Delete the v1 Athena/table application, legacy-only tests, documentation, dependencies, and compatibility paths.
+- [ ] Choose one manifest compiler and one persisted-run implementation; delete the alternatives.
+- [ ] Make package metadata, version reporting, license metadata, tarball contents, release commands, environment names, and artifact names agree.
+- [ ] Update direct dependencies, resolve the current production audit findings, and add an appropriate audit gate.
+- [ ] Expand CI to validate the package tarball, build a real SEA artifact, and smoke-test `--help` and `--version` on a clean target.
+- [ ] Make the remaining test, type-check, and lint exclusions explicit and temporary or remove them.
+
+**Exit:** the README, shipped package, release workflow, CI, current source, and GitHub tracker all describe the same v2 product; no Athena/v1 surface remains.
+
+## Milestone 2 — one portable application
+
+**Goal:** prove a normal CLI can become one self-contained application artifact without changing its programming model.
+
+- [ ] Define the minimal TypeScript application manifest around a developer-owned CLI and named activities.
+- [ ] Define schemas and stable identifiers for applications, immutable logical revisions, target-specific artifacts, activities, and deployment profiles.
+- [ ] Preserve normal argv, stdio, exit codes, and CLI-library choice in local and packaged execution.
+- [ ] Package one content-addressed SEA executable for a clean Linux target and record its locked inputs and provenance; reproducible builds are a later hardening goal.
+- [ ] Define a reserved, non-colliding dispatch mechanism for Wharfie operator commands inside an application-owned executable.
+- [ ] Define the versioned activity protocol and test its serialization, cancellation, deadline, log, error, and host-effect boundaries without requiring a second language implementation yet.
+- [ ] Build one executable example and an end-to-end test from source to clean-machine execution.
+
+**Exit:** a TypeScript CLI runs locally, produces a content-addressed artifact, and runs on a clean machine without a preinstalled Node runtime.
+
+## Milestone 3 — one durable node
+
+**Goal:** let the packaged application remain resident and recover work after process or machine restart.
+
+- [ ] Decide and record whether durable workflows use deterministic replay or an explicitly persisted state-machine/continuation model, including timers, signals, cancellation, side effects, and revision changes.
+- [ ] Define the run → invocation → attempt → effect ledger and state machines.
+- [ ] Persist immutable revision bindings, inputs, outputs, scheduling decisions, attempts, and operator actions.
+- [ ] Implement leases, monotonic fencing tokens, heartbeats, cancellation, retry policy, and recovery.
+- [ ] Implement substantiated `pure`, `idempotent`, and `transactional` replay properties, make begun in-process handlers `unsafe` by default, and add a durable blocked `uncertain` state with explicit reconciliation/compensation paths.
+- [ ] Provide transactional inbox/outbox behavior for Wharfie-managed state and queues, with destination-side deduplication committed atomically with consumer mutations where exactly-once processing is claimed.
+- [ ] Support manual, cron, and workflow-triggered runs through one execution path.
+- [ ] Install/uninstall the artifact as an OS-managed resident service, initially systemd, with startup on boot, health reporting, graceful shutdown/restart, and reboot recovery.
+- [ ] Make service status, logs, run history, retry, cancel, approve, and effect reconciliation available as human-readable and JSON operations in the reserved operator namespace.
+- [ ] Prove recovery with deterministic crash tests at each commit boundary.
+
+**Exit:** kill and restart the application at adversarial points; it reconstructs durable truth, never commits conflicting terminal outcomes, and exposes every ambiguous effect as blocked `uncertain` work.
+
+## Milestone 4 — self-deployment and capability fulfillment
+
+**Goal:** let an application create only the substrate it needs and operate itself on one remote node.
+
+- [ ] Define only the minimum finite capability model needed by the golden path: nodes, application state, control state, artifact storage, runtime identity/secret references, networking, and optional ingress.
+- [ ] Require control-state implementations to provide linearizable conditional writes, transactions, authoritative lease expiry, and fencing validation.
+- [ ] Define the provider contract for `plan`, `apply`, `inspect`, `reconcile`, and `destroy`.
+- [ ] Separate portable requirements from provider-specific deployment profiles.
+- [ ] Implement local/external-host fulfillment and one cloud provider golden path.
+- [ ] Use provider credential chains without embedding operator credentials.
+- [ ] Record managed/external ownership, resource receipts, and narrowly scoped node identities.
+- [ ] Make reconciliation and destroy idempotent and ownership-safe.
+- [ ] Expose plan, deploy, inspect, destroy, and a quiescent single-node upgrade/rollback that refuses in-flight work in the reserved operator namespace; prove them in a clean account. In-flight and staged evolution remains Milestone 6 work.
+
+**Exit:** one executable previews and creates a single-node durable service, survives the end of the authoring session, and later removes only what it owns.
+
+## Milestone 5 — trusted mesh and coordinator recovery
+
+**Goal:** distribute work across trusted nodes without making one machine irreplaceable.
+
+- [ ] Define one-time enrollment, per-deployment authorization, authenticated/encrypted transport, replay protection, and node identity rotation/revocation.
+- [ ] Advertise node capabilities and implement explicit placement constraints.
+- [ ] Store coordination truth in a provider-backed linearizable durable store.
+- [ ] Implement lease acquisition, renewal, and epoch increment as one linearizable conditional operation using store-authoritative expiry.
+- [ ] Fence every scheduling decision and commit with the coordinator epoch, and every attempt with that epoch plus a per-invocation generation, so stale processes cannot have control-state mutations accepted.
+- [ ] Reconstruct schedules and unfinished work from the ledger after coordinator replacement.
+- [ ] Define worker-loss detection and safe attempt reassignment.
+- [ ] Prove the two-node north-star workflow under worker loss, coordinator loss, partition/rejoin, and stale-leader attempts.
+
+**Exit:** coordination and eligible work continue after any individual node loss while durable state and suitable remaining capacity exist; capability-constrained work pauses visibly, and stale coordinators or attempts cannot have Wharfie-managed or control-state commits accepted after replacement. Unmanaged external effects remain governed by the explicit ambiguity rules.
+
+## Milestone 6 — safe evolution
+
+**Goal:** make unattended software straightforward to understand and change across many coding sessions.
+
+- [ ] Pin every run to an immutable revision and define explicit behavior for in-flight work during upgrades.
+- [ ] Make build inputs, dependency locks, target matrices, and provenance inspectable.
+- [ ] Make builds reproducible where the selected packaging toolchain supports it, while always content-addressing the produced artifacts.
+- [ ] Support staged rollout, health gates, rollback, and garbage collection of unreferenced revisions.
+- [ ] Add schema/version migration contracts for durable application and control state.
+- [ ] Expose a stable JSON protocol suitable for coding-agent operation and verification.
+- [ ] Evaluate peer-quorum control state only after provider-backed failover is proven.
+
+**Exit:** a later coding session can inspect why the service is in its current state, publish a new immutable revision, observe its rollout, and safely return to the prior revision.
+
+## Immediate queue
+
+1. Review and merge the project-reset documentation.
+2. Produce a branch/PR/issue decision table from the archived state.
+3. Reconcile the unpublished local packaging work and `jvd/pr4` into small keep-or-delete changes.
+4. Close or archive superseded GitHub work.
+5. Delete v1 and repair the release/package path before adding new distributed-runtime features.
+
+The dated handoff at [llm/checkpoints/2026-07-16-project-reset.md](llm/checkpoints/2026-07-16-project-reset.md) contains exact repository state and restart instructions.

--- a/docs/architecture/decisions/0001-trusted-nodes-only.md
+++ b/docs/architecture/decisions/0001-trusted-nodes-only.md
@@ -1,0 +1,22 @@
+# 0001 — Trusted nodes only
+
+**Status:** Accepted · **Date:** 2026-07-16
+
+## Context
+
+Wharfie needs to place and recover work across machines. A design that assumes mutually suspicious nodes would require Byzantine consensus, adversarial sandboxing, economic or cryptographic identity, and a substantially larger security protocol. None of that helps the initial use case: one operator extending an application from a laptop to machines and accounts that operator controls.
+
+## Decision
+
+All nodes enrolled in a Wharfie deployment are trusted members of that deployment.
+
+Enrollment is authenticated and explicit. Nodes receive narrowly scoped application identities, and transport and stored control data must still be protected. "Trusted" means the coordination protocol does not attempt to remain correct when an enrolled node acts maliciously; it does not mean nodes get broad cloud credentials or that network input is accepted without authentication.
+
+The mesh is an optional progression after local and single-node operation. Applications should not need mesh concepts until they request additional placement, capacity, or recovery.
+
+## Consequences
+
+- Wharfie can use ordinary authenticated coordination, leases, and fencing instead of Byzantine consensus.
+- The threat model remains responsible for outsiders, credential theft, replay, stale members, and compromised transport.
+- Revocation and re-enrollment are required operational features.
+- Running mutually untrusted tenants on the same mesh is out of scope unless a later decision introduces a separate isolation model.

--- a/docs/architecture/decisions/0002-one-recoverable-active-coordinator.md
+++ b/docs/architecture/decisions/0002-one-recoverable-active-coordinator.md
@@ -1,0 +1,30 @@
+# 0002 — One recoverable authoritative coordinator
+
+**Status:** Accepted · **Date:** 2026-07-16
+
+## Context
+
+Multiple simultaneous coordinators would add consensus and conflict-resolution complexity before Wharfie has proven a durable single-node execution model. A coordinator tied permanently to one process or host, however, would make the promised service stop when that machine fails.
+
+## Decision
+
+The initial distributed architecture has one coordinator that is authoritative at the durable-store boundary at a time, but no irreplaceable coordinator machine. A partitioned or paused process may continue believing it is leader and issuing messages; the protocol does not depend on stopping it.
+
+Coordination truth lives in durable storage outside the coordinator process. Lease acquisition, renewal, and epoch increment are a single linearizable conditional operation evaluated against store-authoritative expiry. Scheduling decisions and commits carry the coordinator epoch. An attempt's fencing identity composes that epoch with a monotonically increasing generation scoped to its invocation. Durable storage rejects stale values.
+
+After leadership expires, an eligible trusted node can acquire the next epoch, reconstruct the deployment from the ledger, and reschedule unfinished work. A previous coordinator that wakes up or survives a partition cannot commit current state.
+
+The durability progression is:
+
+1. SQLite or LMDB for local development and restart on the same durable volume.
+2. Synchronously durable, re-attachable volumes for single-node restart or replacement. Snapshots are backup with an explicit recovery-point objective and can lose work committed after the snapshot.
+3. A provider-backed linearizable transactional store for automatic coordinator replacement.
+4. A peer-quorum control store only if later evidence justifies removing the provider dependency.
+
+## Consequences
+
+- The coordinator process can remain conceptually simple while failover correctness is explicit.
+- Local-only state cannot claim automatic recovery after loss of its host.
+- Every mutating path must carry and validate fencing information at the durable boundary; a heartbeat alone is insufficient.
+- Provider-backed control state is an intentional initial dependency for safe automatic failover.
+- Active-active scheduling is deferred and may never be needed.

--- a/docs/architecture/decisions/0003-capability-fulfillment.md
+++ b/docs/architecture/decisions/0003-capability-fulfillment.md
@@ -1,0 +1,32 @@
+# 0003 — Capability fulfillment, not general IaC
+
+**Status:** Accepted · **Date:** 2026-07-16
+
+## Context
+
+A portable Wharfie executable should be able to become a durable service in a clean environment. That requires machines, state, artifacts, identity, networking, and sometimes ingress. Exposing arbitrary provider resource graphs would turn Wharfie into another infrastructure-as-code system and erase the portability of the application model.
+
+## Decision
+
+Applications declare a finite set of portable Wharfie runtime capabilities. Deployment profiles bind those requirements to provider-specific choices. Provider drivers plan, apply, inspect, reconcile, and destroy only resources that implement those capabilities.
+
+Initial capability families include:
+
+- nodes and placement constraints;
+- durable application state;
+- control state with linearizable conditional writes, transactions, store-authoritative lease expiry, and fencing validation;
+- artifact storage;
+- runtime identity and secret references;
+- networking; and
+- optional ingress.
+
+Provider-native application resources are outside this model. For example, an application requests durable key/value application state from Wharfie; a custom DynamoDB schema with provider-specific indexes belongs in application code or external IaC. Control state is a distinct capability with stronger semantics than generic durable key/value storage. An external control store must be validated against that semantic contract.
+
+Every proposed change is represented by a plan, while acknowledging values that a provider cannot know until apply time. `apply`, `reconcile`, and `destroy` are retry-safe and revalidate drift, resource identity, and ownership when they execute. The provider's normal credential chain supplies operator credentials at deploy time; broad credentials are never embedded in the artifact. A deployment records ownership receipts, distinguishes managed resources from external references, bootstraps narrowly scoped runtime identities, and destroys only resources it owns.
+
+## Consequences
+
+- The executable can self-deploy without claiming to model a whole cloud account.
+- Capability contracts must stay small, versioned, and portable even when providers expose richer options.
+- Some provider-specific tuning belongs in deployment profiles, but provider-native resource topology cannot leak into the application manifest.
+- Users remain free to provide external resources or run separate IaC alongside Wharfie.

--- a/docs/architecture/decisions/0004-logical-outcomes-and-effects.md
+++ b/docs/architecture/decisions/0004-logical-outcomes-and-effects.md
@@ -1,0 +1,42 @@
+# 0004 — One authoritative terminal outcome and explicit effects
+
+**Status:** Accepted · **Date:** 2026-07-16
+
+## Context
+
+Durable workers must retry after crashes and lease loss. A process can perform an external action and die before recording success, so no coordinator can truthfully promise that arbitrary handler code or arbitrary external side effects physically execute once.
+
+Wharfie still needs strong abstractions: application authors should not hand-build deduplication for every durable operation, and a stale or duplicate attempt must not be able to commit a second logical result.
+
+## Decision
+
+An invocation has at most one authoritative terminal ledger outcome; a resolved invocation has exactly one. Retryable runnable work uses at-least-once dispatch, and multiple physical attempts can overlap around a failure. Work that is cancelled, blocked, or never made runnable is not promised a physical execution. Each attempt has a unique ID, lease, and fencing token; only the current fenced attempt can commit Wharfie-managed state.
+
+Every activity context exposes stable and attempt-specific identity:
+
+- `runId`;
+- `invocationId`, stable across retries;
+- `attemptId`, unique per physical execution; and
+- `fencingToken`.
+
+Operations routed through Wharfie's effect API are explicit ledger entries with stable effect IDs and one or more substantiated replay properties:
+
+- `pure` — the operation has no externally visible consequence;
+- `idempotent` — the destination deduplicates a stable key;
+- `transactional` — the business mutation and effect record commit atomically.
+
+These properties can compose. Without a supported replay guarantee, an operation is `unsafe`: its destination cannot establish the result after an interrupted attempt.
+
+Trusted in-process JavaScript can bypass the effect API and call an SDK directly, and Wharfie cannot detect whether such a call completed before a crash. Therefore an in-process handler is `unsafe` by default once it begins: if its attempt is interrupted before a terminal commit, the invocation blocks in `uncertain` rather than being retried automatically. An author can opt into a substantiated handler-level `pure` or `idempotent` contract to permit retry. Direct side effects remain unmanaged, and Wharfie makes no deduplication claim for them.
+
+An adapter may claim exactly-once effect behavior only when the destination atomically enforces a stable effect identity with the business mutation. A uniqueness constraint or fencing token must be validated by that destination. A provider idempotency key is sufficient only within its documented scope and retention window. A transactional outbox makes intent atomic and supports at-least-once delivery; exactly-once processing additionally requires destination deduplication, such as an inbox record committed atomically with the consumer mutation.
+
+After an interrupted unsafe operation, `uncertain` is a durable blocked, nonterminal invocation state. Reconciliation either establishes the invocation's single terminal outcome or creates a distinct compensating invocation. It never rewrites an already committed terminal outcome, silently retries the ambiguous operation, or claims success without evidence.
+
+## Consequences
+
+- Documentation and APIs must distinguish invocation outcome, physical attempt, and external effect.
+- There will be no magical `execution: exactly-once` flag for arbitrary code.
+- Adapters carry evidence for the guarantees they expose.
+- The ledger must retain ambiguous states, evidence, and operator reconciliation decisions.
+- Crash tests at commit and effect boundaries are part of the product contract, not only implementation tests.

--- a/docs/architecture/decisions/0005-typescript-and-component-boundary.md
+++ b/docs/architecture/decisions/0005-typescript-and-component-boundary.md
@@ -1,0 +1,29 @@
+# 0005 — TypeScript control plane with a component boundary
+
+**Status:** Accepted · **Date:** 2026-07-16
+
+## Context
+
+TypeScript and Node provide the shortest authoring path for the intended CLI-first experience and for software produced in coding sessions. Some Wharfie internals and user activities will eventually need faster execution, stronger isolation, or libraries written in Rust, Go, Zig, or another language. Supporting several equal application models now would multiply packaging, schema, debugging, and runtime complexity.
+
+## Decision
+
+TypeScript/Node is the sole initial application-authoring and orchestration model. Commands, manifests, workflows, schemas, deployment requirements, and inspection APIs use that model.
+
+Named activities form a versioned, serializable component boundary. Handler implementations may be:
+
+1. in-process JavaScript, the default, with target-specific Node-API modules available as implementation dependencies;
+2. WASI/WASM modules, the preferred portable hot-path escape hatch; or
+3. persistent subprocess workers speaking a small Wharfie activity protocol.
+
+WASM and subprocess handlers use the serialized activity protocol. Their effect operations are mediated by the Wharfie host; component workers do not receive coordinator or provider credentials.
+
+Runs bind immutable application revisions, including handler artifacts. Native handlers can require a platform artifact matrix; WASM is the portable option. Build steps outside Wharfie may produce these artifacts, and Wharfie validates and packages the outputs.
+
+## Consequences
+
+- There is one public authoring and control-plane story to learn and document.
+- The activity protocol must define serialization, cancellation, deadlines, logging, errors, and effect access without depending on JavaScript function calls.
+- Wharfie is not a general multi-language build system.
+- A faster-language implementation can be introduced where measurements justify it without changing workflow semantics.
+- Dynamic LLM-generated code is not evaluated inside the coordinator; it becomes part of an immutable revision first.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,13 @@
+# Architecture decision log
+
+These records capture product-level decisions that should survive implementation rewrites. A decision can be superseded by a later record, but should not be silently edited into a different choice.
+
+| Decision                                                                                               | Status   |
+| ------------------------------------------------------------------------------------------------------ | -------- |
+| [0001 — Trusted nodes only](0001-trusted-nodes-only.md)                                                | Accepted |
+| [0002 — One recoverable authoritative coordinator](0002-one-recoverable-active-coordinator.md)         | Accepted |
+| [0003 — Capability fulfillment, not general IaC](0003-capability-fulfillment.md)                       | Accepted |
+| [0004 — One authoritative terminal outcome and explicit effects](0004-logical-outcomes-and-effects.md) | Accepted |
+| [0005 — TypeScript control plane with a component boundary](0005-typescript-and-component-boundary.md) | Accepted |
+
+The canonical product scope is [PROJECT.md](../../../PROJECT.md). The delivery order is [ROADMAP.md](../../../ROADMAP.md).

--- a/llm/README.md
+++ b/llm/README.md
@@ -3,4 +3,5 @@
 Repo-local design docs and operator prompts live here.
 
 - `llm/design/` contains architectural notes and work-item docs.
+- `llm/checkpoints/` contains dated, restartable project/session handoffs.
 - `llm/prompts/` contains repeatable prompt templates and coding-agent guidance.

--- a/llm/checkpoints/2026-07-16-project-reset.md
+++ b/llm/checkpoints/2026-07-16-project-reset.md
@@ -1,0 +1,216 @@
+# Checkpoint — Wharfie project reset
+
+- **Captured:** 2026-07-16, America/Detroit
+- **Purpose:** restart a future maintainer or coding-agent session from the product and repository decisions reached in the July 2026 reset conversation
+- **Canonical scope:** [`PROJECT.md`](../../PROJECT.md)
+- **Live plan:** [`ROADMAP.md`](../../ROADMAP.md)
+- **Decision log:** [`docs/architecture/decisions/`](../../docs/architecture/decisions/README.md)
+
+This is a distilled checkpoint, not a verbatim transcript. It records the intent, decisions, repository evidence, exact preservation refs, and next review boundary needed to continue without reconstructing the conversation. It is an immutable historical snapshot; future changes belong in the live roadmap, a superseding ADR, or a new dated checkpoint.
+
+## Copy-paste resume prompt
+
+> We are continuing the Wharfie project reset. Read `PROJECT.md`, `ROADMAP.md`, every accepted record in `docs/architecture/decisions/`, and `llm/checkpoints/2026-07-16-project-reset.md` before changing code. Fetch remote refs and verify the `archive/2026-07-16/remote/...` tags still exist. Breaking changes are allowed and v1 is abandoned. Resume at the checkpoint's "Next action" section, inspect any work merged since it was written, update the live roadmap as needed, and create a new dated checkpoint rather than rewriting this snapshot.
+
+## Working agreement from the conversation
+
+- The repository is not used by downstream applications, so breaking changes are acceptable.
+- Optimize for speed toward a coherent eventual design, not v1 compatibility or incremental migration ceremony.
+- Clean branches, PRs, issues, dead code, and partially finished paths before expanding the runtime.
+- During the captured session the user permitted commits and pushes, but this checkpoint grants no authority to a future session. Act only within the current user's request, especially for external or destructive GitHub mutations.
+- The current remote state had to be backed up before cleanup. That backup is complete and verified as described below.
+- Pause for review when a coherent checkpoint is ready; the reset documentation is the first such checkpoint.
+
+## Product intent reached in the conversation
+
+The original motivation was expressed as:
+
+> LLMs make writing software very easy. We are empowered to express and act upon our will locally within coding sessions, but it is hard to carry that out into the cloud or past the end of a chat session. Wharfie should carry that will forward into something we can follow along with and evolve.
+
+The concrete product statement is:
+
+> Wharfie is a local-first TypeScript application runtime that turns an ordinary CLI into a portable executable, then lets that same application become a durable, observable service across trusted machines without an architectural rewrite.
+
+The key value is continuity from local authoring to unattended operation. Node SEA, provisioning, durable execution, and mesh coordination are mechanisms in support of that continuity.
+
+Wharfie persists operator-approved executable intent—immutable revisions, triggers, capabilities, run state, attempts, effects, deployments, and decisions—not an abstract will or chat transcript. It should be especially legible to coding agents without becoming an agent framework.
+
+## Agreed direction and initial decisions
+
+1. **v1 is abandoned.** The Athena/table product, legacy APIs, and backward compatibility are not part of the new scope.
+2. **The mesh contains trusted nodes only.** Trustless or Byzantine coordination is out of scope.
+3. **Start with one authoritative coordinator at the durable-store boundary.** It is a recoverable role, not an irreplaceable machine. Lease acquisition, renewal, and epoch increment are linearizable store operations; all accepted mutations are fenced; and a replacement reconstructs state from the ledger. A stale process may keep issuing messages but cannot have stale control-state writes accepted.
+4. **Automatic coordinator failover initially uses a linearizable provider-backed store.** SQLite/LMDB is appropriate for local and same-volume restart but cannot claim automatic recovery after host loss. Peer quorum can be evaluated later.
+5. **TypeScript/Node is the sole authoring and orchestration model initially.** Preserve a serializable activity boundary that can later host WASI/WASM or persistent subprocess implementations. Target-specific Node-API modules remain dependencies behind JavaScript handlers. Wharfie packages outputs; it is not a multi-language build system.
+6. **One authoritative terminal outcome, not one physical execution.** An invocation has at most one authoritative terminal outcome; a resolved invocation has exactly one. Retryable runnable work uses at-least-once dispatch and fenced attempts. External exactly-once behavior exists only when a managed adapter's destination atomically enforces the effect identity with the business mutation. Replay properties can include `pure`, `idempotent`, and `transactional`; unsupported operations are `unsafe`, and an ambiguous unsafe operation blocks in nonterminal `uncertain` state until reconciled or compensated.
+7. **Cloud work is capability fulfillment, not general IaC.** A produced executable can use a user's normal provider credential chain to plan and create Wharfie nodes, application state, semantically stronger control state, artifacts, identity, networking, and ingress. It records ownership, distinguishes managed/external resources, creates narrow runtime identities, and destroys only what it owns.
+8. **The developer-owned CLI remains the primary surface.** The same executable should run locally and later expose deploy, status, logs, intervention, upgrade, rollback, and destroy operations through an explicit non-colliding operator namespace. A web UI is not an initial priority.
+9. **SEA is a backend, not the permanent abstraction.** The promise is an approachable portable, self-hosting executable with no required Node installation, container runtime, Kubernetes cluster, or hosted orchestration service on the target. Local and single-node use require no external Wharfie control plane; initial automatic coordinator replacement requires a linearizable durable store.
+10. **Revisions and operational history are immutable and inspectable.** Runs pin logical revisions; revisions can own target-specific artifacts; changes create new revisions; upgrade and rollback behavior is explicit; CLI JSON output makes the system operable by people, scripts, and coding agents.
+
+## Repository snapshot before reset work
+
+### Primary refs
+
+- GitHub repository: `wharfie/wharfie`
+- Default remote branch: `master`
+- Remote `master` before reset: `f31595a6048a2aa1593a4d9023c6d82cff01a823` (2026-04-15)
+- Local `master` before reset: `73de463989c6800219992884e99f47d591ff0486` (three unpublished commits ahead of remote)
+- `jvd/pr4`: `1425ba6f4bb32cc219c27b9e33ba2753683726c7`
+- Old stash: `52ca16fa00dcef57be7fcc6da5446e18dab6a88d`, recorded as `WIP on master: 3dee66b work prompt` on 2026-03-12
+- Reset documentation branch: `agent/project-reset`, created cleanly from the archived remote `master`
+
+The unpublished local commits are:
+
+```text
+73de463 fixup
+a1b645f test fix
+2f1a4bb test
+```
+
+Together they change 26 files by roughly +1,460/-438, primarily improving self-build, Node SEA packaging, and packaged-app behavior. They passed the full local CI command under Node 24.13.1 before the reset branch was created. They have not yet been judged against the new scope.
+
+### Verified remote backup
+
+Every branch that existed on the remote on 2026-07-16 was preserved as an annotated Git tag on GitHub before working-tree changes began. The commit in the last column is the peeled tag target.
+
+| Remote branch            | Archive tag                                        | Commit                                     |
+| ------------------------ | -------------------------------------------------- | ------------------------------------------ |
+| `master`                 | `archive/2026-07-16/remote/master`                 | `f31595a6048a2aa1593a4d9023c6d82cff01a823` |
+| `jvd/cast-compaction`    | `archive/2026-07-16/remote/jvd/cast-compaction`    | `76ddfd4fbac1993d092478a4b67289d15ca586bf` |
+| `jvd/chore-lint`         | `archive/2026-07-16/remote/jvd/chore-lint`         | `ff78940f348fc8b8cfc9ba4a982a27388f6c9416` |
+| `jvd/entitlements`       | `archive/2026-07-16/remote/jvd/entitlements`       | `9c04b410e8cae85937a395ae0592d100c57570d1` |
+| `jvd/examples`           | `archive/2026-07-16/remote/jvd/examples`           | `9d3153ee0dc40c493f53b02a54ead33ac31cb1a8` |
+| `jvd/firecracker`        | `archive/2026-07-16/remote/jvd/firecracker`        | `2f33d0c858e2845a5715e01f5a9c5bab0e72d8c9` |
+| `jvd/more-docs`          | `archive/2026-07-16/remote/jvd/more-docs`          | `e02e662d016eb3371adc4fe8afa9cf03ba2f09d8` |
+| `jvd/new-wharfie-events` | `archive/2026-07-16/remote/jvd/new-wharfie-events` | `1767c12892c66721a296f81ef255eac9d143982e` |
+| `jvd/op-tracking`        | `archive/2026-07-16/remote/jvd/op-tracking`        | `90ef89ea53c3946bcff45a4f5afe7e3fd7be4b1c` |
+| `jvd/pr4`                | `archive/2026-07-16/remote/jvd/pr4`                | `1425ba6f4bb32cc219c27b9e33ba2753683726c7` |
+| `jvd/rust-antlr`         | `archive/2026-07-16/remote/jvd/rust-antlr`         | `9de49b6af7cfb6c71e551cf0576dd2553b1785b7` |
+| `jvd/rust-aws-sdk`       | `archive/2026-07-16/remote/jvd/rust-aws-sdk`       | `ca9401e267af5f2e3cd95405003541029016c2ff` |
+| `jvd/side-effects`       | `archive/2026-07-16/remote/jvd/side-effects`       | `a1552d8859e316542845a38a63ead2690be01fbb` |
+| `jvd/tsc`                | `archive/2026-07-16/remote/jvd/tsc`                | `ad8ada269596bdc1a42e78f9a1defa3375382b9a` |
+| `jvd/tsc-lint`           | `archive/2026-07-16/remote/jvd/tsc-lint`           | `f85b5025dbfbbbbc5915f0e02623d56c2fa5114f` |
+
+Verification used `git ls-remote --tags` after the push and returned all 15 tag objects and peeled targets.
+
+Two additional annotated tags exist only in this checkout:
+
+- `archive/2026-07-16/local/unpublished-master` → `73de463989c6800219992884e99f47d591ff0486`
+- `archive/2026-07-16/local/stash` → `52ca16fa00dcef57be7fcc6da5446e18dab6a88d`
+
+They were deliberately not pushed: publishing a stash or other never-published local work can disclose private material. Do not assume those refs exist in another clone. Review the content and obtain explicit approval before publishing; retain this checkout until they are reconciled or exported safely.
+
+## GitHub tracker snapshot
+
+The connected GitHub repository had three open PRs and 24 open issues when this checkpoint was written.
+
+### Open PRs
+
+| PR                                                  | Title                                                 | Head               | Initial disposition                                                                                     |
+| --------------------------------------------------- | ----------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------- |
+| [#100](https://github.com/wharfie/wharfie/pull/100) | actor system / graph refactor                         | `jvd/side-effects` | Preserve research, mine durable graph/effect work, then supersede; 166 commits and not mergeable as-is. |
+| [#99](https://github.com/wharfie/wharfie/pull/99)   | change entitlements to match node doc recommendations | `jvd/entitlements` | Re-evaluate only if still required by the new SEA release path; otherwise supersede.                    |
+| [#25](https://github.com/wharfie/wharfie/pull/25)   | [dnm] rust antlr implementation                       | `jvd/rust-antlr`   | Close as obsolete with v1/Athena; archive tag already preserves it.                                     |
+
+No PR was closed during checkpoint creation.
+
+### Open issues
+
+All 24 issues were stale and appeared without labels or milestones. Most describe the abandoned Athena/v1 product; this is a condensed title list:
+
+```text
+#84 Refresh credentials on UnrecognizedClientException
+#83 test project role has propagated as part of reconcile
+#76 Add a SageMaker feature-store connector
+#64 resource system name uniqueness
+#58 Type casting
+#55 include inter-region transfer in cost estimates
+#53 on error remove progress bars
+#51 tag resources
+#50 release artifacts
+#49 wharfie project init validate project name
+#33 deployment destroy does not clean bucket logs
+#23 handle deleting buckets with objects
+#20 show predicted resource costs on creation
+#17 avoid unexpected S3 path collisions
+#14 tiered config system
+#12 non-string return types for UDFs
+#11 row and map type support for UDF inputs
+#10 investigate using queue source for DLQs
+#9 replace CloudWatch alarms with SNS topics
+#8 end-to-end automation tests
+#7 validate failed-query DLQ and replay behavior
+#6 UDF build system
+#5 make resource stacks nested
+#2 publish GitHub release artifacts alongside npm
+```
+
+Likely surviving concerns should be rewritten as new-scope work rather than keeping misleading v1 tickets open: immutable release artifacts (#50/#2), logical resource identity (#64), ownership/tagging and safe destroy (#51/#23/#33), and real end-to-end tests (#8). The final classification belongs in the Milestone 1 decision table; no issue was changed during checkpoint creation.
+
+## Codebase health at the checkpoint
+
+### What works
+
+- Commander CLI commands include `config`, `init`, `app`, `ops`, `list`, and `build-self`.
+- The current loader compiles CLI surfaces, named activities, workflows, cron triggers, and resources into internal functions/actors.
+- Plain-object applications can reach `ActorSystem` and Node SEA packaging paths.
+- Runtime code contains node supervision, scheduling, queues, DB/lambda gRPC services, provider adapters, and shared resource references.
+- Persisted `Operation`/`Action` DAG machinery already supplies useful durable-execution material.
+- On the unpublished local `master` tip, lint, strict JS type checking, and all 46 Jest suites passed: 158 tests passed and one conditional native-external test was skipped.
+- On `agent/project-reset` at the remote-master code plus documentation, the pinned full CI command passed: lint, type checking, 44 suites and 149 tests passed, and one suite/test was conditionally skipped.
+- Latest remote `master` CI was green at the time of inspection.
+
+### What is misleading or broken
+
+- The pre-reset README, website, and older docs center the Athena/table v1 product and contradict the current v2 CLI implementation. This reset branch rewrites the root README; the other stale docs remain.
+- The project is midway through a v1→v2 migration, with stale design checklists that mark already-implemented work as missing.
+- The release workflow invokes nonexistent `./build.js` commands and has environment-name mismatches.
+- On the unpublished local `master` tip, the npm tarball omits `apps/wharfie-cli/wharfie.app.js`, which that tip's revised `build-self` path requires. The reset branch's older `build-self` inputs are packaged.
+- `package.json` says version `0.0.14`, runtime version reporting says `0.0.0`, package metadata says ISC, and the repository license is Apache-2.0.
+- The unpublished local tip adds an app file that advertises `build:wharfie-cli`, but no such package script exists; the reset branch does not make that advertisement.
+- Production dependency audit reported 14 fixable findings: 1 critical, 3 high, and 10 moderate, including the direct gRPC/protobuf path.
+- Sixty-nine legacy suites are excluded. Type checking excludes AWS resources and record classes; lint excludes important areas; CI does not inspect the npm tarball, build a real SEA artifact, validate installers, build docs, or audit production dependencies.
+- There is one unused duplicate manifest compiler and three active persisted-run implementations.
+- The current CLI implementation has no coherent supported deploy/status/logs/upgrade/rollback path yet.
+- `src/core/lib/mesh/node.js` is empty; first-class mesh membership and coordinator recovery are not implemented.
+
+## Agreed delivery order
+
+1. Preserve/reset and get the charter reviewed.
+2. Clean the tracker and repository; reconcile unpublished work and `jvd/pr4`; remove all v1 code and claims; repair release/package/security correctness.
+3. Prove one portable TypeScript CLI and activity boundary in one executable.
+4. Prove a single durable node with the invocation/attempt/effect ledger and crash recovery.
+5. Implement narrow self-deployment through capability fulfillment.
+6. Add trusted-node placement and recoverable authoritative-coordinator operation.
+7. Add explicit revision rollout, rollback, migrations, provenance, and agent-friendly operation.
+
+Do not begin by building a new consensus layer, general IaC system, web UI, agent framework, or polyglot SDK.
+
+## Next action and review boundary
+
+The immediate action after this checkpoint is to review the `agent/project-reset` documentation changes and merge them if the scope reads correctly. Then create a complete branch/PR/issue decision table that identifies what to absorb before deletion.
+
+The next destructive phase should:
+
+1. inspect the local unpublished commits and `jvd/pr4` file by file against Milestones 1 and 2;
+2. preserve or reimplement only work that advances the new charter;
+3. close the three stale PRs with links to archive tags and a supersession explanation;
+4. rewrite surviving issue concerns as milestone-scoped tickets and close the v1 issues; and
+5. delete remote branches only after confirming their archived tag targets.
+
+After tracker cleanup, remove the v1 application and legacy dependency surface, then fix distribution correctness before adding new runtime features.
+
+## Restart verification commands
+
+Run these from the repository root and investigate any unexpected output before proceeding:
+
+```bash
+git fetch --prune origin
+git status --short --branch
+git show-ref --tags | grep 'refs/tags/archive/2026-07-16/remote/'
+git log --oneline --decorate -10 origin/master
+npm run test:ci
+```
+
+Use Node `24.13.1` and npm `11.12.0`, matching `package.json`. Runtime tests bind localhost ports and can fail with `EPERM` in a restricted sandbox even when the code is healthy.


### PR DESCRIPTION
## Summary

- replace the Athena-era README with the agreed local-CLI-to-durable-service direction
- add the canonical project charter and milestone roadmap
- record accepted decisions for trusted nodes, recoverable authoritative coordination, capability fulfillment, logical outcomes/effects, and the TypeScript/component boundary
- add a dated restart checkpoint with exact Git refs, tracker inventory, health findings, and a copy-paste resume procedure

## Preservation

Before this branch was created, every live remote branch tip was pushed as an annotated tag under `archive/2026-07-16/remote/...` and verified against GitHub.

The unpublished local `master` tip and old stash have local-only archive tags. They were intentionally not published without a separate content review.

No v1 code, remote branch, PR, or issue is removed or closed in this change.

## Important semantics to review

- local-first continuity is the product; SEA, provisioning, and mesh coordination are supporting mechanisms
- nodes are trusted; one coordinator is authoritative at the durable-store boundary and stale epochs are fenced
- a resolved invocation has exactly one authoritative terminal outcome, but physical attempts can overlap
- begun in-process handlers are unsafe by default unless they opt into a substantiated replay-safe contract
- exact-once external behavior is claimed only when a managed destination atomically enforces effect identity with its business mutation
- capability fulfillment is finite Wharfie substrate, not general IaC
- TypeScript/Node remains the authoring/control plane; WASM and subprocesses are future activity implementations, not parallel SDKs

## Validation

- `npm run test:ci` with Node 24.13.1 / npm 11.12.0
  - lint passed
  - type-check passed
  - 44 suites / 149 tests passed
  - 1 conditional suite/test skipped
- Prettier check passed for all changed Markdown
- `git diff --cached --check` passed before commit
- all new relative Markdown links and the README image resolve

## Review boundary

If this direction reads correctly, merge this PR and continue with the Milestone 1 branch/PR/issue decision table. Broad tracker cleanup and v1 deletion intentionally wait for that review.