### PR TITLE
Ship the magnetic application path

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,18 @@ covers crash and reboot recovery with a purpose-built fixture.
 Inside a packaged application, normal argv belongs to the application. Wharfie
 reserves only `<app> wharfie <command>` for operator commands; internal service
 startup uses a private environment-selected runtime command instead of
-consuming public commands.
+consuming public commands. Ordinary argv also avoids preparing Wharfie's native
+durable runtime; native preparation is lazy and occurs only for the reserved
+operator or private-runtime path.
 
-Successful `wharfie app package` now emits one strict schema-version 1
-`wharfie.application.package` receipt. It binds the application and revision
-to a target-sorted list of content-addressed SEA identities, byte digests,
+For a targetless manifest, `wharfie app package` now infers the exact compatible
+host target from the running Node version, platform, architecture, and glibc on
+Linux. Its default output is a human handoff: build phases, target, artifact
+path, size, and an actionable `Next:` step. Matching POSIX hosts receive an
+exact shell command; Windows avoids pretending cmd.exe and PowerShell share
+quoting rules. Machine callers opt into the unchanged
+strict schema-version 1 `wharfie.application.package` receipt with `--json`.
+That target-sorted receipt binds content-addressed SEA identities, byte digests,
 sizes, and immediate local artifact/sidecar paths without exposing the full
 internal revision or provenance records. The receipt and its paths are
 discovery data, not artifact authority; verification still depends on the SEA
@@ -86,11 +93,18 @@ one frozen target dependency closure instead of ambient `node_modules` or a
 newly resolved npm tree. Exact-run inspection, confirmed recovery, and
 authenticated current-owner cancellation use one shared source/SEA operator
 layer; packaged commands bind authority to their embedded application identity.
-Source `wharfie ops run` and packaged `<app> wharfie run` now also use one
+Source `wharfie ops run` and packaged `<app> wharfie activity run` use one
 durable activity host. The source adapter supplies a sealed prepared revision;
 the packaged adapter accepts only its cross-checked embedded manifest and
 revision/runtime pair and exposes no source-directory override. Operator and
 private runtime dispatch choose their path before authored CLI code is loaded.
+The packaged top-level `<app> wharfie run --name <stable-name> --
+<application-args>` is instead the foreground durable-workflow path. The stable
+name selects one run, so repeating the same command resumes it, reports retained
+steps without rerunning them, and follows its verified output to completion.
+`SIGINT` and `SIGTERM` drain the foreground host without cancelling durable
+work and print the exact resume command. Packaged `start` remains
+admission-only, and `worker` remains the explicit long-lived resident.
 
 That host now supports durable submission separately from execution. Source
 `wharfie ops submit` and packaged `<app> wharfie submit` persist an exact
@@ -807,7 +821,22 @@ public command surface. Older material under `llm/design/` can be stale.
 ## Current application contract
 
 A source application is a default-exported plain object in `wharfie.app.js`.
-The v4 boundary is deliberately small and strict:
+For the smallest ordinary CLI, `defineApp()` expands this shorthand into the
+strict v4 contract:
+
+```js
+import { defineApp } from '@wharfie/wharfie/app';
+
+export default defineApp({
+  id: 'hello-world',
+  main: './hello.js',
+});
+```
+
+The shorthand also supports one default durable workflow, a shared
+activity module, activities, workflows, schedules, and optional package
+targets. Authors who need the complete surface can supply the fully explicit v4
+shape; `defineApp()` preserves that object unchanged:
 
 ```js
 import { defineApp } from '@wharfie/wharfie/app';
@@ -928,6 +957,9 @@ A packaged application exposes the same operations without a source-directory
 override:
 
 ```bash
+<app> wharfie run --name greet-ada -- Ada
+<app> wharfie activity run --activity greet \
+  --idempotency-key <stable-key> --input '{"name":"Ada"}'
 <app> wharfie submit --activity greet \
   --idempotency-key <stable-key> --input '{"name":"Ada"}'
 <app> wharfie start -- <application-args>
@@ -937,6 +969,22 @@ override:
 <app> wharfie signal --run-id <run-id> --signal <signal-step-id> \
   --delivery-id <stable-delivery-id> --payload '{"approved":true}'
 ```
+
+Top-level `run` is the shortest interactive durable path. It starts or reopens
+the app's declared default workflow, temporarily hosts it when no resident is
+active, follows an existing resident when one is active, and waits for verified
+terminal output. Repeat the same name and application arguments to resume the
+same run. Interrupting the foreground host drains it without creating a durable
+cancellation decision and prints the exact command to resume. Expert direct
+activity execution now lives under `activity run`.
+
+Every packaged path derives its stores from one app-scoped layout. Set the one
+`WHARFIE_DATA_ROOT` environment variable to an absolute directory when a
+foreground invocation needs an explicit root. It cannot be combined with the
+retired per-store environment overrides. A systemd-managed service pins that
+same variable to the active packaged layout, so foreground and resident
+execution keep using the custom root. Without an explicit root, packaged
+storage uses the stable operating-system account default.
 
 `submit` and `start` are durable and do not require a live worker; the worker
 remains a separate resident process. For an application with `cli.durable`,
@@ -1230,8 +1278,10 @@ are deliberately deferred until private runtime extraction has a tested ACL and
 reparse-point design. Moved Darwin SEAs and the clean hosted-Linux verifier
 exercise a real LMDB dependency with Node absent from `PATH`.
 
-Packaged core native dependencies are always extracted into a fresh private
-root; they are never reused as a mutable cache. Normal exit removes that root.
+Ordinary packaged application argv does not prepare Wharfie's core native
+dependencies. Reserved operator and private-runtime paths prepare them lazily
+in a fresh private root; they are never reused as a mutable cache. Normal exit
+removes that root.
 After `SIGKILL`, a successor verifies the same UID/host/boot/process authority
 and removes only roots whose owner is positively dead, with fixed inspection
 and removal budgets. Foreign or uncertain claims are retained, and a large

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 **Status:** product-outcome rebaseline
 
-**Last updated:** 2026-07-29
+**Last updated:** 2026-08-01
 
 Wharfie's roadmap now tracks three user-visible outcomes. Historical
 implementation detail belongs in the
@@ -25,10 +25,12 @@ to the intended experience.
 
 The repository has substantial foundations:
 
-- a TypeScript/Node application and operator model with strict manifests and
-  immutable revisions;
+- a TypeScript/Node application and operator model with strict manifests,
+  immutable revisions, and a compact `defineApp({ id, main })` authoring path;
 - Node SEA packaging with content-addressed receipts and a reserved packaged
   operator namespace;
+- exact compatible-host inference for targetless manifests, with a human-first
+  package handoff by default and the unchanged v1 receipt behind `--json`;
 - a durable run, invocation, attempt, effect, workflow, timer, signal, and
   schedule ledger;
 - an opt-in per-application coordinator-authority kernel co-located with that
@@ -39,6 +41,11 @@ The repository has substantial foundations:
   effect semantics;
 - source and packaged commands for durable submission, workers, history,
   redacted inspection, confirmed logs, and confirmed logical output;
+- a named packaged foreground workflow command that can be interrupted and
+  resumed by repeating the same invocation, while direct packaged activity
+  execution lives under `activity run`;
+- one `WHARFIE_DATA_ROOT` for every packaged durable store and lazy native
+  runtime preparation that keeps ordinary application argv on the light path;
 - the `steady-file` golden-path application and a hermetic proof of ordinary
   CLI execution, sealed source preparation, durable activity/timer/activity
   continuation across a control-store reopen, and verified retained output,
@@ -82,6 +89,22 @@ started as a persistent service, given durable work, restarted, inspected, and
 updated without being rewritten around a hosted orchestrator, containers, or a
 second application architecture.
 
+### Experience quality bar
+
+The implemented surface in the
+[magnetic first-run experience](docs/product/magnetic-first-run.md) defines the
+teaching sequence for this outcome. A deliberately tiny canonical application
+answers "What is a Wharfie application?" A separate polished showcase answers
+"Why Wharfie?" by packaging ordinary JavaScript, interrupting durable work after
+one committed step, and resuming it from the standalone artifact without
+repeating that step. An external prototype exercises that path in under
+30 seconds on Darwin arm64, including relocated Node-absent execution and an
+abrupt process kill. Release acceptance remains open until the starter and
+complete retained-output gate are versioned here and run against the published
+preview. The target remains one obvious journey that finishes in under two
+minutes after prerequisites, with experimental machinery outside the beginner
+path.
+
 ### What is already concrete
 
 - Authored argv remains application-owned; `<app> wharfie <command>` is the
@@ -92,6 +115,15 @@ second application architecture.
 - A manifest can name one default durable workflow and a pure CLI-argument
   adapter, so the happy path does not require a workflow ID or handwritten
   JSON input.
+- `defineApp({ id, main })` expands the smallest ordinary CLI into the strict v4
+  manifest while the explicit form remains available.
+- A targetless package request selects one exact host artifact and defaults to
+  a human phase/target/path/size/`Next:` handoff; scripts opt into `--json`.
+- Packaged `wharfie run --name <name> -- <args>` starts or reopens the default
+  durable workflow, hosts or follows it in the foreground, and drains without
+  cancellation on interruption. Direct activity execution is `activity run`.
+- Packaged storage derives from one `WHARFIE_DATA_ROOT`, and ordinary argv
+  avoids native durable-runtime preparation.
 - Packaged artifacts can run without Node on the target command path.
 - The local service lifecycle supports install, converge, restart, update,
   rollback, recover, status, prune, and uninstall.
@@ -100,12 +132,15 @@ second application architecture.
 
 ### Work next
 
-1. Keep the split builder/clean-target `steady-file` acceptance proof as the
+1. Version the magnetic copied starter and complete harness as a release
+   regression gate.
+2. Reduce the beginner-path weight: the current install expands to 202 npm
+   packages (about 138 MB) and the Darwin arm64 artifact is 119 MiB.
+3. Keep the split builder/clean-target `steady-file` acceptance proof as the
    regression gate for this outcome.
-2. Carrying a returned run ID was visible friction but did not block the
-   sequence. Change discovery or app-scope ergonomics only when real use
-   demands it.
-3. Add schedule, application state, broader workflow behavior, or more
+4. Preserve the irreducible canonical hello-world app and keep failure probes,
+   provenance mechanics, and experiments in the labeled playground.
+5. Add schedule, application state, broader workflow behavior, or more
    single-host service surface only when a concrete application needs it.
 
 ### Exit evidence

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,15 @@ without an architectural rewrite.
 The project is being reset around that goal. Wharfie v1's Athena and table
 framework is no longer part of the product, and breaking changes are expected.
 
+The implementation candidate in the
+[magnetic first-run experience](./product/magnetic-first-run.md) turns that
+product promise into a concrete two-minute teaching sequence: a
+`defineApp({ id, main })` ordinary CLI first, followed by one visible durable
+interruption and repeat-to-resume. An external prototype proves relocation,
+Node-absent execution, `SIGKILL`, and exact-command resumption; release
+acceptance remains open until the complete starter and later-process output
+check are versioned here and run against the published preview.
+
 The shortest concrete walkthrough is the
 [single-host developer preview](./guides/developer-preview.md): install a
 verified package tarball in a clean builder workspace, copy the supported
@@ -27,7 +36,8 @@ each deliberate exclusion.
 
 1. Write and run a normal TypeScript or JavaScript CLI locally.
 2. Declare named activities that can be run and observed durably.
-3. Package the application as a Node SEA executable for a specific target.
+3. Package the application as a Node SEA executable for this host or an
+   explicit target.
 4. Promote that executable to a persistent single-node service.
 5. Enroll more trusted nodes when placement or recovery requires them.
 
@@ -77,6 +87,23 @@ activity/timer/signal workflow plans. Source `wharfie ops signal` and packaged
 caller-stable delivery ID. The shared exact-run inspection, confirmed recovery,
 cancellation, and evidence-reconciliation commands understand the redacted
 activation-aware workflow cursor.
+For an application with a default durable CLI handoff, packaged top-level
+`<app> wharfie run --name <stable-name> -- <application-args>` starts or reopens
+the named workflow. It temporarily hosts the worker when no resident is active,
+follows an existing matching resident otherwise, and reports verified retained
+output through completion. Interruption drains without cancelling durable work
+and prints the exact command to repeat. Packaged `start` remains admission-only,
+and `worker` remains the long-lived resident; expert direct activity execution
+has moved to `<app> wharfie activity run`.
+
+All packaged stores derive from one app-scoped layout. A foreground caller can
+set the single absolute `WHARFIE_DATA_ROOT`; combining it with legacy split-store
+overrides fails closed, and the systemd service pins that same variable to its
+active packaged layout. Without an explicit root, packaged storage uses the
+stable operating-system account default. Ordinary application argv also skips
+native durable-runtime preparation, which is lazy on the reserved
+Wharfie/private path.
+
 The separate source/packaged `logs` command can disclose one exact physical
 attempt's fully verified retained log prefix after explicit sensitive-output
 confirmation. Its raw schema is deliberately non-authoritative and
@@ -127,20 +154,30 @@ wharfie ops signal --run-id <run-id> --signal <signal-step-id> \
 wharfie app package ./path/to/app
 ```
 
-The package command writes one schema-version 1
-`wharfie.application.package` JSON receipt. Its target-sorted `artifacts`
+For a targetless manifest with no filter, the package command infers the exact
+compatible host target from the running Node version, platform, architecture,
+and glibc on Linux. Its default human output reports build phases, exact target,
+artifact path, size, and an actionable `Next:` step. Matching POSIX hosts get
+a copy-pasteable command; Windows gets a shell-neutral instruction.
+
+`--json` writes the unchanged schema-version 1
+`wharfie.application.package` machine receipt. Its target-sorted `artifacts`
 contain the content-addressed identity, exact target, digest, size, and
 immediate local executable and sidecar paths. It omits the full internal
 revision and artifact records. Those paths and the receipt provide local
 discovery, not authority: the executable bytes, canonical sidecar, and embedded
 revision association must still verify together.
 
-The packaged equivalents are `<app> wharfie submit ...`, `<app> wharfie start
-...`, `<app> wharfie worker`, and `<app> wharfie signal ...`; they are bound to
-the manifest and revision embedded in that artifact and do not accept `--dir`.
+The packaged namespace includes `<app> wharfie run --name <name> -- <args>`,
+`<app> wharfie activity run ...`, `<app> wharfie submit ...`, `<app> wharfie
+start ...`, `<app> wharfie worker`, and `<app> wharfie signal ...`. These
+commands are bound to the manifest and revision embedded in that artifact and
+do not accept `--dir`.
+
 Signal delivery accepts only the current wait. `early-signal`,
 `unexpected-signal`, and `late-signal` are durable, exactly replayable
-rejections rather than a buffered inbox. Exact-run `inspect --json` emits the shared schema-v8 redacted trigger,
+rejections rather than a buffered inbox. Exact-run `inspect --json` emits the
+shared schema-v8 redacted trigger,
 activation-aware cursor, timer, signal-wait, and signal-delivery lifecycle;
 confirmed `recover` and evidence-backed `reconcile` use the same safe view.
 

--- a/docs/architecture/decisions/0011-persisted-state-machine-execution-ledger.md
+++ b/docs/architecture/decisions/0011-persisted-state-machine-execution-ledger.md
@@ -1,6 +1,6 @@
 # 0011 — Persisted state-machine execution ledger
 
-**Status:** Accepted · **Date:** 2026-07-17
+**Status:** Accepted, amended 2026-08-01 · **Date:** 2026-07-17
 
 ## Context
 
@@ -358,7 +358,8 @@ After ownership is claimed, the service records `STARTING` → `READY` →
 the old pathname may remain), does not fabricate `STOPPED`, and lets one later
 owner conditionally replace the absent session with a new endpoint and higher
 generation. On the same local LMDB control volume, mutating source `wharfie ops
-run`, packaged `<app> wharfie run`, recovery, and reconciliation acquire that
+run`, packaged `<app> wharfie activity run`, recovery, and
+reconciliation acquire that
 same ownership fence and refuse to race a resident service; read-only
 inspection does not.
 
@@ -385,14 +386,28 @@ access, `STARTED` built-in application-state siblings are probed read-only, and
 the exact set plus stopped attempt settle atomically. That path exposes neither
 authored activity execution nor the normal adapter catalog.
 
-Foreground activity origination also shares one core host. The installed
-source command supplies one sealed prepared revision; the packaged command
-supplies only its validated embedded manifest and revision/runtime pair. Both
-derive the V7 manual run from app identity plus the caller's idempotency key and
-use the same claim, `STARTED`, managed-effect, framed-attempt, terminal,
-cancellation, and cleanup path. Unlike source-free operator transitions,
-packaged execution authority is exact-revision scoped: an artifact cannot
-override its app, revision, source directory, run ID, attempt, or fence.
+Foreground direct activity origination also shares one core host. The installed
+form is `wharfie ops run`; the packaged form is `<app> wharfie activity run`.
+The source command supplies one sealed prepared revision, while the packaged
+command supplies only its validated embedded manifest and revision/runtime
+pair. Both derive the V7 manual run from app identity plus the caller's
+idempotency key and use the same claim, `STARTED`, managed-effect,
+framed-attempt, terminal, cancellation, and cleanup path. Packaged execution
+authority is exact-revision scoped: an artifact cannot override its app,
+revision, source directory, run ID, attempt, or fence.
+
+The packaged top-level `<app> wharfie run --name <stable-name> --
+<application-args>` is a distinct foreground durable-workflow composition. It
+requires the manifest's default durable CLI handoff, uses the stable name as
+the workflow idempotency key, projects ordinary application arguments, and
+starts or reopens that exact run. It temporarily enters the resident worker
+when no owner is active, follows an existing matching resident otherwise, and
+polls verified logical output and inspection state through terminal completion.
+Repeating the same command reports committed outputs as retained rather than
+running those steps again. `SIGINT` or `SIGTERM` drains the foreground host
+without recording durable cancellation and prints the exact resume command.
+Packaged `start` remains admission-only, and `worker` remains the explicit
+long-lived resident.
 
 Exact-run inspection, confirmed recovery, evidence-backed reconciliation, and
 current-owner cancellation share one core implementation between the installed

--- a/docs/architecture/decisions/0020-systemd-user-service-lifecycle.md
+++ b/docs/architecture/decisions/0020-systemd-user-service-lifecycle.md
@@ -116,13 +116,16 @@ hidden runtime can execute. The layout is carried as process-local async
 bootstrap context rather than hidden environment mutation. Installing a
 service adds supervision and immutable releases around those same state paths;
 it does not move, copy, or select a second ledger. Explicit foreground storage
-overrides remain available, but service management refuses them unless every
-durable route exactly matches the fixed resident layout.
+uses the single `WHARFIE_DATA_ROOT` authority; service management derives its
+resident layout from that active packaged context. An explicit operator/test
+`dataRoot` is accepted only when it agrees, and legacy per-store redirects
+remain rejected.
 
-The packaged layout uses an account-stable data root that does not move with
-invocation-specific `XDG_DATA_HOME` or `HOME`. On Linux it is fixed below the
-service account's `~/.local/share/wharfie-nodejs`, using the home directory
-recorded for that operating-system account:
+Without `WHARFIE_DATA_ROOT`, the packaged layout uses an account-stable data
+root that does not move with invocation-specific `XDG_DATA_HOME` or `HOME`.
+On Linux the default is below the service account's
+`~/.local/share/wharfie-nodejs`, using the home directory recorded for that
+operating-system account:
 
 ```text
 <wharfie-data>/applications/<appId>/
@@ -292,16 +295,9 @@ Wants=network-online.target
 Type=exec
 ExecStart=<wharfie-data>/applications/<appId>/current/app
 WorkingDirectory=<wharfie-data>/applications/<appId>/state
+Environment=WHARFIE_DATA_ROOT=<wharfie-data>
 Environment=WHARFIE_RUNTIME_COMMAND=ledger-service
 Environment=WHARFIE_RUNTIME_ARGS=[]
-Environment=WHARFIE_CONTROL_ADAPTER=lmdb
-Environment=WHARFIE_CONTROL_PATH=<wharfie-data>/applications/<appId>/state/control
-Environment=WHARFIE_EXECUTION_PAYLOAD_PATH=<wharfie-data>/applications/<appId>/state/control/execution-payloads
-Environment=WHARFIE_EXECUTION_PAYLOAD_STORE_ID=
-Environment=WHARFIE_EXECUTION_LEDGER_TABLE=wharfie-execution-ledger-v10
-Environment=WHARFIE_APPLICATION_STATE_ADAPTER=lmdb
-Environment=WHARFIE_APPLICATION_STATE_PATH=<wharfie-data>/applications/<appId>/state/application-state
-Environment=WHARFIE_LEDGER_SERVICE_SESSION_PATH=<wharfie-data>/applications/<appId>/state/control/ledger-service-sessions
 Restart=on-failure
 RestartSec=5s
 KillSignal=SIGTERM
@@ -315,19 +311,21 @@ WantedBy=default.target
 ```
 
 The rendered unit uses systemd argument semantics directly; Wharfie never
-constructs a shell command. The installer does not persist credentials or
-caller-supplied environment values. Runtime dispatch arguments and the local
-payload-store identity are explicitly reset so ambient user-manager values
-cannot redirect the resident bootstrap. Other ambient environment remains an
+constructs a shell command. The installer persists only the active
+`WHARFIE_DATA_ROOT` storage authority and the fixed runtime dispatch
+settings; it does not persist credentials or arbitrary caller-supplied
+environment values. Installation refuses an explicit root that disagrees with
+the packaged process's active root. Other ambient environment remains an
 operating-system property, and authored code runs with the invoking user's
 ordinary authority. A future deployment/runtime-identity contract may narrow
 that authority, but this user-service slice does not pretend to provide that
 isolation.
 
-The explicit LMDB control, payload, application-state, and logical session
-paths remain stable across service restarts, artifact reinstallation, and
+The single data root deterministically derives the LMDB control, payload,
+application-state, and logical-session paths. Those paths remain stable across
+foreground commands, service restarts, artifact reinstallation, and
 uninstallation/reinstallation. They do not depend on the service process's
-working directory or on mutable ambient path defaults. The process working
+working directory or mutable XDG and shell-home values. The process working
 directory is the private `state/` root.
 
 ### Systemd liveness and ledger readiness remain distinct

--- a/docs/architecture/decisions/0030-versioned-application-package-receipt.md
+++ b/docs/architecture/decisions/0030-versioned-application-package-receipt.md
@@ -1,6 +1,6 @@
 # 0030 — Versioned application-package receipt
 
-**Status:** Accepted · **Date:** 2026-07-27
+**Status:** Accepted, amended 2026-08-01 · **Date:** 2026-07-27
 
 ## Context
 
@@ -28,8 +28,8 @@ policy, or independent artifact verification.
 ### Keep the internal result; project a public receipt
 
 `packageLocalApp()` continues to return its rich internal result. The source
-package command alone projects that successful result into this schema-version
-1 JSON document:
+package command projects that successful result when `--json` selects this
+schema-version 1 document:
 
 ```json
 {
@@ -65,6 +65,18 @@ The public receipt deliberately omits the complete application revision,
 artifact record, provenance, embedded inputs, build graph, and publication
 internals. It repeats only the byte identity and target fields needed to
 identify and invoke a freshly published local artifact.
+
+### A targetless manifest means this host
+
+When the manifest omits `targets` and the caller supplies no `--target` filter,
+packaging selects the exact compatible host target: the running Node version,
+platform, architecture, and glibc on Linux. The common local package path no
+longer requires a build matrix whose only member restates the current machine.
+
+A public `--target` filter still selects from targets declared by the manifest.
+Combining a filter with a targetless manifest fails with guidance to remove the
+filter or declare the intended matrix; Wharfie does not infer a cross-target
+request from a filter.
 
 ### The projection is strict and deterministic
 
@@ -117,20 +129,28 @@ are local discovery conveniences for the process and filesystem that performed
 packaging. They are not portable references, durable deployment authority, or
 safe substitutes for byte verification.
 
-### JSON remains the only package-command output
+### Human-first output and stable JSON machine mode
 
-`wharfie app package` continues to emit JSON by default. `--json` remains an
-explicit spelling of that behavior, while `--no-pretty` emits the same one
-document compactly. A successful invocation writes exactly one receipt.
-Packaging or projection failure writes no partial receipt.
+By default, `wharfie app package` reports its resolution, preparation, build,
+download when needed, and publication phases as human diagnostics. Its final
+human summary names every exact target, executable size, and absolute artifact
+path, then prints an actionable `Next:` step. Matching POSIX hosts receive a
+copy-pasteable command; Windows receives a shell-neutral instruction because
+cmd.exe and PowerShell have different quoting rules. For a durable application,
+that command includes the foreground `wharfie run --name first-run --` handoff.
 
-While packaging runs, Wharfie reserves its process stdout for that final
-document. Ordinary in-process writes through `process.stdout` and
-Wharfie-owned build-subprocess output are routed to stderr as diagnostics.
-Application source and build extensions are trusted code, not sandboxed code:
-code that deliberately bypasses the streams or starts its own
-stdout-inheriting subprocess, or leaves stdout-producing work unawaited after
-packaging settles, violates the package-command contract.
+`--json` selects the unchanged schema-version 1 machine document. It is pretty
+by default; `--no-pretty` makes that same JSON document compact. A successful
+JSON invocation writes exactly one receipt. Packaging or projection failure
+writes no partial document.
+
+While packaging runs, both modes reserve process stdout for the selected final
+human summary or JSON document. Ordinary in-process writes through
+`process.stdout` and Wharfie-owned build-subprocess output are routed to stderr
+as diagnostics. Application source and build extensions are trusted code:
+code that bypasses the streams, starts its own stdout-inheriting subprocess, or
+leaves stdout-producing work unawaited after packaging settles violates the
+package-command contract.
 
 The receipt intentionally does not say whether each immutable destination was
 newly created or already contained the exact same bytes and sidecar. Repeated
@@ -138,8 +158,11 @@ successful publication projects the same semantic receipt.
 
 ## Consequences
 
-- Humans, scripts, and coding agents receive one small stable document from
-  local source packaging instead of an internal object graph.
+- Humans receive an immediate artifact handoff and exact next command without
+  interpreting an internal object graph.
+- Scripts and coding agents request the small stable receipt with `--json`.
+- A targetless manifest gives the common local path one exact host artifact;
+  explicit target matrices continue to express cross-target intent.
 - Deployment internals keep their existing fresh-generation authority; no
   path or serialized receipt gains it.
 - Adding a target, artifact, revision, or internal result field cannot silently
@@ -156,8 +179,8 @@ successful publication projects the same semantic receipt.
 - independently rehashing the output files during receipt projection;
 - claiming reproducible SEA bytes or cross-host target executability;
 - exposing complete artifact provenance in command output;
-- adding a human table mode, publication event journal, or `created`/`reused`
-  outcome; and
+- adding a publication event journal or `created`/`reused` outcome to either
+  output mode; and
 - changing selected-SEA deployment authority or packaged operator commands.
 
 ## Rejected alternatives

--- a/docs/guides/application-structure.md
+++ b/docs/guides/application-structure.md
@@ -2,20 +2,41 @@
 
 A Wharfie application is a normal TypeScript or JavaScript CLI plus a small
 `wharfie.app.js` manifest. Wharfie does not impose a generated project tree.
-A minimal application can look like this:
+Inside an ESM npm project where `@wharfie/wharfie` is installed, the smallest
+application-specific surface is two files:
 
 ```text
 my-app/
-├── package.json
-├── wharfie.app.js
-└── src/
-    ├── cli.js
-    └── activities/
-        └── sync.js
+├── hello.js
+└── wharfie.app.js
 ```
 
-The manifest points at the developer-owned CLI and names any work that should
-be available as a durable activity:
+`hello.js` is ordinary application code:
+
+```js
+export function main(argv = process.argv) {
+  process.stdout.write(`Hello, ${argv[2] || 'world'}!\n`);
+}
+```
+
+The manifest points at that developer-owned CLI:
+
+```js
+import { defineApp } from '@wharfie/wharfie/app';
+
+export default defineApp({
+  id: 'hello-world',
+  main: './hello.js',
+});
+```
+
+`defineApp()` expands only the mechanical v4 fields. No second Wharfie-only
+entrypoint, target matrix, activity, workflow, or schedule is required.
+
+## Expanded application
+
+When work needs to be durable, the same manifest can name activities,
+workflows, schedules, and package targets:
 
 ```js
 export default {
@@ -73,9 +94,11 @@ export default {
 };
 ```
 
-`schemaVersion`, `app`, and `cli` are required. `activities`, `workflows`,
-`schedules`, and `targets` are optional, although every declared map and the
-packaging target list must be nonempty. All entrypoints currently use
+`schemaVersion`, `app`, and `cli` are required in the expanded v4 object;
+the compact `defineApp({ id, main })` form supplies them mechanically.
+`activities`, `workflows`, `schedules`, and `targets` are optional,
+although every declared map and the packaging target list must be nonempty.
+All entrypoints currently use
 `{ kind: 'node', path, export }`; both `path` and the named `export` are
 required.
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -18,27 +18,45 @@ Use the exact Node version in `package.json#engines` and the npm version in
 the project reset. The examples below use `wharfie` as shorthand for
 `node ./bin/wharfie` from the repository root.
 
-For the shortest supported product walkthrough, start with the
-[single-host developer preview](./developer-preview.md). Its installed starter
-runs as an ordinary CLI, packages as an SEA, and uses the same fingerprinting
-logic in a durable activity/timer/activity workflow. The longer
+The [magnetic first-run](../product/magnetic-first-run.md) defines the intended
+shortest product journey. Until its canonical starter is versioned here, the
+[single-host developer preview](./developer-preview.md) is the runnable,
+advanced walkthrough. It packages an SEA and exercises a durable
+activity/timer/activity workflow. The longer
 [golden-path guide](./golden-path.md) records the current command and evidence
-boundaries. A clean Ubuntu walkthrough already proves the same-host packaged
-service lifecycle, and the
+boundaries. A clean Ubuntu walkthrough proves the same-host packaged service
+lifecycle, and the
 [accepted split builder/clean-target proof](../../llm/checkpoints/2026-07-29-single-host-developer-preview.md)
 closes the preview milestone with unfinished work at caller exit, explicit
 purge, and complete cleanup.
 
 ## Create an app
 
-Create a `wharfie.app.js` beside your TypeScript or JavaScript sources. The
-manifest identifies the developer-owned CLI, named activities, workflows,
-schedules, and package targets. Its default export must be a plain object using
-the exact v4 schema; unknown or malformed fields are errors. Wharfie does not
-require a generated project tree. See [Application
-Structure](./application-structure.md) for a minimal layout. The
-`@wharfie/wharfie/app` subpath ships TypeScript declarations for the manifest
-helper and activity invocation API.
+Create an ordinary module with a named `main` export:
+
+```js
+export function main(argv = process.argv) {
+  process.stdout.write(`Hello, ${argv[2] || 'world'}!\n`);
+}
+```
+
+Then point a `wharfie.app.js` manifest at it:
+
+```js
+import { defineApp } from '@wharfie/wharfie/app';
+
+export default defineApp({
+  id: 'hello-world',
+  main: './hello.js',
+});
+```
+
+That is the complete beginner-facing manifest. `defineApp()` expands the
+mechanical boilerplate into the strict v4 contract, while unknown or malformed
+fields still fail closed. Wharfie does not require a generated project tree.
+See [Application Structure](./application-structure.md) for the minimal layout.
+The `@wharfie/wharfie/app` subpath ships TypeScript declarations for this
+helper and the activity invocation API.
 
 Activity definitions do not accept `environmentVariables`. Current local
 execution has no per-activity environment boundary, and portable artifacts must
@@ -46,7 +64,9 @@ not embed per-activity environment values in manifests. Supply runtime
 configuration to the process environment until Wharfie has first-class portable
 configuration and secret references.
 
-Every Node entrypoint declares its export explicitly:
+When the application needs named activities, workflows, schedules, or
+cross-target packaging, use the expanded v4 shape. Every Node entrypoint then
+declares its export explicitly:
 
 ```js
 import { defineApp } from '@wharfie/wharfie/app';
@@ -382,10 +402,14 @@ The unit location is fixed to the account's `~/.config/systemd/user`; custom
 `XDG_CONFIG_HOME` topology is rejected, installation verifies the live
 manager's search path, and unit-name mutations require an exact, non-stale
 effective fragment without drop-ins. Packaged durable state is likewise fixed
-to the operating-system account's data root rather than ambient
-`XDG_DATA_HOME` or `HOME`. Uninstall disables the unit and removes the
-executable selector while preserving immutable releases, ledger data, payloads,
-and application state. It retains both an installation identity tombstone and
+to one root rather than ambient `XDG_DATA_HOME` or `HOME`. By default that
+is the operating-system account's stable data root. Set
+`WHARFIE_DATA_ROOT` to a canonical absolute path to choose an explicit root;
+use that same value for every foreground and service-management invocation,
+and the generated unit pins it for the resident. Retired per-store overrides
+are rejected. Uninstall disables the unit and removes the executable selector
+while preserving immutable releases, ledger data, payloads, and application
+state. It retains both an installation identity tombstone and
 the durable `ACTIVE` selection, rollback candidate, and same-revision run
 admission. Run `service install` again from that same selected SEA to rehydrate
 the service without changing activation record version or selection generation.
@@ -780,8 +804,16 @@ commands keep their smaller request default.
 
 ## Package the app
 
-Packaging requires at least one target. Targets use a complete Node version
-and one supported platform/architecture pair:
+For the shortest local path, omit `targets`: packaging selects the exact host
+target and prints a concise result with an actionable next step. On POSIX hosts
+that step is a copy-pasteable command; Windows output stays shell-neutral:
+
+```bash
+wharfie app package ./path/to/app
+```
+
+Declare targets when producing artifacts for other machines. Targets use a
+complete Node version and one supported platform/architecture pair:
 
 ```js
 targets: [
@@ -796,23 +828,24 @@ targets: [
 
 ```bash
 wharfie app package ./path/to/app --target linux-x64 \
-  --no-pretty > package-receipt.json
+  --json --no-pretty > package-receipt.json
 ```
 
 Packaging creates target-specific Node SEA executables. Target machines do not
 need a preinstalled Node runtime, container runtime, or hosted Wharfie service.
 
-Success writes exactly one schema-version 1
-`wharfie.application.package` JSON receipt. Its `artifacts` are sorted by exact
-target and include each content-addressed artifact ID, target, SHA-256 digest,
-byte size, local executable path, and adjacent artifact-record path. The full
-application revision and artifact provenance records remain out of command
-output.
+By default, success writes a human summary. With `--json`, it writes exactly
+one schema-version 1 `wharfie.application.package` JSON receipt. Its
+`artifacts` are sorted by exact target and include each content-addressed
+artifact ID, target, SHA-256 digest, byte size, local executable path, and
+adjacent artifact-record path. The full application revision and artifact
+provenance records remain out of command output.
 
-Ordinary manifest/build diagnostics and Wharfie-owned build-tool output go to
-stderr, leaving redirected stdout as only the receipt. App code is trusted and
-not sandboxed; authored code that deliberately writes directly to file
-descriptor 1 or leaves stdout-producing work unawaited violates this command
+With `--json`, ordinary manifest/build diagnostics and Wharfie-owned
+build-tool output go to stderr, leaving redirected stdout as only the receipt.
+App code is trusted and not sandboxed; authored code that deliberately writes
+directly to file descriptor 1 or leaves stdout-producing work unawaited
+violates this command
 contract.
 
 For an immediate handoff on the matching Linux/systemd host where packaging

--- a/docs/product/magnetic-first-run.md
+++ b/docs/product/magnetic-first-run.md
@@ -1,0 +1,225 @@
+# Magnetic first-run experience
+
+**Status:** Implementation candidate · **Last updated:** 2026-08-05
+
+This note defines Wharfie's north-star promise as a concrete first-run
+experience. The authoring, packaging, storage, and foreground-resume surfaces
+described here are implemented. An external dogfood project exercises the
+journey, but release acceptance remains open until the starter and its complete
+harness are versioned here and run against the published preview package.
+
+## The product moment
+
+The first compelling Wharfie demonstration should leave a developer able to
+say:
+
+> I wrote ordinary JavaScript, packaged it once, killed it halfway through,
+> and the standalone executable resumed exactly where it left off.
+
+Portable packaging is useful, but by itself it resembles an application
+bundler. The combination of an ordinary CLI, one portable artifact, and
+visible durable continuation is the distinctive Wharfie experience.
+
+## Teach it in two steps
+
+### 1. The smallest application
+
+Keep one canonical hello-world application deliberately unsurprising:
+
+- ordinary JavaScript with ordinary argv, stdout, and exit behavior;
+- one small, readable manifest;
+- no imports from a Wharfie source checkout;
+- one local command, one test command, and one package command; and
+- an artifact that runs after it is moved away from its source tree, with Node
+  absent from `PATH`.
+
+This application answers **"What is a Wharfie application?"** Its entire
+authored application should fit on one screen, and every manifest field should
+be explainable in the first read.
+
+The canonical manifest is the complete beginner-facing contract:
+
+```js
+import { defineApp } from '@wharfie/wharfie/app';
+
+export default defineApp({
+  id: 'hello-world',
+  main: './hello.js',
+});
+```
+
+`defineApp()` expands that shorthand into the strict v4 manifest. The full
+schema remains available when an application needs its additional controls.
+
+### 2. The polished resumable showcase
+
+Add one equally polished example that reuses the same application shape and
+adds the minimum durable behavior needed to answer **"Why Wharfie?"**:
+
+```text
+prepare greeting -> wait on a durable timer -> print greeting
+```
+
+The showcase kills the foreground durable `run` process after
+`prepare greeting`. Repeating the exact named command visibly continues from
+the retained timer without preparing the greeting a second time. A graceful
+`SIGINT` or `SIGTERM` separately drains without cancelling durable work and
+prints that same resume command. The final result remains inspectable from a
+later process.
+
+This is a supported showcase, not a playground experiment. Messy probes,
+failure injection, provenance tooling, and incomplete ideas should remain in a
+separately labeled playground so they do not become part of the beginner's
+mental model.
+
+## Target journey
+
+A fresh checkout or copied starter should expose one obvious path:
+
+```bash
+npm install
+npm run demo
+```
+
+The repository-level `demo` command may orchestrate the product commands, but
+it must make those commands and their results visible. An illustrative
+transcript is:
+
+```text
+  Resolving application and build target
+  Preparing resumable-hello for <host-target>
+  Building executable artifacts
+  Publishing verified artifacts
+✓ Packaged resumable-hello
+  <host-target> · <size>
+  <artifact>
+Next: <artifact> wharfie run --name first-run --
+
+$ WHARFIE_DATA_ROOT=<data-root> <artifact> wharfie run --name first-run -- Ada
+• resumable-hello · new durable run first-run (<run-id>).
+✓ prepare — committed
+◷ wait — durable timer, 4.8s remaining
+<foreground process receives SIGKILL>
+
+$ <same command>
+↻ Resuming first-run (<run-id>).
+✓ prepare — retained; not run again
+◷ wait — same durable timer, 1.2s remaining
+✓ wait — committed
+✓ say-hello — committed
+✓ Completed first-run; result retained.
+Hello, Ada!
+```
+
+The exact wording is not normative. The important sequence is authored source,
+artifact creation, relocation, interruption, resumption, and an inspectable
+result. A developer should reach that sequence in under two minutes on a warm
+development machine.
+
+## Experience requirements
+
+### Minimize ceremony
+
+- Installation and the first demo each have one obvious command.
+- The beginner path does not expose custom provenance scripts, hand-built
+  package tarballs, internal receipts, or repository-relative toolchain wiring.
+- The default package command infers the host target. Cross-target packaging
+  remains an explicit advanced operation.
+- The smallest manifest is `defineApp({ id, main })`; the helper expands it to
+  the strict runtime contract.
+- Local execution does not require a second application entrypoint solely for
+  Wharfie.
+- The first durable handoff uses ordinary application arguments rather than
+  requiring the user to construct workflow JSON or repeat internal IDs.
+- One `WHARFIE_DATA_ROOT` keeps every packaged durable store under the same
+  explicit root.
+
+### Make the artifact feel approachable
+
+- Packaging reports what it is doing, where the artifact was written, its
+  target and size, and the exact next command to run.
+- Human handoff is the package default; the stable v1 machine receipt is
+  explicitly selected with `--json`.
+- The demo proves that the artifact works outside its source tree without an
+  ambient Node installation or sibling Wharfie checkout.
+- Ordinary artifact argv does not pay the native durable-runtime preparation
+  cost; the reserved Wharfie path prepares it lazily.
+- Artifact size and build time are tracked as product metrics. They should not
+  become the first objection a developer has after the demo succeeds.
+
+### Make durability visible and honest
+
+- The interruption happens after one committed step and before the timer
+  completes.
+- Repeating the exact named foreground command resumes the run and does not
+  repeat that committed step.
+- The timer remains framework-owned state rather than a sleep hidden inside
+  application code.
+- The transcript distinguishes a resumed durable run from a new invocation.
+- The example does not imply that arbitrary physical execution is exactly
+  once; it demonstrates Wharfie's actual retained-state and recovery
+  guarantees.
+
+## Acceptance check
+
+The showcase earns an experience-level acceptance when an automated harness
+can prove all of the following from only a copied starter and an installed,
+pinned Wharfie package:
+
+1. Run the ordinary CLI and its tests.
+2. Compile and display the application manifest.
+3. Package exactly one host-target artifact.
+4. Copy the artifact to a clean temporary directory and run it without source
+   files or Node on `PATH`.
+5. Start the named foreground durable greeting and observe its first committed
+   step.
+6. Interrupt the foreground process before the timer becomes due.
+7. Repeat the exact command with the same artifact and data root.
+8. Observe the greeting complete without the first step running twice.
+9. Inspect the retained terminal result from a later process.
+
+The harness is evidence for the experience, not part of the application users
+must understand.
+
+**Prototype evidence (2026-08-01, Darwin arm64):** the external harness passed
+the ordinary, packaging, relocation, interruption, exact-resume, completion,
+and redacted-inspection path against a checksum-pinned working-tree package.
+It inferred `node24.13.1-darwin-arm64`, packaged in 8.3 seconds, produced one
+119.0 MiB artifact, and launched the relocated ordinary CLI in 1.414 seconds
+with Node absent from `PATH` and no durable-runtime extraction. After
+`SIGKILL`, the same artifact, data root, command, run identity, preparation
+attempt, timer identity, and deadline were retained. Repeating the exact
+command completed `wait` and `say-hello`; later-process inspection proved
+one `prepare` invocation and one physical attempt. The complete disposable
+run took under 30 seconds and cleaned up its state. This is useful
+implementation evidence, not the acceptance above: the harness is not yet in
+this repository and it does not yet perform the final later-process
+retained-output read.
+
+## Dogfood baseline
+
+The external hello-world dogfood project was evaluated on 2026-07-31. Its
+canonical application was 24 authored lines and successfully passed local CLI,
+test, manifest, package, relocated-artifact, and Node-absent execution checks.
+That established a sound **B- / 7 out of 10** baseline.
+
+The experience was not yet magnetic because installation expanded to 202 npm
+packages (about 138 MB), the Darwin arm64 artifact was about 119 MB, the
+private-package tarball and exact Node/npm pins were visible setup concerns,
+and the canonical application demonstrated packaging but not Wharfie's durable
+continuity.
+
+The 2026-08-01 implementation candidate addresses the product-side friction:
+compact `defineApp()` authoring, automatic exact-host targeting for a
+targetless manifest, human-first package output with an unchanged `--json`
+receipt, lazy native-runtime preparation for ordinary argv, one
+`WHARFIE_DATA_ROOT`, and the repeatable packaged
+`wharfie run --name <name> -- <args>` foreground workflow. The external
+hello-world showcase exercises that path with the measurements above.
+
+The prototype is an **A- / 9 out of 10 candidate**: the beginner path preserves
+the small application and adds the polished interruption-and-resumption moment
+without exposing the harness machinery. It earns that grade as a shipped
+experience only after the versioned gate passes against the published preview.
+The other main first-run objection is weight: 202 installed npm packages
+(about 138 MB) and a 119 MiB executable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6709,9 +6709,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/scripts/verify-package-sea.js
+++ b/scripts/verify-package-sea.js
@@ -150,6 +150,32 @@ const SEA_SCHEDULE_MARKER_DIRECTORY = 'scheduled-workflow-markers';
 const SEA_SCHEDULE_PROOF_CRON =
   '0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58 * * * *';
 const SEA_WORKFLOW_ACTIVITY_ID = 'workflow-step';
+const SEA_EXECUTION_LEDGER_TABLE = 'wharfie-execution-ledger-v10';
+
+/**
+ * Independently derive the packaged app's sealed local-storage layout. Every
+ * relocated SEA receives only the public data-root authority; the host-side
+ * verifier uses these derived paths to seed and inspect the same stores.
+ * @param {{appId: string, root: string}} options - App identity and isolated proof root.
+ * @returns {Readonly<Record<string, string>>} - Canonical packaged storage paths.
+ */
+function createVerifierPackagedStorageLayout(options) {
+  assert.ok(
+    path.isAbsolute(options.root),
+    'SEA verifier root must be absolute',
+  );
+  const dataRoot = path.join(options.root, 'wharfie-data');
+  const stateRoot = path.join(dataRoot, 'applications', options.appId, 'state');
+  const controlPath = path.join(stateRoot, 'control');
+  return Object.freeze({
+    dataRoot,
+    controlPath,
+    payloadPath: path.join(controlPath, 'execution-payloads'),
+    sessionPath: path.join(controlPath, 'ledger-service-sessions'),
+    applicationStatePath: path.join(stateRoot, 'application-state'),
+    tableName: SEA_EXECUTION_LEDGER_TABLE,
+  });
+}
 const SEA_CRASH_CASES = Object.freeze([
   {
     boundary: 'request-payload-published',
@@ -3701,22 +3727,22 @@ async function verifyRelocatedSeaCrashMatrix(options) {
   };
   for (const scenario of SEA_CRASH_CASES) {
     const caseRoot = path.join(options.root, scenario.boundary);
-    const controlPath = path.join(caseRoot, 'control');
-    const payloadPath = path.join(controlPath, 'execution-payloads');
-    const sessionPath = path.join(caseRoot, 'sessions');
-    const applicationStatePath = path.join(caseRoot, 'application-state');
+    const {
+      dataRoot,
+      controlPath,
+      payloadPath,
+      sessionPath,
+      applicationStatePath,
+      tableName,
+    } = createVerifierPackagedStorageLayout({
+      appId: options.appId,
+      root: caseRoot,
+    });
     const markerPath = path.join(caseRoot, 'user-continuation.json');
-    const tableName = 'wharfie-package-sea-crash-matrix';
     mkdirSync(caseRoot, { recursive: true, mode: 0o700 });
     const environment = {
       ...options.cleanEnvironment,
-      WHARFIE_CONTROL_ADAPTER: 'lmdb',
-      WHARFIE_CONTROL_PATH: controlPath,
-      WHARFIE_EXECUTION_LEDGER_TABLE: tableName,
-      WHARFIE_EXECUTION_PAYLOAD_PATH: payloadPath,
-      WHARFIE_LEDGER_SERVICE_SESSION_PATH: sessionPath,
-      WHARFIE_APPLICATION_STATE_ADAPTER: 'lmdb',
-      WHARFIE_APPLICATION_STATE_PATH: applicationStatePath,
+      WHARFIE_DATA_ROOT: dataRoot,
     };
     const fixture = await createInstalledExecutionLedgerFixture({
       installedPackageRoot: options.installedPackageRoot,
@@ -3758,6 +3784,7 @@ async function verifyRelocatedSeaCrashMatrix(options) {
     };
     const runArgs = [
       'wharfie',
+      'activity',
       'run',
       '--activity',
       'persist-once',
@@ -4096,25 +4123,25 @@ async function verifyRelocatedSeaMixedSettlementCrashMatrix(options) {
   };
   for (const scenario of SEA_MIXED_SETTLEMENT_CRASH_CASES) {
     const caseRoot = path.join(options.root, scenario.boundary);
-    const controlPath = path.join(caseRoot, 'control');
-    const payloadPath = path.join(controlPath, 'execution-payloads');
-    const sessionPath = path.join(caseRoot, 'sessions');
-    const applicationStatePath = path.join(caseRoot, 'application-state');
+    const {
+      dataRoot,
+      controlPath,
+      payloadPath,
+      sessionPath,
+      applicationStatePath,
+      tableName,
+    } = createVerifierPackagedStorageLayout({
+      appId: options.appId,
+      root: caseRoot,
+    });
     const markerPath = path.join(
       caseRoot,
       'authored-marker-must-not-exist.json',
     );
-    const tableName = 'wharfie-package-sea-mixed-settlement-crash-matrix';
     mkdirSync(caseRoot, { recursive: true, mode: 0o700 });
     const environment = {
       ...options.cleanEnvironment,
-      WHARFIE_CONTROL_ADAPTER: 'lmdb',
-      WHARFIE_CONTROL_PATH: controlPath,
-      WHARFIE_EXECUTION_LEDGER_TABLE: tableName,
-      WHARFIE_EXECUTION_PAYLOAD_PATH: payloadPath,
-      WHARFIE_LEDGER_SERVICE_SESSION_PATH: sessionPath,
-      WHARFIE_APPLICATION_STATE_ADAPTER: 'lmdb',
-      WHARFIE_APPLICATION_STATE_PATH: applicationStatePath,
+      WHARFIE_DATA_ROOT: dataRoot,
     };
     const fixture = await createInstalledExecutionLedgerFixture({
       installedPackageRoot: options.installedPackageRoot,
@@ -4492,12 +4519,18 @@ async function verifyRelocatedSeaMixedSettlementCrashMatrix(options) {
  */
 async function verifyRelocatedSeaEffectReconciliationCrashMatrix(options) {
   const caseRoot = options.root;
-  const controlPath = path.join(caseRoot, 'control');
-  const payloadPath = path.join(controlPath, 'execution-payloads');
-  const sessionPath = path.join(caseRoot, 'sessions');
-  const applicationStatePath = path.join(caseRoot, 'application-state');
+  const {
+    dataRoot,
+    controlPath,
+    payloadPath,
+    sessionPath,
+    applicationStatePath,
+    tableName,
+  } = createVerifierPackagedStorageLayout({
+    appId: options.appId,
+    root: caseRoot,
+  });
   const markerPath = path.join(caseRoot, 'authored-activity-must-not-run.json');
-  const tableName = 'wharfie-package-sea-effect-reconciliation-crash-matrix';
   const packagedActor = {
     kind: 'packaged-operator',
     id: options.revisionId,
@@ -4506,13 +4539,7 @@ async function verifyRelocatedSeaEffectReconciliationCrashMatrix(options) {
   mkdirSync(caseRoot, { recursive: true, mode: 0o700 });
   const environment = {
     ...options.cleanEnvironment,
-    WHARFIE_CONTROL_ADAPTER: 'lmdb',
-    WHARFIE_CONTROL_PATH: controlPath,
-    WHARFIE_EXECUTION_LEDGER_TABLE: tableName,
-    WHARFIE_EXECUTION_PAYLOAD_PATH: payloadPath,
-    WHARFIE_LEDGER_SERVICE_SESSION_PATH: sessionPath,
-    WHARFIE_APPLICATION_STATE_ADAPTER: 'lmdb',
-    WHARFIE_APPLICATION_STATE_PATH: applicationStatePath,
+    WHARFIE_DATA_ROOT: dataRoot,
   };
   const fixture = await createInstalledExecutionLedgerFixture({
     installedPackageRoot: options.installedPackageRoot,
@@ -6268,15 +6295,21 @@ async function verifyRelocatedSeaManagedEffectSuccessorCrashMatrix(options) {
     ] of SEA_SUCCESSOR_CRASH_CASES.entries()) {
       const caseId = `case-${scenarioIndex + 1}`;
       const caseRoot = path.join(options.root, scenario.boundary);
-      const controlPath = path.join(caseRoot, 'control');
-      const payloadPath = path.join(controlPath, 'execution-payloads');
-      const sessionPath = path.join(caseRoot, 'sessions');
-      const applicationStatePath = path.join(caseRoot, 'application-state');
+      const {
+        dataRoot,
+        controlPath,
+        payloadPath,
+        sessionPath,
+        applicationStatePath,
+        tableName,
+      } = createVerifierPackagedStorageLayout({
+        appId: options.appId,
+        root: caseRoot,
+      });
       const markerPath = path.join(
         caseRoot,
         'authored-activity-must-not-run.json',
       );
-      const tableName = `wharfie-package-sea-${scenario.boundary}`;
       const packagedActor = {
         kind: 'packaged-operator',
         id: options.revisionId,
@@ -6291,13 +6324,7 @@ async function verifyRelocatedSeaManagedEffectSuccessorCrashMatrix(options) {
       mkdirSync(caseRoot, { recursive: true, mode: 0o700 });
       const environment = {
         ...options.cleanEnvironment,
-        WHARFIE_CONTROL_ADAPTER: 'lmdb',
-        WHARFIE_CONTROL_PATH: controlPath,
-        WHARFIE_EXECUTION_LEDGER_TABLE: tableName,
-        WHARFIE_EXECUTION_PAYLOAD_PATH: payloadPath,
-        WHARFIE_LEDGER_SERVICE_SESSION_PATH: sessionPath,
-        WHARFIE_APPLICATION_STATE_ADAPTER: 'lmdb',
-        WHARFIE_APPLICATION_STATE_PATH: applicationStatePath,
+        WHARFIE_DATA_ROOT: dataRoot,
       };
       const fixture = await createInstalledExecutionLedgerFixture({
         installedPackageRoot: options.installedPackageRoot,
@@ -7336,22 +7363,22 @@ function workflowReadySummary(items) {
  */
 async function createRelocatedSeaWorkflowCase(options, boundary) {
   const caseRoot = path.join(options.root, boundary);
-  const controlPath = path.join(caseRoot, 'control');
-  const payloadPath = path.join(controlPath, 'execution-payloads');
-  const sessionPath = path.join(caseRoot, 'sessions');
-  const applicationStatePath = path.join(caseRoot, 'application-state');
+  const {
+    dataRoot,
+    controlPath,
+    payloadPath,
+    sessionPath,
+    applicationStatePath,
+    tableName,
+  } = createVerifierPackagedStorageLayout({
+    appId: options.appId,
+    root: caseRoot,
+  });
   const markerDirectory = path.join(caseRoot, 'workflow-markers');
-  const tableName = 'wharfie-package-sea-workflow-crash-matrix';
   mkdirSync(markerDirectory, { recursive: true, mode: 0o700 });
   const environment = {
     ...options.cleanEnvironment,
-    WHARFIE_CONTROL_ADAPTER: 'lmdb',
-    WHARFIE_CONTROL_PATH: controlPath,
-    WHARFIE_EXECUTION_LEDGER_TABLE: tableName,
-    WHARFIE_EXECUTION_PAYLOAD_PATH: payloadPath,
-    WHARFIE_LEDGER_SERVICE_SESSION_PATH: sessionPath,
-    WHARFIE_APPLICATION_STATE_ADAPTER: 'lmdb',
-    WHARFIE_APPLICATION_STATE_PATH: applicationStatePath,
+    WHARFIE_DATA_ROOT: dataRoot,
   };
   const fixture = await createInstalledExecutionLedgerFixture({
     installedPackageRoot: options.installedPackageRoot,
@@ -7450,6 +7477,7 @@ async function createRelocatedSeaWorkflowCase(options, boundary) {
     payloadPath,
     sessionPath,
     applicationStatePath,
+    tableName,
     markerDirectory,
     environment,
     fixture,
@@ -7722,22 +7750,22 @@ async function assertCompletedSeaWorkflow(
 async function verifyRelocatedSeaTimerSignalWorkflow(options) {
   rmSync(options.root, { recursive: true, force: true });
   mkdirSync(options.root, { recursive: true, mode: 0o700 });
-  const controlPath = path.join(options.root, 'control');
-  const payloadPath = path.join(controlPath, 'execution-payloads');
-  const sessionPath = path.join(options.root, 'sessions');
-  const applicationStatePath = path.join(options.root, 'application-state');
+  const {
+    dataRoot,
+    controlPath,
+    payloadPath,
+    sessionPath,
+    applicationStatePath,
+    tableName,
+  } = createVerifierPackagedStorageLayout({
+    appId: options.appId,
+    root: options.root,
+  });
   const markerDirectory = path.join(options.root, 'workflow-markers');
-  const tableName = 'wharfie-package-sea-timer-signal-workflow';
   mkdirSync(markerDirectory, { recursive: true, mode: 0o700 });
   const environment = {
     ...options.cleanEnvironment,
-    WHARFIE_CONTROL_ADAPTER: 'lmdb',
-    WHARFIE_CONTROL_PATH: controlPath,
-    WHARFIE_EXECUTION_LEDGER_TABLE: tableName,
-    WHARFIE_EXECUTION_PAYLOAD_PATH: payloadPath,
-    WHARFIE_LEDGER_SERVICE_SESSION_PATH: sessionPath,
-    WHARFIE_APPLICATION_STATE_ADAPTER: 'lmdb',
-    WHARFIE_APPLICATION_STATE_PATH: applicationStatePath,
+    WHARFIE_DATA_ROOT: dataRoot,
   };
   const fixture = await createInstalledExecutionLedgerFixture({
     installedPackageRoot: options.installedPackageRoot,
@@ -8118,26 +8146,25 @@ async function verifyRelocatedSeaScheduleRestartProof(options) {
     'linux',
     'the relocated SEA schedule/restart proof is Linux-only',
   );
-  const controlPath = path.join(options.root, 'control');
-  const payloadPath = path.join(controlPath, 'execution-payloads');
-  const sessionPath = path.join(options.root, 'sessions');
-  const applicationStatePath = path.join(options.root, 'application-state');
+  const {
+    dataRoot,
+    controlPath,
+    payloadPath,
+    applicationStatePath,
+    tableName,
+  } = createVerifierPackagedStorageLayout({
+    appId: options.appId,
+    root: options.root,
+  });
   const markerDirectory = path.join(
     options.root,
     SEA_SCHEDULE_MARKER_DIRECTORY,
   );
   const markerPath = path.join(markerDirectory, '1.json');
   const dispatchLogPath = path.join(options.root, 'workflow-dispatch.jsonl');
-  const tableName = 'wharfie-package-sea-schedule-restart-proof';
   const environment = {
     ...options.cleanEnvironment,
-    WHARFIE_CONTROL_ADAPTER: 'lmdb',
-    WHARFIE_CONTROL_PATH: controlPath,
-    WHARFIE_EXECUTION_LEDGER_TABLE: tableName,
-    WHARFIE_EXECUTION_PAYLOAD_PATH: payloadPath,
-    WHARFIE_LEDGER_SERVICE_SESSION_PATH: sessionPath,
-    WHARFIE_APPLICATION_STATE_ADAPTER: 'lmdb',
-    WHARFIE_APPLICATION_STATE_PATH: applicationStatePath,
+    WHARFIE_DATA_ROOT: dataRoot,
     WHARFIE_SEA_VERIFIER_WORKFLOW_DISPATCH_LOG: dispatchLogPath,
   };
   const lifecycle = await createInstalledLedgerLifecycleObserver({
@@ -8444,6 +8471,7 @@ async function packageAndVerifyRelocatedSeaScheduleRestart(options) {
           options.appDirectory,
           '--output-dir',
           outputDirectory,
+          '--json',
           '--no-pretty',
         ],
         {
@@ -8549,8 +8577,7 @@ async function verifyRelocatedSeaWorkflowCrashMatrix(options) {
         ...process.env,
         WHARFIE_CONTROL_ADAPTER: 'lmdb',
         WHARFIE_CONTROL_PATH: cross.controlPath,
-        WHARFIE_EXECUTION_LEDGER_TABLE:
-          cross.environment.WHARFIE_EXECUTION_LEDGER_TABLE,
+        WHARFIE_EXECUTION_LEDGER_TABLE: cross.tableName,
         WHARFIE_EXECUTION_PAYLOAD_PATH: cross.payloadPath,
         WHARFIE_LEDGER_SERVICE_SESSION_PATH: cross.sessionPath,
         WHARFIE_APPLICATION_STATE_ADAPTER: 'lmdb',
@@ -9783,6 +9810,7 @@ export default defineApp({
       appDirectory,
       '--output-dir',
       outputDirectory,
+      '--json',
       '--no-pretty',
     ],
     { cwd: appDirectory, capture: true },
@@ -10203,22 +10231,21 @@ export default defineApp({
     JSON.parse(JSON.stringify(packagedAuthority.revision.contract.schedules)),
   );
 
-  const controlPath = path.join(cleanRunDirectory, 'resident-control');
-  const sessionPath = path.join(cleanRunDirectory, 'resident-sessions');
-  const payloadPath = path.join(controlPath, 'execution-payloads');
-  const applicationStatePath = path.join(
-    cleanRunDirectory,
-    'application-state',
-  );
-  const activeRecoveryProbePath = path.join(
-    cleanRunDirectory,
-    'active-recovery-probe-must-remain-absent',
-  );
+  const {
+    dataRoot,
+    controlPath,
+    payloadPath,
+    sessionPath,
+    applicationStatePath,
+    tableName: ledgerTableName,
+  } = createVerifierPackagedStorageLayout({
+    appId: embeddedManifest.app.id,
+    root: cleanRunDirectory,
+  });
   const residentActivityDispatchMarkerPath = path.join(
     cleanRunDirectory,
     'resident-activity-dispatch-must-remain-absent.json',
   );
-  const ledgerTableName = 'wharfie-package-sea-ledger-service';
   const lifecycleObserver = await createInstalledLedgerLifecycleObserver({
     installedPackageRoot,
     controlPath,
@@ -10226,6 +10253,10 @@ export default defineApp({
     appId: embeddedManifest.app.id,
   });
   const operatorEnvironment = {
+    ...cleanEnvironment,
+    WHARFIE_DATA_ROOT: dataRoot,
+  };
+  const sourceOperatorEnvironment = {
     ...cleanEnvironment,
     WHARFIE_CONTROL_ADAPTER: 'lmdb',
     WHARFIE_CONTROL_PATH: controlPath,
@@ -10279,6 +10310,7 @@ export default defineApp({
   };
   const durableRunArgs = [
     'wharfie',
+    'activity',
     'run',
     '--activity',
     'persist-once',
@@ -10793,6 +10825,7 @@ export default defineApp({
         fixture: sourceEffectBatch,
         command: process.execPath,
         operatorPrefix: [wharfieBin, 'ops'],
+        environment: sourceOperatorEnvironment,
         actor: { kind: 'local', id: 'cli' },
       },
       {
@@ -10800,6 +10833,7 @@ export default defineApp({
         fixture: seaEffectBatch,
         command: cleanArtifactPath,
         operatorPrefix: ['wharfie'],
+        environment: operatorEnvironment,
         actor: {
           kind: 'packaged-operator',
           id: packagedRevisionId,
@@ -10851,7 +10885,7 @@ export default defineApp({
       {
         cwd: cleanRunDirectory,
         capture: true,
-        env: operatorEnvironment,
+        env: sourceOperatorEnvironment,
       },
     ).stdout.trim();
     const packagedInspectionText = runCommand(
@@ -10896,7 +10930,7 @@ export default defineApp({
         {
           cwd: cleanRunDirectory,
           capture: true,
-          env: operatorEnvironment,
+          env: sourceOperatorEnvironment,
         },
       ).stdout.trim();
       const seaEffectInspectionText = runCommand(
@@ -10957,7 +10991,7 @@ export default defineApp({
         {
           cwd: cleanRunDirectory,
           capture: true,
-          env: operatorEnvironment,
+          env: sourceOperatorEnvironment,
         },
       ).stdout,
     );
@@ -11133,10 +11167,6 @@ export default defineApp({
         await ledgerFixture.readRun(target.fixture.runId),
       );
     }
-    const activeRecoveryEnvironment = {
-      ...operatorEnvironment,
-      WHARFIE_APPLICATION_STATE_PATH: activeRecoveryProbePath,
-    };
     for (const target of effectRecoveryTargets) {
       const refused = spawnSync(
         target.command,
@@ -11151,7 +11181,7 @@ export default defineApp({
         {
           cwd: cleanRunDirectory,
           encoding: 'utf8',
-          env: activeRecoveryEnvironment,
+          env: target.environment,
         },
       );
       if (refused.error) throw refused.error;
@@ -11163,11 +11193,6 @@ export default defineApp({
         `${target.label} recovery did not refuse the active owner`,
       );
     }
-    assert.equal(
-      existsSync(activeRecoveryProbePath),
-      false,
-      'active-owner refusal probed or materialized application state',
-    );
     for (const target of effectRecoveryTargets) {
       assert.deepEqual(
         await ledgerFixture.readRun(target.fixture.runId),
@@ -11380,7 +11405,7 @@ export default defineApp({
         {
           cwd: cleanRunDirectory,
           capture: true,
-          env: operatorEnvironment,
+          env: target.environment,
         },
       ).stdout.trim();
       assertManagedEffectBatchRecoveryView(recoveryText, target.fixture, {

--- a/scripts/verify-steady-file-systemd-linux.js
+++ b/scripts/verify-steady-file-systemd-linux.js
@@ -626,6 +626,7 @@ function packageSteadyFileArtifacts() {
         outputDirectory,
         '--target',
         target,
+        '--json',
         '--no-pretty',
       ],
       { cwd: consumerRoot, env: process.env, timeoutMs: 600_000 },

--- a/scripts/verify-systemd-user-service-linux.js
+++ b/scripts/verify-systemd-user-service-linux.js
@@ -596,6 +596,7 @@ function packageProofArtifacts(repoRoot) {
         outputDirectory,
         '--target',
         target,
+        '--json',
         '--no-pretty',
       ],
       { cwd: consumerRoot, env: process.env, timeoutMs: 600_000 },

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -228,6 +228,173 @@ export type WharfieAppDefinition = WharfieAppDefinitionBase & {
   schemaVersion: 4;
 };
 
+/** One activity entrypoint in the compact source-authoring form. */
+export interface AppActivityShorthand {
+  /** Overrides the shared activity module for this activity. */
+  path?: string;
+  /** Defaults to the logical activity ID only when that ID is a JS export name. */
+  export?: string;
+  externalPackages?: readonly ExternalPackage[];
+}
+
+/**
+ * Compact source-only application authoring. Logical durable identities remain
+ * explicit; defineApp expands only mechanical v4 and Node entrypoint fields.
+ */
+export interface WharfieAppShorthand {
+  id: LogicalId;
+  /** Node module whose conventional `main` export implements the ordinary CLI. */
+  main: string;
+  /** Workflow handed ordinary arguments through conventional `toDurableInput`. */
+  durable?: LogicalId;
+  /** Shared Node module path for activities that omit their own path. */
+  activityModule?: string;
+  targets?: readonly AppTarget[];
+  activities?: Readonly<Record<LogicalId, AppActivityShorthand>>;
+  workflows?: Readonly<Record<LogicalId, WorkflowDefinition>>;
+  schedules?: Readonly<Record<LogicalId, WorkflowScheduleDefinition>>;
+}
+
+type ExpandedShorthandActivity<
+  App extends WharfieAppShorthand,
+  Id extends PropertyKey,
+  Activity extends AppActivityShorthand,
+> = {
+  readonly entrypoint: {
+    readonly kind: 'node';
+    readonly path: Activity extends { readonly path: infer Path extends string }
+      ? Path
+      : App extends { readonly activityModule: infer Path extends string }
+        ? Path
+        : string;
+    readonly export: Activity extends {
+      readonly export: infer Export extends string;
+    }
+      ? Export
+      : Id extends string
+        ? Id
+        : string;
+  };
+} & (Activity extends { readonly externalPackages: infer Packages }
+  ? { readonly externalPackages: Packages }
+  : unknown);
+
+type ExpandedShorthandActivities<App extends WharfieAppShorthand> =
+  App extends {
+    readonly activities: infer Activities extends Readonly<
+      Record<string, AppActivityShorthand>
+    >;
+  }
+    ? {
+        readonly activities: {
+          readonly [Id in keyof Activities]: ExpandedShorthandActivity<
+            App,
+            Id,
+            Activities[Id]
+          >;
+        };
+      }
+    : unknown;
+
+type ShorthandDurableReferencesDeclaredWorkflow<Actual> = Actual extends {
+  readonly durable: infer Durable;
+}
+  ? Actual extends { readonly workflows: infer Workflows }
+    ? Durable extends keyof Workflows
+      ? unknown
+      : never
+    : never
+  : unknown;
+
+type ShorthandActivityModuleRequiresActivities<Actual> = Actual extends {
+  readonly activityModule: unknown;
+}
+  ? Actual extends { readonly activities: Readonly<Record<string, any>> }
+    ? unknown
+    : never
+  : unknown;
+
+type ShorthandActivitiesHaveValidPresentStrings<Actual> = Actual extends {
+  readonly activities: infer Activities extends Readonly<Record<string, any>>;
+}
+  ? {
+      [Id in keyof Activities]:
+        | ('path' extends keyof Activities[Id]
+            ? Activities[Id] extends { readonly path: string }
+              ? never
+              : Id
+            : never)
+        | ('export' extends keyof Activities[Id]
+            ? Activities[Id] extends { readonly export: string }
+              ? never
+              : Id
+            : never);
+    }[keyof Activities] extends never
+    ? unknown
+    : never
+  : unknown;
+
+type ShorthandActivitiesHavePaths<Actual> = Actual extends {
+  readonly activities: infer Activities extends Readonly<Record<string, any>>;
+}
+  ? Actual extends { readonly activityModule: string }
+    ? unknown
+    : {
+          [Id in keyof Activities]: Activities[Id] extends {
+            readonly path: string;
+          }
+            ? never
+            : Id;
+        }[keyof Activities] extends never
+      ? unknown
+      : never
+  : unknown;
+
+type ShorthandActivitiesHaveExports<Actual> = Actual extends {
+  readonly activities: infer Activities extends Readonly<Record<string, any>>;
+}
+  ? {
+      [Id in keyof Activities]: Id extends string
+        ? Id extends `${string}-${string}`
+          ? Activities[Id] extends { readonly export: string }
+            ? never
+            : Id
+          : never
+        : Id;
+    }[keyof Activities] extends never
+    ? unknown
+    : never
+  : unknown;
+
+/** The exact explicit v4 source shape returned for compact authoring. */
+export type ExpandedWharfieAppShorthand<App extends WharfieAppShorthand> = {
+  readonly schemaVersion: 4;
+  readonly app: { readonly id: App['id'] };
+  readonly cli: {
+    readonly entrypoint: {
+      readonly kind: 'node';
+      readonly path: App['main'];
+      readonly export: 'main';
+    };
+  } & (App extends { readonly durable: infer Workflow extends string }
+    ? {
+        readonly durable: {
+          readonly workflow: Workflow;
+          readonly export: 'toDurableInput';
+        };
+      }
+    : unknown);
+} & (App extends { readonly targets: infer Targets }
+  ? { readonly targets: Targets }
+  : unknown) &
+  ExpandedShorthandActivities<App> &
+  (App extends { readonly workflows: infer Workflows }
+    ? { readonly workflows: Workflows }
+    : unknown) &
+  (App extends { readonly schedules: infer Schedules }
+    ? { readonly schedules: Schedules }
+    : unknown);
+
 type StrictShape<Actual, Shape> = Shape extends unknown
   ? Actual extends Shape
     ? Shape extends readonly (infer ShapeItem)[]
@@ -293,6 +460,20 @@ export declare function defineApp<const App>(
     ScheduleReferencesDeclaredWorkflow<App> &
     DurableCliReferencesDeclaredWorkflow<App>,
 ): App;
+
+export declare function defineApp<const App extends WharfieAppShorthand>(
+  definition: App &
+    StrictShape<App, WharfieAppShorthand> &
+    NonEmptyWhenDeclared<App, 'activities'> &
+    NonEmptyWhenDeclared<App, 'workflows'> &
+    NonEmptyWhenDeclared<App, 'schedules'> &
+    ScheduleReferencesDeclaredWorkflow<App> &
+    ShorthandDurableReferencesDeclaredWorkflow<App> &
+    ShorthandActivityModuleRequiresActivities<App> &
+    ShorthandActivitiesHaveValidPresentStrings<App> &
+    ShorthandActivitiesHavePaths<App> &
+    ShorthandActivitiesHaveExports<App>,
+): ExpandedWharfieAppShorthand<App>;
 
 export declare function invokeActivity<
   Result extends JsonValue = JsonValue,

--- a/src/app.js
+++ b/src/app.js
@@ -11,15 +11,205 @@ const SOURCE_REVISION_COMPILER_PATH =
  * @typedef {{kind: 'prepared-source', prepared: import('./cli/app/compile-application-revision.js').PreparedApplicationRevision} | {kind: 'embedded', manifest: any, embeddedRevision: import('./core/resources/builds/lib/revision-runtime-assets.js').EmbeddedRevisionRuntimePair}} RuntimeExecution
  */
 
+const APP_SHORTHAND_KEYS = new Set([
+  'id',
+  'main',
+  'durable',
+  'activityModule',
+  'targets',
+  'activities',
+  'workflows',
+  'schedules',
+]);
+const APP_SHORTHAND_ACTIVITY_KEYS = new Set([
+  'path',
+  'export',
+  'externalPackages',
+]);
+const CONVENTIONAL_EXPORT_NAME_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/u;
+
 /**
- * Preserve a manifest's literal TypeScript shape while checking it against the
- * public Wharfie application contract.
- * @template T
- * @param {T} definition - Application definition.
- * @returns {T} - The unchanged application definition.
+ * @param {unknown} value - Candidate plain data object.
+ * @returns {value is Record<string, any>} - Whether the value is plain data.
+ */
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * @param {Record<string, any>} value - Shorthand object to inspect.
+ * @param {Set<string>} allowedKeys - Exact supported property names.
+ * @param {string} valuePath - Human-readable authoring path.
+ * @returns {void} - Returns after exact plain-property validation.
+ */
+function assertShorthandKeys(value, allowedKeys, valuePath) {
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (
+      typeof key !== 'string' ||
+      !allowedKeys.has(key) ||
+      !descriptor?.enumerable ||
+      !('value' in descriptor)
+    ) {
+      const propertyPath =
+        typeof key === 'string' ? `${valuePath}.${key}` : valuePath;
+      throw new TypeError(
+        `${propertyPath} is not supported by defineApp shorthand.`,
+      );
+    }
+  }
+}
+
+/**
+ * Expand the deliberately small source shorthand into the strict v4 source
+ * manifest shape. Fully explicit manifests remain unchanged by identity.
+ * @param {any} definition - Full v4 source manifest or source shorthand.
+ * @returns {any} - The original full manifest or one expanded v4 source manifest.
  */
 export function defineApp(definition) {
-  return definition;
+  if (
+    !isPlainObject(definition) ||
+    ['schemaVersion', 'app', 'cli'].some((key) =>
+      Object.prototype.hasOwnProperty.call(definition, key),
+    )
+  ) {
+    return definition;
+  }
+
+  assertShorthandKeys(definition, APP_SHORTHAND_KEYS, 'defineApp');
+  if (
+    !Object.prototype.hasOwnProperty.call(definition, 'id') ||
+    !Object.prototype.hasOwnProperty.call(definition, 'main')
+  ) {
+    throw new TypeError('defineApp shorthand requires id and main.');
+  }
+  const hasActivityModule = Object.prototype.hasOwnProperty.call(
+    definition,
+    'activityModule',
+  );
+  const hasActivities = Object.prototype.hasOwnProperty.call(
+    definition,
+    'activities',
+  );
+  if (
+    hasActivityModule &&
+    (!hasActivities ||
+      (isPlainObject(definition.activities) &&
+        Object.keys(definition.activities).length === 0))
+  ) {
+    throw new TypeError(
+      'defineApp.activityModule requires at least one declared activity.',
+    );
+  }
+
+  const cli = {
+    entrypoint: {
+      kind: 'node',
+      path: definition.main,
+      export: 'main',
+    },
+    ...(Object.prototype.hasOwnProperty.call(definition, 'durable')
+      ? {
+          durable: {
+            workflow: definition.durable,
+            export: 'toDurableInput',
+          },
+        }
+      : {}),
+  };
+  /** @type {Record<string, any>} */
+  const expanded = {
+    schemaVersion: 4,
+    app: { id: definition.id },
+    cli,
+    ...(Object.prototype.hasOwnProperty.call(definition, 'targets')
+      ? { targets: definition.targets }
+      : {}),
+  };
+
+  if (Object.prototype.hasOwnProperty.call(definition, 'activities')) {
+    if (!isPlainObject(definition.activities)) {
+      throw new TypeError('defineApp.activities must be a plain object.');
+    }
+    expanded.activities = {};
+    for (const [activityId, activity] of Object.entries(
+      definition.activities,
+    )) {
+      if (!isPlainObject(activity)) {
+        throw new TypeError(
+          `defineApp.activities.${activityId} must be a plain object.`,
+        );
+      }
+      assertShorthandKeys(
+        activity,
+        APP_SHORTHAND_ACTIVITY_KEYS,
+        `defineApp.activities.${activityId}`,
+      );
+      const hasEntrypointPath = Object.prototype.hasOwnProperty.call(
+        activity,
+        'path',
+      );
+      if (
+        hasEntrypointPath &&
+        (typeof activity.path !== 'string' || activity.path.length === 0)
+      ) {
+        throw new TypeError(
+          `defineApp.activities.${activityId}.path must be a nonempty string when provided.`,
+        );
+      }
+      const entrypointPath = hasEntrypointPath
+        ? activity.path
+        : definition.activityModule;
+      if (typeof entrypointPath !== 'string' || entrypointPath.length === 0) {
+        throw new TypeError(
+          `defineApp.activities.${activityId} requires path or defineApp.activityModule.`,
+        );
+      }
+      const hasExportName = Object.prototype.hasOwnProperty.call(
+        activity,
+        'export',
+      );
+      if (
+        hasExportName &&
+        (typeof activity.export !== 'string' || activity.export.length === 0)
+      ) {
+        throw new TypeError(
+          `defineApp.activities.${activityId}.export must be a nonempty string when provided.`,
+        );
+      }
+      const exportName = hasExportName
+        ? activity.export
+        : CONVENTIONAL_EXPORT_NAME_PATTERN.test(activityId)
+          ? activityId
+          : undefined;
+      if (exportName === undefined) {
+        throw new TypeError(
+          `defineApp.activities.${activityId}.export is required when the activity ID is not a JavaScript export name.`,
+        );
+      }
+      expanded.activities[activityId] = {
+        entrypoint: {
+          kind: 'node',
+          path: entrypointPath,
+          export: exportName,
+        },
+        ...(Object.prototype.hasOwnProperty.call(activity, 'externalPackages')
+          ? { externalPackages: activity.externalPackages }
+          : {}),
+      };
+    }
+  }
+
+  for (const key of ['workflows', 'schedules']) {
+    if (Object.prototype.hasOwnProperty.call(definition, key)) {
+      expanded[key] = definition[key];
+    }
+  }
+  return expanded;
 }
 
 /**

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -18,6 +18,27 @@ by the current cursor is accepted; `early-signal`, `unexpected-signal`, and
 `late-signal` are durable, exactly replayable rejections rather than entries in
 an early-signal inbox. Reusing a delivery ID with changed contents conflicts.
 
+A packaged application with `cli.durable` exposes
+`<app> wharfie run --name <stable-name> -- <application-args>` as the foreground
+durable-workflow path. The stable name is the workflow's idempotency key; repeat
+the same command to reopen the same run. The command temporarily hosts the exact
+revision when no resident is active, follows a matching resident when one is
+already active, reports committed or retained steps and the persisted timer,
+and waits for verified terminal output. `SIGINT` or `SIGTERM` drains that
+foreground host without cancelling durable work and prints the exact resume
+command. Packaged `start` remains admission-only, and `worker` remains the
+explicit long-lived resident. Expert direct activity execution moved to
+`<app> wharfie activity run`; its source equivalent remains `wharfie ops run`.
+
+Packaged dispatch resolves one app-scoped storage layout before entrypoint
+selection. Ordinary application argv does not prepare Wharfie's native durable
+runtime; only the reserved operator and private-runtime paths do so lazily. An
+explicit foreground root uses the single `WHARFIE_DATA_ROOT` environment
+variable and cannot be combined with the retired per-store overrides. The
+systemd service pins the same variable to the active packaged layout. Without
+an explicit root, packaged storage uses the stable operating-system account
+default.
+
 With `--json`, source and packaged durable operations emit the same
 schema-versioned camelCase receipt for the same immutable decision:
 `wharfie.execution-ledger.activity-run`,
@@ -32,11 +53,22 @@ Failed/blocked/in-progress runs, rejected signals, and unknown-run refusals
 still emit their receipt before exiting nonzero; failures before a durable
 decision or explicit absence emit no JSON document.
 
-Source `wharfie app package` also has a stable machine boundary. Success emits
-exactly one schema-version 1 `wharfie.application.package` JSON receipt, pretty
-by default or compact with `--no-pretty`. It binds the application and revision
-to a canonical target-sorted artifact list containing content identity,
-target, digest, size, and immediate local executable/sidecar paths. It does not
+Source `wharfie app package` defaults to a human handoff. It reports resolution,
+preparation, build, download when needed, and publication phases on stderr, then
+prints the exact artifact target, path, size, and actionable `Next:` step on
+stdout. Matching POSIX hosts receive a copy-pasteable command; Windows gets a
+safe shell-neutral instruction because cmd.exe and PowerShell quote differently.
+
+When the manifest declares no targets and the user supplies no filter, packaging
+infers the exact compatible host target from the running Node version, platform,
+architecture, and glibc on Linux. `--target` still selects from an explicit
+manifest target matrix; it does not invent a cross-target matrix.
+
+`--json` emits exactly one schema-version 1 `wharfie.application.package` JSON
+receipt, pretty by default or compact with `--no-pretty`. It binds application
+and revision to a canonical target-sorted artifact list containing content
+identity, target, digest, size, and immediate local executable/sidecar paths. It
+does not
 serialize the complete internal revision or artifact records and does not
 grant deployment authority. The receipt is a projection of the package
 operation's prior final-byte and canonical sidecar/owning-revision record
@@ -44,11 +76,11 @@ association; it is not independent verification, and its paths are local
 discovery conveniences. Packaged and selected-artifact consumer boundaries
 separately verify the executable's embedded revision/runtime metadata.
 
-During packaging, ordinary manifest/build writes and Wharfie-owned build-tool
-output are routed to stderr so stdout remains the receipt. Authored code is
-trusted rather than sandboxed; deliberately writing directly to file
-descriptor 1 or leaving stdout-producing work unawaited violates this command
-contract.
+During packaging, all modes reserve stdout for the selected final human summary
+or JSON document. Ordinary manifest/build writes and Wharfie-owned build-tool
+output are routed to stderr. Authored code is trusted rather than sandboxed;
+deliberately bypassing those streams or leaving stdout-producing work unawaited
+violates the command contract.
 
 Discover retained durable runs with
 `wharfie ops list [--dir <app-dir>] [--limit <1..100>] [--cursor <opaque>] [--json]`

--- a/src/cli/app/local-app.js
+++ b/src/cli/app/local-app.js
@@ -38,6 +38,7 @@ import {
   getManifestActivityNames,
   invokeManifestActivity,
 } from '../../core/runtime/app-runs.js';
+import { getHostBuildTarget } from '../../core/runtime/host-build-target.js';
 
 import { prepareApplicationRevision } from './compile-application-revision.js';
 import { createArtifactProvenance } from './artifact-provenance.js';
@@ -97,6 +98,7 @@ import {
  * @property {string} [outputDir] - outputDir.
  * @property {string[]} [targetFilters] - targetFilters.
  * @property {LocalAppBuildConfig} [build] - Ephemeral build request; never embedded in the app manifest.
+ * @property {(progress: {phase: 'resolve'|'prepare'|'build'|'download'|'publish', message: string}) => unknown} [onProgress] - Optional human-facing package phase observer.
  */
 
 /**
@@ -141,6 +143,43 @@ function isObjectRecord(value) {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
+/**
+ * @param {PackageLocalAppOptions} options - Package request.
+ * @param {'resolve'|'prepare'|'build'|'download'|'publish'} phase - Stable package phase.
+ * @param {string} message - Human-facing progress message.
+ * @returns {void}
+ */
+function reportPackageProgress(options, phase, message) {
+  if (typeof options.onProgress !== 'function') return;
+  options.onProgress(
+    Object.freeze({
+      phase,
+      message,
+    }),
+  );
+}
+
+/**
+ * @param {PackageLocalAppOptions} options - Package request.
+ * @returns {((progress: {version: string, downloadedBytes: number, totalBytes: number|null}) => void) | undefined} - Focused Node download observer.
+ */
+function createNodeDownloadProgressObserver(options) {
+  if (typeof options.onProgress !== 'function') return undefined;
+  return (progress) => {
+    const downloadedMiB = (progress.downloadedBytes / (1024 * 1024)).toFixed(1);
+    const size =
+      progress.totalBytes === null
+        ? `${downloadedMiB} MiB`
+        : `${downloadedMiB}/${(progress.totalBytes / (1024 * 1024)).toFixed(
+            1,
+          )} MiB`;
+    reportPackageProgress(
+      options,
+      'download',
+      `Downloading Node ${progress.version} (${size})`,
+    );
+  };
+}
 /**
  * @param {string | undefined} input - input.
  * @param {string} label - label.
@@ -378,7 +417,7 @@ function assertPortableManifestContract(manifest) {
 }
 
 /**
- * @param {{ appDir: string, manifest: any, dependencyLock: { path: string, input: import('../../core/runtime/application-revision.js').LockedInputDescriptor } }} loaded - loaded.
+ * @param {{ appDir: string, manifest: any, dependencyLock: { path: string, input: import('../../core/runtime/application-revision.js').LockedInputDescriptor }, nodeDownloadProgress?: (progress: {version: string, downloadedBytes: number, totalBytes: number|null}) => unknown }} loaded - loaded.
  * @returns {ActorSystem} - Result.
  */
 function toPackageableActorSystem(loaded) {
@@ -421,6 +460,7 @@ function toPackageableActorSystem(loaded) {
     functions,
     properties,
     dependencyLock: loaded.dependencyLock,
+    nodeDownloadProgress: loaded.nodeDownloadProgress,
   });
 }
 
@@ -1297,26 +1337,35 @@ export async function runLocalApp(options) {
  * @returns {Promise<PackageLocalAppResult>} - Result.
  */
 export async function packageLocalApp(options) {
+  reportPackageProgress(
+    options,
+    'resolve',
+    'Resolving application and build target',
+  );
   const loaded = await loadApp({ dir: options.dir });
   const manifest = cloneJson(loaded.manifest);
 
-  const availableTargets = Array.isArray(manifest.targets)
+  const targetFilters = Array.isArray(options.targetFilters)
+    ? options.targetFilters
+    : [];
+  let availableTargets = Array.isArray(manifest.targets)
     ? manifest.targets
     : [];
   if (availableTargets.length === 0) {
-    throw new Error(
-      'App has no build targets. Define targets in wharfie.app.js before packaging.',
-    );
+    if (targetFilters.length > 0) {
+      throw new Error(
+        'App has no declared build targets, so --target cannot select one. Remove --target to package this host, or define targets in wharfie.app.js.',
+      );
+    }
+    availableTargets = [getHostBuildTarget()];
   }
 
-  const selectedTargets = selectTargets(
-    availableTargets,
-    options.targetFilters,
-  ).map((target) =>
-    assertSupportedSeaTarget({
-      ...target,
-      nodeVersion: assertSeaNodeVersionCompatible(target.nodeVersion),
-    }),
+  const selectedTargets = selectTargets(availableTargets, targetFilters).map(
+    (target) =>
+      assertSupportedSeaTarget({
+        ...target,
+        nodeVersion: assertSeaNodeVersionCompatible(target.nodeVersion),
+      }),
   );
   if (selectedTargets.length === 0) {
     throw new Error('No targets matched the requested package filter.');
@@ -1332,6 +1381,11 @@ export async function packageLocalApp(options) {
 
   assertPortableManifestContract(manifest);
 
+  reportPackageProgress(
+    options,
+    'prepare',
+    `Preparing ${manifest.app.id} for ${selectedTargets.map((target) => getTargetAliases(target)[4]).join(', ')}`,
+  );
   const outputDir = path.resolve(
     options.outputDir || path.join(options.dir, 'dist'),
   );
@@ -1357,6 +1411,7 @@ export async function packageLocalApp(options) {
       appDir: preparedRevision.appDir,
       manifest: preparedRevision.manifest,
       dependencyLock: preparedRevision.dependencyLock,
+      nodeDownloadProgress: createNodeDownloadProgressObserver(options),
     });
     applyPackagingSigningConfig(actorSystem, options.build);
     applyTargetSelection(actorSystem, selectedTargets);
@@ -1389,6 +1444,7 @@ export async function packageLocalApp(options) {
       await actorSystem.initializeEnvironment();
     }
     await preparedRevision.verifyRuntime();
+    reportPackageProgress(options, 'build', 'Building executable artifacts');
     manifestAssets = await attachEmbeddedManifestAssets(
       builds,
       revision,
@@ -1403,6 +1459,7 @@ export async function packageLocalApp(options) {
       );
     }
 
+    reportPackageProgress(options, 'publish', 'Publishing verified artifacts');
     artifactTransaction = await stagePackageArtifacts({
       builds,
       appName: manifest.app.id,
@@ -1451,6 +1508,7 @@ export async function packageLocalApp(options) {
   );
   const cleanupResults = await Promise.allSettled([
     preparedRevision.cleanup(),
+    removePackageOwnedSeaBuildOutputs(builds),
     ...manifestAssets.map((asset) => asset.cleanup()),
     ...functionAssetPaths.map((assetPath) =>
       fsp.rm(assetPath, { force: true }),

--- a/src/cli/cmds/app_cmds/package.js
+++ b/src/cli/cmds/app_cmds/package.js
@@ -2,6 +2,8 @@ import { Command } from 'commander';
 
 import { packageLocalApp, stringifyJson } from '../../app/local-app.js';
 import { createApplicationPackageReceipt } from '../../app/package-command-receipt.js';
+import { getHostBuildTarget } from '../../../core/runtime/host-build-target.js';
+import { renderTerminalSafeJson } from '../../../core/runtime/operator/terminal-safe-json.js';
 import { displayFailure } from '../../output/basic.js';
 
 /**
@@ -11,6 +13,152 @@ import { displayFailure } from '../../output/basic.js';
  */
 function collectTargetFilter(value, previous) {
   return [...previous, value];
+}
+
+const UNSAFE_TERMINAL_CHARACTER = /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}\p{Cs}]/u;
+
+/**
+ * @param {string} value - Candidate terminal text.
+ * @returns {boolean} - Whether the text contains active terminal controls.
+ */
+function containsUnsafeTerminalCharacters(value) {
+  return UNSAFE_TERMINAL_CHARACTER.test(value);
+}
+
+/**
+ * @param {string} value - Exact artifact path.
+ * @returns {string} - Terminal-inert human path presentation.
+ */
+function formatHumanArtifactPath(value) {
+  return containsUnsafeTerminalCharacters(value)
+    ? 'path (JSON): ' + renderTerminalSafeJson(value)
+    : value;
+}
+
+/**
+ * @param {number} bytes - Exact byte length.
+ * @returns {string} - Compact binary-size label.
+ */
+function formatArtifactSize(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+
+  const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(1)} ${units[unitIndex]}`;
+}
+
+/**
+ * @param {{nodeVersion: string, platform: string, architecture: string, libc?: string}} target - Exact artifact target.
+ * @returns {string} - Readable exact target identity.
+ */
+function formatTarget(target) {
+  return `node${target.nodeVersion}-${target.platform}-${target.architecture}${
+    target.libc ? `-${target.libc}` : ''
+  }`;
+}
+
+/**
+ * @param {string} value - One shell argument.
+ * @returns {string} - Copy-pasteable POSIX shell argument.
+ */
+function quoteShellArgument(value) {
+  if (containsUnsafeTerminalCharacters(value)) {
+    throw new TypeError(
+      'A terminal-unsafe path cannot be rendered as a shell command.',
+    );
+  }
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/u.test(value)) return value;
+  return "'" + value.replaceAll("'", "'\\''") + "'";
+}
+
+/**
+ * @param {{nodeVersion: string, platform: string, architecture: string, libc?: string}} target - Exact artifact target.
+ * @param {{nodeVersion: string, platform: string, architecture: string, libc?: string}|null} hostTarget - Exact host target when it can be established.
+ * @returns {boolean} - Whether the standalone artifact can run on this host.
+ */
+function isHostTarget(target, hostTarget) {
+  if (!hostTarget) return false;
+  return (
+    target.platform === hostTarget.platform &&
+    target.architecture === hostTarget.architecture &&
+    (target.platform !== 'linux' || target.libc === hostTarget.libc)
+  );
+}
+
+/**
+ * @param {() => {nodeVersion: string, platform: string, architecture: string, libc?: string}} readHostTarget - Exact host target reader.
+ * @returns {{nodeVersion: string, platform: string, architecture: string, libc?: string}|null} - Exact host target, or null when this host is unsupported.
+ */
+function resolveHumanHostTarget(readHostTarget) {
+  try {
+    return readHostTarget();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Render the default, human-first package result. The versioned JSON receipt
+ * remains available unchanged behind --json.
+ * @param {ReturnType<typeof createApplicationPackageReceipt>} receipt - Validated package receipt.
+ * @param {boolean} durable - Whether the packaged app declares a durable CLI handoff.
+ * @param {{nodeVersion: string, platform: string, architecture: string, libc?: string}|null} hostTarget - Exact host target when it can be established.
+ * @returns {string} - Human package summary including a copy-pasteable next command when safe.
+ */
+function formatPackageSummary(receipt, durable, hostTarget) {
+  const artifactLabel =
+    receipt.artifactCount === 1
+      ? ''
+      : ' (' + receipt.artifactCount + ' artifacts)';
+  const lines = ['✓ Packaged ' + receipt.appId + artifactLabel];
+
+  for (const artifact of receipt.artifacts) {
+    lines.push(
+      '  ' +
+        formatTarget(artifact.target) +
+        ' · ' +
+        formatArtifactSize(artifact.size),
+      '  ' + formatHumanArtifactPath(artifact.path),
+    );
+  }
+
+  const nextArtifact =
+    receipt.artifacts.find((artifact) =>
+      isHostTarget(artifact.target, hostTarget),
+    ) || receipt.artifacts[0];
+  const nextIsOnThisHost = isHostTarget(nextArtifact.target, hostTarget);
+  const nextLabel = nextIsOnThisHost
+    ? 'Next'
+    : 'Next on ' + formatTarget(nextArtifact.target);
+  if (!nextIsOnThisHost) {
+    lines.push(
+      nextLabel +
+        ': copy the artifact shown above to a matching host and invoke it there.',
+    );
+  } else if (nextArtifact.target.platform === 'win32') {
+    lines.push(
+      'Next: invoke the artifact shown above from your Windows shell; an exact command is omitted because cmd.exe and PowerShell use different quoting syntax.',
+    );
+  } else if (containsUnsafeTerminalCharacters(nextArtifact.path)) {
+    lines.push(
+      nextLabel +
+        ': shell command omitted because the artifact path contains terminal-unsafe control or format characters; rerun with --json for the exact machine-readable path.',
+    );
+  } else {
+    const durableArguments = durable ? ' wharfie run --name first-run --' : '';
+    lines.push(
+      nextLabel +
+        ': ' +
+        quoteShellArgument(nextArtifact.path) +
+        durableArguments,
+    );
+  }
+  return lines.join('\n') + '\n';
 }
 
 /**
@@ -60,7 +208,9 @@ async function withPackageStdoutReserved(operation) {
  * independently testable without constructing a native SEA.
  * @param {{
  *   packageApplication?: typeof packageLocalApp,
- *   writeOutput?: (value: string) => unknown
+ *   writeOutput?: (value: string) => unknown,
+ *   writeDiagnostic?: (value: string) => unknown,
+ *   readHostTarget?: typeof getHostBuildTarget
  * }} [dependencies] - Optional command adapters.
  * @returns {Command} - Fresh package command.
  */
@@ -71,6 +221,12 @@ export function createPackageCommand(dependencies = {}) {
     ((value) => {
       process.stdout.write(value);
     });
+  const writeDiagnostic =
+    dependencies.writeDiagnostic ||
+    ((value) => {
+      process.stderr.write(value);
+    });
+  const readHostTarget = dependencies.readHostTarget || getHostBuildTarget;
 
   return new Command('package')
     .description('Package a Wharfie app into executable artifacts')
@@ -85,21 +241,43 @@ export function createPackageCommand(dependencies = {}) {
       collectTargetFilter,
       [],
     )
-    .option('--json', 'Output JSON (default)')
-    .option('--no-pretty', 'Disable pretty JSON output')
+    .option('--json', 'Output the versioned JSON package receipt')
+    .option(
+      '--no-pretty',
+      'Disable pretty JSON output (implies --json for compatibility)',
+    )
     .action(async (dir, options) => {
       const resolvedDir = dir || process.cwd();
+      const jsonOutput = options.json || options.pretty === false;
 
       try {
-        const receipt = await withPackageStdoutReserved(async () => {
+        const packageOutput = await withPackageStdoutReserved(async () => {
+          const onProgress = jsonOutput
+            ? undefined
+            : (/** @type {{message?: unknown}} */ progress) => {
+                if (typeof progress?.message !== 'string') return;
+                writeDiagnostic(`  ${progress.message}\n`);
+              };
           const result = await packageApplication({
             dir: resolvedDir,
             outputDir: options.outputDir,
             targetFilters: Array.isArray(options.target) ? options.target : [],
+            ...(onProgress ? { onProgress } : {}),
           });
-          return createApplicationPackageReceipt(result);
+          return {
+            receipt: createApplicationPackageReceipt(result),
+            durable: !!result?.revision?.contract?.cli?.durable,
+          };
         });
-        writeOutput(`${stringifyJson(receipt, options)}\n`);
+        writeOutput(
+          jsonOutput
+            ? `${stringifyJson(packageOutput.receipt, options)}\n`
+            : formatPackageSummary(
+                packageOutput.receipt,
+                packageOutput.durable,
+                resolveHumanHostTarget(readHostTarget),
+              ),
+        );
       } catch (err) {
         displayFailure(err);
         process.exitCode = 1;

--- a/src/core/resources/builds/actor-system-cli/control_cmds/foreground-run.js
+++ b/src/core/resources/builds/actor-system-cli/control_cmds/foreground-run.js
@@ -1,0 +1,42 @@
+import { createDurableWorkflowRunCommand } from '../../../../runtime/operator/durable-workflow-run-command.js';
+import { loadEmbeddedDurableExecution } from '../lib/durable-execution.js';
+
+/**
+ * Build the packaged app's foreground durable workflow command. The command is
+ * bound to immutable embedded identity and has no source-directory override.
+ * @param {{loadExecution?: () => Promise<import('../../../../runtime/operator/durable-workflow-run-command.js').DurableWorkflowRunExecutionHandle>, loadCliModule?: import('../../../../runtime/operator/durable-workflow-run-command.js').DurableWorkflowRunCliModuleLoader, output?: Partial<import('../../../../runtime/operator/durable-workflow-run-command.js').DurableWorkflowRunOutput>, startWorkflow?: import('../../../../runtime/operator/durable-workflow-run-command.js').DurableWorkflowRunStarter, runWorker?: import('../../../../runtime/operator/durable-workflow-run-command.js').DurableWorkflowForegroundWorker, readRunOutput?: (request: {appId: string, runId: string}) => unknown | Promise<unknown>, inspectRun?: (request: {runId: string, expectedAppId: string}) => Record<string, any> | null | Promise<Record<string, any> | null>, processRef?: import('../../../../runtime/operator/durable-workflow-run-command.js').DurableWorkflowRunProcess, pollIntervalMs?: number, ownerRetryIntervalMs?: number, now?: () => number}} [options] - Test or packaged host seams.
+ * @returns {import('commander').Command} - Fresh packaged foreground command.
+ */
+export function createPackagedDurableWorkflowRunCommand(options = {}) {
+  return createDurableWorkflowRunCommand({
+    loadExecution: options.loadExecution || loadEmbeddedDurableExecution,
+    ...(options.loadCliModule === undefined
+      ? {}
+      : { loadCliModule: options.loadCliModule }),
+    ...(options.output === undefined ? {} : { output: options.output }),
+    ...(options.startWorkflow === undefined
+      ? {}
+      : { startWorkflow: options.startWorkflow }),
+    ...(options.runWorker === undefined
+      ? {}
+      : { runWorker: options.runWorker }),
+    ...(options.readRunOutput === undefined
+      ? {}
+      : { readRunOutput: options.readRunOutput }),
+    ...(options.inspectRun === undefined
+      ? {}
+      : { inspectRun: options.inspectRun }),
+    ...(options.processRef === undefined
+      ? {}
+      : { processRef: options.processRef }),
+    ...(options.pollIntervalMs === undefined
+      ? {}
+      : { pollIntervalMs: options.pollIntervalMs }),
+    ...(options.ownerRetryIntervalMs === undefined
+      ? {}
+      : { ownerRetryIntervalMs: options.ownerRetryIntervalMs }),
+    ...(options.now === undefined ? {} : { now: options.now }),
+  });
+}
+
+export default createPackagedDurableWorkflowRunCommand;

--- a/src/core/resources/builds/actor-system-cli/index.js
+++ b/src/core/resources/builds/actor-system-cli/index.js
@@ -5,6 +5,7 @@ import { createExecutionLedgerHistoryCommand } from '../../../runtime/operator/e
 import { createExecutionLedgerOperatorCommands } from '../../../runtime/operator/execution-ledger-operator.js';
 import { createExecutionLedgerRunOutputCommand } from '../../../runtime/operator/execution-ledger-run-output-command.js';
 import { readEmbeddedRevisionRuntimePair } from '../lib/revision-runtime-assets.js';
+import { createPackagedDurableWorkflowRunCommand } from './control_cmds/foreground-run.js';
 import { createPackagedManifestCommand } from './control_cmds/manifest.js';
 import { createPackagedMetadataCommand } from './control_cmds/metadata.js';
 import { createPackagedDeploymentCommand } from './control_cmds/deployment.js';
@@ -18,7 +19,7 @@ import { createPackagedDurableWorkerCommand } from './control_cmds/worker.js';
 /**
  * Build a fresh packaged operator program. Identity is read lazily so help and
  * immutable metadata commands do not open application control state.
- * @param {{resolveExpectedIdentity?: () => Promise<{appId: string, revisionId?: string}>, readRunOutput?: (request: {appId: string, runId: string}) => unknown | Promise<unknown>, runOutputOutput?: Partial<import('../../../runtime/operator/execution-ledger-run-output-command.js').ExecutionLedgerRunOutputPort>, loadDurableRunExecution?: () => Promise<import('../../../runtime/operator/durable-run-command.js').DurableRunExecutionHandle>, durableRunOutput?: Partial<import('../../../runtime/operator/durable-run-command.js').DurableRunCommandOutput>, runActivity?: typeof import('../../../runtime/durable-activity-host.js').runLocalDurableManifestActivity, loadDurableWorkflowStartExecution?: () => Promise<import('../../../runtime/operator/durable-workflow-start-command.js').DurableWorkflowStartExecutionHandle>, loadDeveloperCliModule?: () => Promise<Record<string, any> | null> | Record<string, any> | null, durableWorkflowStartOutput?: Partial<import('../../../runtime/operator/durable-workflow-start-command.js').DurableWorkflowStartCommandOutput>, startWorkflow?: import('../../../runtime/operator/durable-workflow-start-command.js').DurableWorkflowStarter, durableWorkflowSignalOutput?: Partial<import('../../../runtime/operator/durable-workflow-signal-command.js').DurableWorkflowSignalCommandOutput>, deliverWorkflowSignal?: typeof import('../../../runtime/operator/durable-workflow-signal-command.js').deliverLocalDurableWorkflowSignal, loadDurableSubmitExecution?: () => Promise<import('../../../runtime/operator/durable-submit-command.js').DurableSubmitExecutionHandle>, durableSubmitOutput?: Partial<import('../../../runtime/operator/durable-submit-command.js').DurableSubmitCommandOutput>, submitActivity?: import('../../../runtime/operator/durable-submit-command.js').ResidentActivitySubmit, loadDurableWorkerExecution?: () => Promise<import('../../../runtime/operator/durable-worker-command.js').DurableWorkerExecutionHandle>, durableWorkerOutput?: Partial<import('../../../runtime/operator/durable-worker-command.js').DurableWorkerCommandOutput>, runResidentWorker?: import('../../../runtime/operator/durable-worker-command.js').ResidentActivityWorkerRunner, loadSystemdUserServiceOperator?: () => any | Promise<any>, systemdUserServiceOutput?: Partial<import('../../../runtime/operator/systemd-user-service-command.js').SystemdUserServiceCommandOutput>, processRef?: import('../../../runtime/operator/durable-run-command.js').DurableRunProcess}} [options] - Test or packaged identity and durable command providers.
+ * @param {{resolveExpectedIdentity?: () => Promise<{appId: string, revisionId?: string}>, readRunOutput?: (request: {appId: string, runId: string}) => unknown | Promise<unknown>, runOutputOutput?: Partial<import('../../../runtime/operator/execution-ledger-run-output-command.js').ExecutionLedgerRunOutputPort>, loadDurableRunExecution?: () => Promise<import('../../../runtime/operator/durable-run-command.js').DurableRunExecutionHandle>, durableRunOutput?: Partial<import('../../../runtime/operator/durable-run-command.js').DurableRunCommandOutput>, runActivity?: typeof import('../../../runtime/durable-activity-host.js').runLocalDurableManifestActivity, loadDurableWorkflowRunExecution?: () => Promise<import('../../../runtime/operator/durable-workflow-run-command.js').DurableWorkflowRunExecutionHandle>, durableWorkflowRunOutput?: Partial<import('../../../runtime/operator/durable-workflow-run-command.js').DurableWorkflowRunOutput>, runForegroundWorker?: import('../../../runtime/operator/durable-workflow-run-command.js').DurableWorkflowForegroundWorker, readForegroundRunOutput?: (request: {appId: string, runId: string}) => unknown | Promise<unknown>, inspectForegroundRun?: (request: {runId: string, expectedAppId: string}) => Record<string, any> | null | Promise<Record<string, any> | null>, loadDurableWorkflowStartExecution?: () => Promise<import('../../../runtime/operator/durable-workflow-start-command.js').DurableWorkflowStartExecutionHandle>, loadDeveloperCliModule?: () => Promise<Record<string, any> | null> | Record<string, any> | null, durableWorkflowStartOutput?: Partial<import('../../../runtime/operator/durable-workflow-start-command.js').DurableWorkflowStartCommandOutput>, startWorkflow?: import('../../../runtime/operator/durable-workflow-start-command.js').DurableWorkflowStarter, durableWorkflowSignalOutput?: Partial<import('../../../runtime/operator/durable-workflow-signal-command.js').DurableWorkflowSignalCommandOutput>, deliverWorkflowSignal?: typeof import('../../../runtime/operator/durable-workflow-signal-command.js').deliverLocalDurableWorkflowSignal, loadDurableSubmitExecution?: () => Promise<import('../../../runtime/operator/durable-submit-command.js').DurableSubmitExecutionHandle>, durableSubmitOutput?: Partial<import('../../../runtime/operator/durable-submit-command.js').DurableSubmitCommandOutput>, submitActivity?: import('../../../runtime/operator/durable-submit-command.js').ResidentActivitySubmit, loadDurableWorkerExecution?: () => Promise<import('../../../runtime/operator/durable-worker-command.js').DurableWorkerExecutionHandle>, durableWorkerOutput?: Partial<import('../../../runtime/operator/durable-worker-command.js').DurableWorkerCommandOutput>, runResidentWorker?: import('../../../runtime/operator/durable-worker-command.js').ResidentActivityWorkerRunner, loadSystemdUserServiceOperator?: () => any | Promise<any>, systemdUserServiceOutput?: Partial<import('../../../runtime/operator/systemd-user-service-command.js').SystemdUserServiceCommandOutput>, processRef?: import('../../../runtime/operator/durable-run-command.js').DurableRunProcess}} [options] - Test or packaged identity and durable command providers.
  * @returns {Command} - Packaged operator program.
  */
 export function createProgram(options = {}) {
@@ -64,7 +65,7 @@ export function createProgram(options = {}) {
       ? {}
       : { output: options.runOutputOutput }),
   });
-  const runCommand = createPackagedDurableRunCommand({
+  const activityRunCommand = createPackagedDurableRunCommand({
     ...(options.loadDurableRunExecution === undefined
       ? {}
       : { loadExecution: options.loadDurableRunExecution }),
@@ -74,6 +75,40 @@ export function createProgram(options = {}) {
     ...(options.runActivity === undefined
       ? {}
       : { runActivity: options.runActivity }),
+    ...(options.processRef === undefined
+      ? {}
+      : { processRef: options.processRef }),
+  });
+  const activityCommand = new Command('activity')
+    .description('Expert durable activity commands')
+    .addCommand(activityRunCommand);
+  const runCommand = createPackagedDurableWorkflowRunCommand({
+    ...(options.loadDurableWorkflowRunExecution === undefined &&
+    options.loadDurableWorkflowStartExecution === undefined
+      ? {}
+      : {
+          loadExecution:
+            options.loadDurableWorkflowRunExecution ||
+            options.loadDurableWorkflowStartExecution,
+        }),
+    ...(options.loadDeveloperCliModule === undefined
+      ? {}
+      : { loadCliModule: options.loadDeveloperCliModule }),
+    ...(options.durableWorkflowRunOutput === undefined
+      ? {}
+      : { output: options.durableWorkflowRunOutput }),
+    ...(options.startWorkflow === undefined
+      ? {}
+      : { startWorkflow: options.startWorkflow }),
+    ...(options.runForegroundWorker === undefined
+      ? {}
+      : { runWorker: options.runForegroundWorker }),
+    ...(options.readForegroundRunOutput === undefined
+      ? {}
+      : { readRunOutput: options.readForegroundRunOutput }),
+    ...(options.inspectForegroundRun === undefined
+      ? {}
+      : { inspectRun: options.inspectForegroundRun }),
     ...(options.processRef === undefined
       ? {}
       : { processRef: options.processRef }),
@@ -158,6 +193,7 @@ export function createProgram(options = {}) {
     .addCommand(createPackagedManifestCommand())
     .addCommand(createPackagedMetadataCommand())
     .addCommand(runCommand)
+    .addCommand(activityCommand)
     .addCommand(startCommand)
     .addCommand(submitCommand)
     .addCommand(workerCommand)

--- a/src/core/resources/builds/actor-system.js
+++ b/src/core/resources/builds/actor-system.js
@@ -173,6 +173,7 @@ function resolveNodeBinaryVersion(nodeBinary, configuredVersion) {
  * @property {import('node:events').EventEmitter} [emitter] - Compatibility alias for the scoped telemetry emitter.
  * @property {import('../runtime-config.js').WharfieRuntimeConfig} [runtime] - Structured runtime configuration.
  * @property {{ path: string, input: import('../../runtime/application-revision.js').LockedInputDescriptor }} [dependencyLock] - Transient sealed dependency lock for target packaging.
+ * @property {(progress: {version: string, downloadedBytes: number, totalBytes: number|null}) => unknown} [nodeDownloadProgress] - Optional throttled Node archive progress observer.
  */
 
 class ActorSystem extends BuildResourceGroup {
@@ -192,6 +193,7 @@ class ActorSystem extends BuildResourceGroup {
     emitter,
     runtime,
     dependencyLock,
+    nodeDownloadProgress,
   }) {
     if (
       properties &&
@@ -232,6 +234,10 @@ class ActorSystem extends BuildResourceGroup {
     });
     this.functions = functions;
     this._dependencyLock = dependencyLock;
+    this._nodeDownloadProgress =
+      typeof nodeDownloadProgress === 'function'
+        ? nodeDownloadProgress
+        : undefined;
     setMacOSSigningCredentials(this, macosSigningCredentials);
     // normally _defineGroupResources is used but this is a workaround to make sure this.functions is set before defining things
     this.addResources(
@@ -284,6 +290,7 @@ class ActorSystem extends BuildResourceGroup {
     const node_binary = new NodeBinary({
       name: `${this.name}-node-binary-${nodeVersion}-${platform}-${architecture}`,
       parent,
+      onDownloadProgress: this._nodeDownloadProgress,
       properties: {
         version: nodeVersion,
         platform,
@@ -405,11 +412,11 @@ class ActorSystem extends BuildResourceGroup {
               ${developerCliLoader}
               (async () => {
                 sourceMapSupport.install();
-                await preparePackagedCoreRuntimeDependencies();
                 const packagedAppStorage = await resolvePackagedAppStorage();
                 await withLocalAppStorageLayout(packagedAppStorage, async () => {
                   await runPackagedApp({
                     loadDeveloperCliModule,
+                    prepareRuntime: preparePackagedCoreRuntimeDependencies,
                     ${
                       developerCliExportName
                         ? `cliExportName: ${JSON.stringify(developerCliExportName)},`

--- a/src/core/resources/builds/node-binary.js
+++ b/src/core/resources/builds/node-binary.js
@@ -12,6 +12,7 @@ import {
   stat,
 } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
+import { Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import JSZip from 'jszip';
 import { extract as _extract } from 'tar';
@@ -99,13 +100,21 @@ function createAtomicTemporaryPath(finalPath) {
  * @property {import('../reconcilable.js').default.Status} [status] - status.
  * @property {import('../reconcilable.js').default[]} [dependsOn] - dependsOn.
  * @property {NodeBinaryProperties & import('../../actors/typedefs.js').SharedProperties} properties - properties.
+ * @property {(progress: {version: string, downloadedBytes: number, totalBytes: number|null}) => unknown} [onDownloadProgress] - Optional throttled archive download observer.
  */
 
 class NodeBinary extends BaseResource {
   /**
    * @param {NodeBinaryOptions} options - options.
    */
-  constructor({ name, parent, status, dependsOn, properties }) {
+  constructor({
+    name,
+    parent,
+    status,
+    dependsOn,
+    properties,
+    onDownloadProgress,
+  }) {
     const propertiesWithDefaults = Object.assign(
       {
         version: '23',
@@ -119,6 +128,8 @@ class NodeBinary extends BaseResource {
       dependsOn,
       properties: propertiesWithDefaults,
     });
+    this.onDownloadProgress =
+      typeof onDownloadProgress === 'function' ? onDownloadProgress : undefined;
   }
 
   /**
@@ -360,10 +371,59 @@ class NodeBinary extends BaseResource {
       throw new Error(`Unexpected content-type '${contentType}' from ${url}`);
     }
 
+    const reportProgress = this.onDownloadProgress;
+    if (!reportProgress) {
+      await pipeline(
+        response,
+        createWriteStream(destinationPath, { flags: 'wx', mode: 0o600 }),
+      );
+      return;
+    }
+
+    const contentLengthHeader = response.headers['content-length'];
+    const parsedContentLength = Number(
+      Array.isArray(contentLengthHeader)
+        ? contentLengthHeader[0]
+        : contentLengthHeader,
+    );
+    const totalBytes =
+      Number.isSafeInteger(parsedContentLength) && parsedContentLength >= 0
+        ? parsedContentLength
+        : null;
+    const version = await this.getExactVersion();
+    let downloadedBytes = 0;
+    let lastReportedBytes = 0;
+    const reportInterval = totalBytes
+      ? Math.max(1024 * 1024, Math.ceil(totalBytes / 10))
+      : 5 * 1024 * 1024;
+    reportProgress({ version, downloadedBytes, totalBytes });
+    const progressStream = new Transform({
+      transform(chunk, _encoding, callback) {
+        downloadedBytes += chunk.length;
+        const complete = totalBytes !== null && downloadedBytes >= totalBytes;
+        try {
+          if (
+            complete ||
+            downloadedBytes - lastReportedBytes >= reportInterval
+          ) {
+            lastReportedBytes = downloadedBytes;
+            reportProgress({ version, downloadedBytes, totalBytes });
+          }
+          callback(null, chunk);
+        } catch (error) {
+          callback(/** @type {Error} */ (error));
+        }
+      },
+    });
+
     await pipeline(
       response,
+      progressStream,
       createWriteStream(destinationPath, { flags: 'wx', mode: 0o600 }),
     );
+    if (downloadedBytes !== lastReportedBytes) {
+      reportProgress({ version, downloadedBytes, totalBytes });
+    }
   }
 
   /**

--- a/src/core/resources/builds/packaged-app-entry.js
+++ b/src/core/resources/builds/packaged-app-entry.js
@@ -191,14 +191,19 @@ export async function runRuntimeBootstrap(runtimeModules, options = {}) {
 }
 
 /**
- * @param {{ developerCliModule?: Record<string, any> | null, cliModule?: Record<string, any> | null, loadDeveloperCliModule?: function(): Promise<Record<string, any> | null> | Record<string, any> | null, cliExportName?: string, runtimeModules?: Record<string, any>, argv?: string[] }} [options] - options.
+ * @param {{ developerCliModule?: Record<string, any> | null, cliModule?: Record<string, any> | null, loadDeveloperCliModule?: function(): Promise<Record<string, any> | null> | Record<string, any> | null, cliExportName?: string, runtimeModules?: Record<string, any>, prepareRuntime?: function(): Promise<void> | void, argv?: string[] }} [options] - options.
  * @returns {Promise<void>} - Result.
  */
 export async function runPackagedApp(options = {}) {
   const argv = Array.isArray(options.argv) ? options.argv : process.argv;
   const runtimeModules = options.runtimeModules || {};
+  const prepareRuntime =
+    typeof options.prepareRuntime === 'function'
+      ? options.prepareRuntime
+      : async () => {};
 
   if (getDispatchMode() === 'runtime') {
+    await prepareRuntime();
     await runRuntimeBootstrap(runtimeModules, { argv });
     return;
   }
@@ -210,6 +215,7 @@ export async function runPackagedApp(options = {}) {
       );
     }
 
+    await prepareRuntime();
     await runDeveloperCli(
       { default: runtimeModules.operatorCli },
       {

--- a/src/core/runtime/app-runs.js
+++ b/src/core/runtime/app-runs.js
@@ -6,7 +6,7 @@ import path from 'node:path';
 import WharfieFunction from '../resources/builds/function.js';
 import FunctionResource from '../resources/builds/function-resource.js';
 import { validateAppManifest } from './app-manifest.js';
-import { getBuildTargetId, validateBuildTarget } from './build-target.js';
+import { getBuildTargetId } from './build-target.js';
 import {
   compareCanonicalStrings,
   sortCanonicalJsonValue,
@@ -23,6 +23,7 @@ import {
 } from './activity-protocol.js';
 import { cloneJsonObject, cloneJsonValue } from './json-value.js';
 import { assertLogicalId } from './logical-id.js';
+import { getHostBuildTarget } from './host-build-target.js';
 import { validateEmbeddedRevisionRuntimePair } from '../resources/builds/lib/revision-runtime-assets.js';
 
 /**
@@ -86,43 +87,7 @@ function hasSameCanonicalJson(left, right) {
  * @returns {{ nodeVersion: string, platform: 'darwin'|'linux'|'win32', architecture: 'arm64'|'x64', libc?: 'glibc' }} - Exact canonical host target.
  */
 export function getHostSourceBuildTarget(overrides = {}) {
-  const nodeVersion = overrides.nodeVersion ?? process.versions.node;
-  const platform = overrides.platform ?? process.platform;
-  const architecture = overrides.architecture ?? process.arch;
-  let glibcVersionRuntime;
-
-  if (platform === 'linux') {
-    if (
-      Object.prototype.hasOwnProperty.call(overrides, 'glibcVersionRuntime')
-    ) {
-      glibcVersionRuntime = overrides.glibcVersionRuntime;
-    } else {
-      try {
-        const report = /** @type {any} */ (process.report?.getReport?.());
-        glibcVersionRuntime = report?.header?.glibcVersionRuntime;
-      } catch {
-        glibcVersionRuntime = undefined;
-      }
-    }
-    if (
-      typeof glibcVersionRuntime !== 'string' ||
-      !glibcVersionRuntime.trim()
-    ) {
-      throw new Error(
-        'Source external execution on Linux requires a positively identified glibc host; musl and unknown libc hosts are not supported.',
-      );
-    }
-  }
-
-  return validateBuildTarget(
-    {
-      nodeVersion,
-      platform,
-      architecture,
-      ...(platform === 'linux' ? { libc: 'glibc' } : {}),
-    },
-    'source host target',
-  );
+  return getHostBuildTarget(overrides);
 }
 
 /**

--- a/src/core/runtime/host-build-target.js
+++ b/src/core/runtime/host-build-target.js
@@ -1,0 +1,51 @@
+import { validateBuildTarget } from './build-target.js';
+
+/**
+ * Derive the exact build target of the current Node host. Linux must
+ * positively identify glibc: treating musl or an unknown libc as glibc can
+ * select native dependencies and Node distribution bytes that cannot execute.
+ * Optional observations keep the platform boundary deterministic in tests.
+ * @param {{nodeVersion?: string, platform?: string, architecture?: string, glibcVersionRuntime?: string | undefined}} [overrides] - Host observations.
+ * @returns {{nodeVersion: string, platform: 'darwin'|'linux'|'win32', architecture: 'arm64'|'x64', libc?: 'glibc'}} - Exact canonical host target.
+ */
+export function getHostBuildTarget(overrides = {}) {
+  const nodeVersion = overrides.nodeVersion ?? process.versions.node;
+  const platform = overrides.platform ?? process.platform;
+  const architecture = overrides.architecture ?? process.arch;
+  let glibcVersionRuntime;
+
+  if (platform === 'linux') {
+    if (
+      Object.prototype.hasOwnProperty.call(overrides, 'glibcVersionRuntime')
+    ) {
+      glibcVersionRuntime = overrides.glibcVersionRuntime;
+    } else {
+      try {
+        const report = /** @type {any} */ (process.report?.getReport?.());
+        glibcVersionRuntime = report?.header?.glibcVersionRuntime;
+      } catch {
+        glibcVersionRuntime = undefined;
+      }
+    }
+    if (
+      typeof glibcVersionRuntime !== 'string' ||
+      !glibcVersionRuntime.trim()
+    ) {
+      throw new Error(
+        'Host build target on Linux requires a positively identified glibc runtime; musl and unknown libc hosts are not supported.',
+      );
+    }
+  }
+
+  return validateBuildTarget(
+    {
+      nodeVersion,
+      platform,
+      architecture,
+      ...(platform === 'linux' ? { libc: 'glibc' } : {}),
+    },
+    'host build target',
+  );
+}
+
+export default getHostBuildTarget;

--- a/src/core/runtime/local-app-storage.js
+++ b/src/core/runtime/local-app-storage.js
@@ -7,6 +7,7 @@ import process from 'node:process';
 import { assertLogicalId } from './logical-id.js';
 
 export const LOCAL_APP_EXECUTION_LEDGER_TABLE = 'wharfie-execution-ledger-v10';
+export const LOCAL_APP_DATA_ROOT_ENVIRONMENT_VARIABLE = 'WHARFIE_DATA_ROOT';
 
 /**
  * @param {unknown} value - Candidate absolute path.

--- a/src/core/runtime/operator/durable-workflow-run-command.js
+++ b/src/core/runtime/operator/durable-workflow-run-command.js
@@ -1,0 +1,639 @@
+import { Command, InvalidArgumentError } from 'commander';
+
+import { resolveManifestActivityExecutionIdentity } from '../app-runs.js';
+import { resolveManifestWorkflowStartBinding } from '../durable-workflow-host.js';
+import { LOCAL_APP_DATA_ROOT_ENVIRONMENT_VARIABLE } from '../local-app-storage.js';
+import { assertLedgerOpaqueId } from '../../lib/ledger/record-key.js';
+import { createWorkflowRunId } from '../../lib/ledger/workflow-execution-contract.js';
+import { LocalServiceSessionActiveError } from '../local-service-session.js';
+import {
+  runLocalResidentActivityService,
+  startLocalDurableManifestWorkflow,
+} from '../services/resident-activity-worker.js';
+import {
+  projectExecutionLedgerRunOutput,
+  readExecutionLedgerRunOutput,
+} from './execution-ledger-run-output-command.js';
+import {
+  projectVerifiedDurableCliInput,
+  withOperatorStdoutReserved,
+} from './durable-workflow-start-command.js';
+import { createDurableWorkflowStartReceipt } from './durable-operation-receipt.js';
+import { inspectExecutionLedgerRun } from './execution-ledger-operator.js';
+import { renderTerminalSafeJson } from './terminal-safe-json.js';
+
+const DEFAULT_POLL_INTERVAL_MS = 200;
+const DEFAULT_OWNER_RETRY_INTERVAL_MS = 500;
+const TERMINAL_STATUSES = new Set(['COMPLETED', 'FAILED', 'CANCELLED']);
+
+/**
+ * @typedef DurableWorkflowRunOutput
+ * @property {(message: string) => void} info - Write run identity text.
+ * @property {(message: string) => void} progress - Write one durable progress line.
+ * @property {(message: string) => void} success - Write terminal success text.
+ * @property {(value: any, rendered: string) => void} result - Write the terminal application result.
+ * @property {(message: string) => void} paused - Write an interruption and resume instruction.
+ * @property {(error: unknown) => void} failure - Write one safe failure.
+ */
+
+/**
+ * @typedef DurableWorkflowRunExecutionHandle
+ * @property {import('../durable-activity-host.js').ManifestActivityExecution} execution - Embedded immutable execution descriptor.
+ * @property {() => void | Promise<void>} [cleanup] - Release execution resources.
+ */
+
+/**
+ * @typedef DurableWorkflowRunProcess
+ * @property {(event: string | symbol, listener: (...args: any[]) => void) => unknown} once - Register one signal listener.
+ * @property {(event: string | symbol, listener: (...args: any[]) => void) => unknown} removeListener - Remove one signal listener.
+ * @property {string} [execPath] - Packaged executable path.
+ * @property {string[]} [argv] - Original packaged invocation.
+ * @property {number | undefined} exitCode - Process exit status.
+ */
+
+/**
+ * @typedef {(execution: import('../durable-activity-host.js').ManifestActivityExecution) => Promise<Record<string, any> | null> | Record<string, any> | null} DurableWorkflowRunCliModuleLoader
+ */
+
+/**
+ * @typedef {(options: {execution: import('../durable-activity-host.js').ManifestActivityExecution, workflowId: string, idempotencyKey: string, input: any, callerMetadata: Record<string, any>, actor?: {kind: string, id: string}}) => Promise<Readonly<Record<string, any>>> | Readonly<Record<string, any>>} DurableWorkflowRunStarter
+ */
+
+/**
+ * @typedef {(options: {execution: import('../durable-activity-host.js').ManifestActivityExecution, signal: AbortSignal}) => Promise<unknown> | unknown} DurableWorkflowForegroundWorker
+ */
+
+/**
+ * @param {Partial<DurableWorkflowRunOutput> | undefined} provided - Optional output hooks.
+ * @returns {DurableWorkflowRunOutput} - Complete human output adapter.
+ */
+function resolveOutput(provided) {
+  return {
+    info: provided?.info || ((message) => console.log(message)),
+    progress: provided?.progress || ((message) => console.log(message)),
+    success:
+      provided?.success ||
+      ((message) => {
+        console.log(message);
+      }),
+    result:
+      provided?.result ||
+      ((_value, rendered) => {
+        console.log(rendered);
+      }),
+    paused:
+      provided?.paused ||
+      ((message) => {
+        console.log(message);
+      }),
+    failure:
+      provided?.failure ||
+      ((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(message);
+      }),
+  };
+}
+
+/**
+ * Parse the stable, human-selected durable identity. Restricting the display
+ * name to shell-safe characters makes the printed resume command exact and
+ * terminal-inert without changing the ledger's broader idempotency contract.
+ * @param {string} value - Commander option value.
+ * @returns {string} - Valid stable name.
+ */
+function parseRunName(value) {
+  try {
+    assertLedgerOpaqueId(value, '--name');
+  } catch (error) {
+    throw new InvalidArgumentError(
+      error instanceof Error ? error.message : '--name is invalid.',
+    );
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(value)) {
+    throw new InvalidArgumentError(
+      '--name must start with an alphanumeric character and contain only letters, numbers, dot, underscore, or dash.',
+    );
+  }
+  return value;
+}
+
+/**
+ * Render one exact shell argument without allowing terminal controls. Common
+ * path/name arguments remain readable; every other byte uses ANSI-C quoting.
+ * @param {string} value - Argument value.
+ * @returns {string} - Shell-safe argument.
+ */
+function quoteShellArgument(value) {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/u.test(value)) return value;
+  const bytes = Buffer.from(value, 'utf8');
+  let encoded = '';
+  for (const byte of bytes) {
+    if (byte >= 0x20 && byte <= 0x7e && byte !== 0x27 && byte !== 0x5c) {
+      encoded += String.fromCharCode(byte);
+    } else {
+      encoded += `\\x${byte.toString(16).padStart(2, '0')}`;
+    }
+  }
+  return `$'${encoded}'`;
+}
+
+/**
+ * @param {DurableWorkflowRunProcess} processRef - Packaged process seam.
+ * @param {string} name - Stable run name.
+ * @param {string[]} appArgs - Original application arguments.
+ * @param {Record<string, string | undefined>} environment - Foreground storage environment.
+ * @returns {string} - Exact repeatable foreground command.
+ */
+function formatResumeCommand(processRef, name, appArgs, environment) {
+  const executable =
+    typeof processRef.execPath === 'string' && processRef.execPath.length > 0
+      ? processRef.execPath
+      : '<app>';
+  const dataRoot = environment[LOCAL_APP_DATA_ROOT_ENVIRONMENT_VARIABLE];
+  const prefix =
+    typeof dataRoot === 'string' && dataRoot.length > 0
+      ? [
+          `${LOCAL_APP_DATA_ROOT_ENVIRONMENT_VARIABLE}=${quoteShellArgument(
+            dataRoot,
+          )}`,
+        ]
+      : [];
+  return [
+    ...prefix,
+    ...[executable, 'wharfie', 'run', '--name', name, '--', ...appArgs].map(
+      quoteShellArgument,
+    ),
+  ].join(' ');
+}
+
+/**
+ * Remove JSON's structural string quotes while preserving terminal-safety.
+ * Printable quotes and backslashes are restored as authored; JSON escapes for
+ * control/format characters remain visible rather than activating a terminal.
+ * @param {string} value - Application string result.
+ * @returns {string} - Terminal-inert text without JSON wrapper quotes.
+ */
+function renderTerminalSafeString(value) {
+  const rendered = renderTerminalSafeJson(value).slice(1, -1);
+  return rendered.replaceAll('\\"', '"').replaceAll('\\\\', '\\');
+}
+
+/**
+ * Turn SIGINT/SIGTERM into a foreground drain request. It deliberately does
+ * not call the durable cancellation API. A second signal receives the normal
+ * process behavior because the one-shot listeners are removed immediately.
+ * @param {Pick<DurableWorkflowRunProcess, 'once' | 'removeListener'>} processRef - Signal source.
+ * @returns {{signal: AbortSignal, stop: () => void, close: () => void, requestedSignal: () => 'SIGINT'|'SIGTERM'|undefined}} - Drain handle.
+ */
+export function createForegroundWorkflowDrain(processRef = process) {
+  const controller = new AbortController();
+  /** @type {'SIGINT'|'SIGTERM'|undefined} */
+  let received;
+
+  /** Remove only the foreground drain listeners installed here. */
+  function close() {
+    processRef.removeListener('SIGINT', onSigint);
+    processRef.removeListener('SIGTERM', onSigterm);
+  }
+
+  /** @param {'SIGINT'|'SIGTERM'} signalName - Received process signal. */
+  function request(signalName) {
+    received = signalName;
+    close();
+    controller.abort(
+      Object.assign(
+        new Error(`Foreground durable run drain requested with ${signalName}.`),
+        {
+          name: 'ForegroundDurableRunDrainRequested',
+          code: 'foreground-durable-run-drain-requested',
+          details: { signal: signalName },
+        },
+      ),
+    );
+  }
+
+  /** Request a foreground drain after SIGINT. */
+  function onSigint() {
+    request('SIGINT');
+  }
+
+  /** Request a foreground drain after SIGTERM. */
+  function onSigterm() {
+    request('SIGTERM');
+  }
+
+  processRef.once('SIGINT', onSigint);
+  processRef.once('SIGTERM', onSigterm);
+  return {
+    signal: controller.signal,
+    stop: () => {
+      if (!controller.signal.aborted) controller.abort();
+    },
+    close,
+    requestedSignal: () => received,
+  };
+}
+
+/**
+ * Wait without keeping a foreground run alive after its drain request.
+ * @param {number} milliseconds - Maximum delay.
+ * @param {AbortSignal} signal - Foreground lifetime.
+ * @returns {Promise<void>} - Resolves on timeout or abort.
+ */
+function waitForPoll(milliseconds, signal) {
+  if (signal.aborted || milliseconds === 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(done, milliseconds);
+    /** Settle the wait and remove its abort listener. */
+    function done() {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', done);
+      resolve();
+    }
+    signal.addEventListener('abort', done, { once: true });
+  });
+}
+
+/**
+ * @param {unknown} error - Resident startup failure.
+ * @returns {boolean} - Whether another healthy local resident owns the app.
+ */
+function isResidentAlreadyActive(error) {
+  return (
+    error instanceof LocalServiceSessionActiveError ||
+    (error instanceof Error && error.name === 'LocalServiceSessionActiveError')
+  );
+}
+
+/**
+ * Keep trying to host execution while no resident owns the app. An ownership
+ * conflict is the follower path, not a failure; if that resident exits before
+ * the selected run completes, one waiting foreground process can take over.
+ * @param {{execution: import('../durable-activity-host.js').ManifestActivityExecution, signal: AbortSignal, runWorker: DurableWorkflowForegroundWorker, retryIntervalMs: number}} options - Driver inputs.
+ * @returns {Promise<void>} - Resolves only after foreground stop.
+ */
+async function driveOrFollow(options) {
+  while (!options.signal.aborted) {
+    try {
+      await options.runWorker({
+        execution: options.execution,
+        signal: options.signal,
+      });
+      if (!options.signal.aborted) {
+        throw new Error(
+          'The foreground resident worker stopped before the durable run completed.',
+        );
+      }
+    } catch (error) {
+      if (!isResidentAlreadyActive(error)) throw error;
+      if (options.signal.aborted) return;
+      await waitForPoll(options.retryIntervalMs, options.signal);
+      continue;
+    }
+    return;
+  }
+}
+
+/**
+ * Present one durable timer exactly once while it is the active workflow
+ * cursor. On reopen, the persisted timer identity and deadline are described
+ * as the same timer rather than a newly-created delay.
+ * @param {{view: Record<string, any> | null, retainedTimers: Set<string>, seenTimers: Set<string>, now: () => number, output: DurableWorkflowRunOutput}} options - Timer presentation state.
+ * @returns {boolean} - Whether an active timer was presented or already seen.
+ */
+function presentActiveTimer(options) {
+  const cursor = options.view?.workflowCursor;
+  if (!cursor || cursor.disposition !== 'TIMER_WAITING') return false;
+  const timer = options.view?.timers?.find(
+    (/** @type {Record<string, any>} */ candidate) =>
+      candidate.timerId === cursor.timerId,
+  );
+  if (!timer || timer.status !== 'WAITING') return false;
+  if (options.seenTimers.has(timer.timerId)) return true;
+  options.seenTimers.add(timer.timerId);
+  const remainingMilliseconds = Math.max(0, timer.dueAt - options.now());
+  const remainingSeconds = (remainingMilliseconds / 1_000).toFixed(1);
+  options.output.progress(
+    `◷ ${timer.stepId} — ${
+      options.retainedTimers.has(timer.timerId)
+        ? 'same durable timer'
+        : 'durable timer'
+    }, ${remainingSeconds}s remaining`,
+  );
+  return true;
+}
+
+/**
+ * Read, validate, and scope one run snapshot.
+ * @param {{appId: string, runId: string, readRunOutput: (request: {appId: string, runId: string}) => unknown | Promise<unknown>}} options - Read request.
+ * @returns {Promise<ReturnType<typeof projectExecutionLedgerRunOutput>>} - Verified projection.
+ */
+async function readProjectedRunOutput(options) {
+  const request = { appId: options.appId, runId: options.runId };
+  const raw = await options.readRunOutput(request);
+  if (raw === null) {
+    throw new Error(
+      `Durable run ${options.runId} was accepted but its retained output snapshot is unavailable.`,
+    );
+  }
+  return projectExecutionLedgerRunOutput(raw, request);
+}
+
+/**
+ * Create the packaged-app magnetic foreground durable command. This is a
+ * composite convenience path: `start` remains admission-only and `worker`
+ * remains a long-lived app resident.
+ * @param {{loadExecution: (options: Record<string, any>) => Promise<DurableWorkflowRunExecutionHandle> | DurableWorkflowRunExecutionHandle, loadCliModule?: DurableWorkflowRunCliModuleLoader, output?: Partial<DurableWorkflowRunOutput>, startWorkflow?: DurableWorkflowRunStarter, runWorker?: DurableWorkflowForegroundWorker, readRunOutput?: (request: {appId: string, runId: string}) => unknown | Promise<unknown>, inspectRun?: (request: {runId: string, expectedAppId: string}) => Record<string, any> | null | Promise<Record<string, any> | null>, processRef?: DurableWorkflowRunProcess, environment?: Record<string, string | undefined>, pollIntervalMs?: number, ownerRetryIntervalMs?: number, now?: () => number}} options - Packaged host seams.
+ * @returns {Command} - Fresh foreground workflow command.
+ */
+export function createDurableWorkflowRunCommand(options) {
+  if (!options || typeof options.loadExecution !== 'function') {
+    throw new TypeError(
+      'createDurableWorkflowRunCommand requires loadExecution.',
+    );
+  }
+  const output = resolveOutput(options.output);
+  const startWorkflow =
+    options.startWorkflow || startLocalDurableManifestWorkflow;
+  const runWorker = options.runWorker || runLocalResidentActivityService;
+  const readRunOutput = options.readRunOutput || readExecutionLedgerRunOutput;
+  const inspectRun = options.inspectRun || inspectExecutionLedgerRun;
+  const now = options.now || (() => Date.now());
+  if (typeof now !== 'function') {
+    throw new TypeError('now must be a function when provided.');
+  }
+  const processRef = /** @type {DurableWorkflowRunProcess} */ (
+    options.processRef || process
+  );
+  const environment = options.environment || process.env;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const ownerRetryIntervalMs =
+    options.ownerRetryIntervalMs ?? DEFAULT_OWNER_RETRY_INTERVAL_MS;
+  for (const [label, value] of /** @type {Array<[string, number]>} */ ([
+    ['pollIntervalMs', pollIntervalMs],
+    ['ownerRetryIntervalMs', ownerRetryIntervalMs],
+  ])) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new TypeError(`${label} must be a nonnegative safe integer.`);
+    }
+  }
+
+  const command = new Command('run').description(
+    'Run or resume the app’s named durable workflow in the foreground',
+  );
+  command.argument(
+    '[appArgs...]',
+    'Application arguments for the declared durable CLI adapter',
+  );
+  command
+    .requiredOption(
+      '--name <stableName>',
+      'Stable name; repeat the same command to resume this run',
+      parseRunName,
+    )
+    .action(async (appArgs, commandOptions) => {
+      /** @type {DurableWorkflowRunExecutionHandle | undefined} */
+      let loaded;
+      /** @type {unknown} */
+      let actionError;
+      /** @type {ReturnType<typeof projectExecutionLedgerRunOutput> | undefined} */
+      let terminalOutput;
+      /** @type {'SIGINT'|'SIGTERM'|undefined} */
+      let interruptedBy;
+      let runId = '';
+      let appId = '';
+      let resumeCommand = '';
+      try {
+        loaded = await options.loadExecution(commandOptions);
+        if (
+          !loaded ||
+          typeof loaded !== 'object' ||
+          Array.isArray(loaded) ||
+          !loaded.execution
+        ) {
+          throw new TypeError(
+            'Foreground workflow execution loader must return { execution, cleanup? }.',
+          );
+        }
+        if (
+          loaded.cleanup !== undefined &&
+          typeof loaded.cleanup !== 'function'
+        ) {
+          throw new TypeError(
+            'Foreground workflow execution cleanup must be a function when provided.',
+          );
+        }
+        if (typeof options.loadCliModule !== 'function') {
+          throw new TypeError(
+            'This packaged application cannot load its durable CLI adapter.',
+          );
+        }
+
+        const execution = loaded.execution;
+        const loadCliModule = options.loadCliModule;
+        const identity = resolveManifestActivityExecutionIdentity(execution);
+        appId = identity.appId;
+        const durableCli = identity.manifest.cli?.durable;
+        if (!durableCli) {
+          throw new TypeError(
+            'This application does not declare cli.durable; use `wharfie start --workflow ...` for expert workflow admission.',
+          );
+        }
+        const workflow = resolveManifestWorkflowStartBinding({
+          identity,
+          workflowId: durableCli.workflow,
+        });
+        runId = createWorkflowRunId({
+          appId,
+          idempotencyKey: commandOptions.name,
+        });
+        resumeCommand = formatResumeCommand(
+          processRef,
+          commandOptions.name,
+          appArgs,
+          environment,
+        );
+
+        const input = await withOperatorStdoutReserved(
+          async () =>
+            await projectVerifiedDurableCliInput({
+              execution,
+              moduleLike: await loadCliModule(execution),
+              exportName: durableCli.export,
+              appArgs,
+            }),
+        );
+        const started = await startWorkflow({
+          execution,
+          workflowId: durableCli.workflow,
+          idempotencyKey: commandOptions.name,
+          input,
+          callerMetadata: {},
+          actor: {
+            kind: 'packaged-foreground',
+            id: identity.revisionId,
+          },
+        });
+        const startReceipt = createDurableWorkflowStartReceipt(started, {
+          runId,
+          appId,
+          revisionId: identity.revisionId,
+          workflowId: durableCli.workflow,
+          idempotencyKey: commandOptions.name,
+          planId: workflow.planId,
+          definition: workflow.planPayload.definition,
+        });
+        const reused = startReceipt.reused;
+        const retainedTimers = new Set();
+        const admittedTimerId = started?.outcome?.workflowCursor?.timerId;
+        if (reused && typeof admittedTimerId === 'string') {
+          retainedTimers.add(admittedTimerId);
+        }
+
+        output.info(
+          reused
+            ? `↻ Resuming ${commandOptions.name} (${runId}).`
+            : `• ${appId} · new durable run ${commandOptions.name} (${runId}).`,
+        );
+
+        const drain = createForegroundWorkflowDrain(processRef);
+        /** @type {unknown} */
+        let driverError;
+        let driver = Promise.resolve();
+        const seenOutputs = new Set();
+        const seenTimers = new Set();
+        let waitingPrinted = false;
+        try {
+          const baseline = await readProjectedRunOutput({
+            appId,
+            runId,
+            readRunOutput,
+          });
+          for (const step of baseline.outputs) {
+            seenOutputs.add(step.stepId);
+            output.progress(
+              reused
+                ? `✓ ${step.stepId} — retained; not run again`
+                : `✓ ${step.stepId} — committed`,
+            );
+          }
+          if (TERMINAL_STATUSES.has(baseline.snapshot.status)) {
+            terminalOutput = baseline;
+          }
+          if (!terminalOutput && !drain.signal.aborted) {
+            driver = driveOrFollow({
+              execution,
+              signal: drain.signal,
+              runWorker,
+              retryIntervalMs: ownerRetryIntervalMs,
+            }).catch((error) => {
+              driverError = error;
+            });
+            const timerPresented = presentActiveTimer({
+              view: await inspectRun({ runId, expectedAppId: appId }),
+              retainedTimers,
+              seenTimers,
+              now,
+              output,
+            });
+            if (!waitingPrinted && !timerPresented) {
+              output.progress('◷ Waiting for durable workflow progress…');
+              waitingPrinted = true;
+            }
+          }
+          while (!drain.signal.aborted && !terminalOutput) {
+            if (driverError !== undefined) throw driverError;
+            const current = await readProjectedRunOutput({
+              appId,
+              runId,
+              readRunOutput,
+            });
+            for (const step of current.outputs) {
+              if (seenOutputs.has(step.stepId)) continue;
+              seenOutputs.add(step.stepId);
+              output.progress(`✓ ${step.stepId} — committed`);
+            }
+            if (TERMINAL_STATUSES.has(current.snapshot.status)) {
+              terminalOutput = current;
+              break;
+            }
+            const timerPresented = presentActiveTimer({
+              view: await inspectRun({ runId, expectedAppId: appId }),
+              retainedTimers,
+              seenTimers,
+              now,
+              output,
+            });
+            if (!waitingPrinted && !timerPresented) {
+              output.progress('◷ Waiting for durable workflow progress…');
+              waitingPrinted = true;
+            }
+            await waitForPoll(pollIntervalMs, drain.signal);
+          }
+          interruptedBy = drain.requestedSignal();
+        } finally {
+          drain.stop();
+          await driver;
+          drain.close();
+        }
+        if (driverError !== undefined) throw driverError;
+      } catch (error) {
+        actionError = error;
+      } finally {
+        if (typeof loaded?.cleanup === 'function') {
+          try {
+            await loaded.cleanup();
+          } catch (cleanupError) {
+            actionError = actionError
+              ? new AggregateError(
+                  [actionError, cleanupError],
+                  'Foreground durable workflow and cleanup both failed.',
+                )
+              : cleanupError;
+          }
+        }
+      }
+
+      if (actionError) {
+        output.failure(actionError);
+        processRef.exitCode = 1;
+        return;
+      }
+      if (interruptedBy) {
+        output.paused(
+          `Paused ${commandOptions.name} without cancelling durable work. Resume with: ${resumeCommand}`,
+        );
+        processRef.exitCode = interruptedBy === 'SIGINT' ? 130 : 143;
+        return;
+      }
+      if (!terminalOutput?.terminal) {
+        output.failure(
+          new Error(`Durable run ${runId} stopped without a terminal result.`),
+        );
+        processRef.exitCode = 1;
+        return;
+      }
+      if (terminalOutput.terminal.type !== 'completed') {
+        output.failure(
+          new Error(
+            `Durable run ${runId} finished ${terminalOutput.snapshot.status}. Retained failure evidence is available through inspect and output.`,
+          ),
+        );
+        processRef.exitCode = 1;
+        return;
+      }
+      output.success(`✓ Completed ${commandOptions.name}; result retained.`);
+      const result = terminalOutput.terminal.result;
+      output.result(
+        result,
+        typeof result === 'string'
+          ? renderTerminalSafeString(result)
+          : renderTerminalSafeJson(result),
+      );
+    });
+
+  return command;
+}
+
+export default createDurableWorkflowRunCommand;

--- a/src/core/runtime/operator/durable-workflow-start-command.js
+++ b/src/core/runtime/operator/durable-workflow-start-command.js
@@ -115,7 +115,7 @@ function resolveIdempotencyKey(value) {
  * @param {() => Promise<T>} operation - Admission and start operation.
  * @returns {Promise<T>} - Operation result.
  */
-async function withOperatorStdoutReserved(operation) {
+export async function withOperatorStdoutReserved(operation) {
   const originalStdoutWrite = process.stdout.write;
   const stderrWrite = process.stderr.write;
   /** @type {StreamWrite} */
@@ -181,7 +181,7 @@ async function verifyPreparedSourceRuntime(execution) {
  * @param {{execution: import('../durable-activity-host.js').ManifestActivityExecution, moduleLike: Record<string, any> | null, exportName: string, appArgs: string[]}} options - Adapter invocation.
  * @returns {Promise<any>} - Bounded JSON workflow input.
  */
-async function projectVerifiedDurableCliInput(options) {
+export async function projectVerifiedDurableCliInput(options) {
   let projected;
   let projectionFailed = false;
   /** @type {unknown} */

--- a/src/core/runtime/operator/execution-ledger-run-output-command.js
+++ b/src/core/runtime/operator/execution-ledger-run-output-command.js
@@ -280,7 +280,7 @@ function projectTerminal(value, status, runKind) {
  * @param {{appId: string, runId: string}} request - Exact requested scope.
  * @returns {{scope: Record<string, any>, snapshot: Record<string, any>, outputs: Record<string, any>[], terminal: Record<string, any> | null}} - Strict public data.
  */
-function projectRunOutput(raw, request) {
+export function projectExecutionLedgerRunOutput(raw, request) {
   const value = cloneBoundedJsonObject(
     raw,
     EXECUTION_LEDGER_RUN_OUTPUT_MAX_BYTES,
@@ -479,7 +479,7 @@ export function createExecutionLedgerRunOutputCommand(options) {
         });
         const raw = await readOutput(request);
         if (raw === null) throw new TypeError(INVALID_OUTPUT);
-        const projected = projectRunOutput(raw, request);
+        const projected = projectExecutionLedgerRunOutput(raw, request);
         const publicOutput = deepFreezeJson(
           cloneBoundedJsonObject(
             {

--- a/src/core/runtime/packaged-app-storage.js
+++ b/src/core/runtime/packaged-app-storage.js
@@ -1,8 +1,41 @@
 import { readEmbeddedRevisionRuntimePair } from '../resources/builds/lib/revision-runtime-assets.js';
 import {
+  LOCAL_APP_DATA_ROOT_ENVIRONMENT_VARIABLE,
   createLocalAppStorageLayout,
   resolveStableLocalAppDataRoot,
 } from './local-app-storage.js';
+
+export const LEGACY_PACKAGED_STORAGE_ENVIRONMENT_VARIABLES = Object.freeze([
+  'WHARFIE_APPLICATION_STATE_ADAPTER',
+  'WHARFIE_APPLICATION_STATE_PATH',
+  'WHARFIE_CONTROL_ADAPTER',
+  'WHARFIE_CONTROL_PATH',
+  'WHARFIE_DB_ADAPTER',
+  'WHARFIE_DB_PATH',
+  'WHARFIE_EXECUTION_LEDGER_TABLE',
+  'WHARFIE_EXECUTION_PAYLOAD_PATH',
+  'WHARFIE_EXECUTION_PAYLOAD_STORE_ID',
+  'WHARFIE_LEDGER_SERVICE_SESSION_PATH',
+  'WHARFIE_STATE_ADAPTER',
+  'WHARFIE_STATE_DB_PATH',
+]);
+
+/**
+ * A single packaged data root and legacy per-store routing are mutually
+ * exclusive. Reject the combination before installing storage context so no
+ * packaged command can silently address a split layout.
+ * @param {Record<string, string | undefined>} environment - Packaged process environment.
+ * @returns {void} - Returns when storage routing is unambiguous.
+ */
+function assertNoLegacyPackagedStorageOverrides(environment) {
+  const conflictingNames = LEGACY_PACKAGED_STORAGE_ENVIRONMENT_VARIABLES.filter(
+    (name) => environment[name] !== undefined,
+  );
+  if (conflictingNames.length === 0) return;
+  throw new TypeError(
+    `Legacy Wharfie storage overrides are not supported for packaged apps: ${conflictingNames.join(', ')}. Unset those variables; packaged storage is derived only from ${LOCAL_APP_DATA_ROOT_ENVIRONMENT_VARIABLE} or the stable account default.`,
+  );
+}
 
 /**
  * Resolve app-scoped storage before any packaged developer, operator, or
@@ -10,10 +43,23 @@ import {
  * immutable layout as async bootstrap context, avoiding process-environment
  * mutation. The default data root is derived from the operating-system account
  * rather than invocation-specific XDG or shell-home variables.
- * @param {{dataRoot?: string, platform?: string, getHomeDirectory?: () => string, readEmbeddedRevisionRuntimePair?: () => Promise<any>}} [options] - Testable account and embedded identity reader.
+ * @param {{dataRoot?: string, environment?: Record<string, string | undefined>, platform?: string, getHomeDirectory?: () => string, readEmbeddedRevisionRuntimePair?: () => Promise<any>}} [options] - Testable account, foreground environment, and embedded identity reader.
  * @returns {Promise<Readonly<Record<string, string>>>} - Canonical packaged layout.
  */
 export async function resolvePackagedAppStorage(options = {}) {
+  const environment = options.environment ?? process.env;
+  const environmentDataRoot =
+    environment[LOCAL_APP_DATA_ROOT_ENVIRONMENT_VARIABLE];
+  assertNoLegacyPackagedStorageOverrides(environment);
+  if (
+    options.dataRoot !== undefined &&
+    environmentDataRoot !== undefined &&
+    options.dataRoot !== environmentDataRoot
+  ) {
+    throw new TypeError(
+      `resolvePackagedAppStorage dataRoot must agree with active ${LOCAL_APP_DATA_ROOT_ENVIRONMENT_VARIABLE} packaged storage authority.`,
+    );
+  }
   const readPair =
     options.readEmbeddedRevisionRuntimePair || readEmbeddedRevisionRuntimePair;
   const pair = await readPair();
@@ -21,6 +67,7 @@ export async function resolvePackagedAppStorage(options = {}) {
     appId: pair.runtime.appId,
     dataRoot:
       options.dataRoot ??
+      environmentDataRoot ??
       resolveStableLocalAppDataRoot({
         platform: options.platform,
         homeDirectory: options.getHomeDirectory?.(),

--- a/src/core/runtime/services/systemd-user-service-manager.js
+++ b/src/core/runtime/services/systemd-user-service-manager.js
@@ -25,11 +25,12 @@ import { createLocalExecutionPayloadStore } from '../../lib/payload-store/local.
 import { APPLICATION_STATE_EFFECT_EVIDENCE_VERIFIERS } from '../effects/application-state.js';
 import { assertApplicationRevisionId } from '../application-revision.js';
 import { assertArtifactId } from '../artifact-record.js';
-import { resolveStableLocalAppDataRoot } from '../local-app-storage.js';
+import { LOCAL_APP_DATA_ROOT_ENVIRONMENT_VARIABLE } from '../local-app-storage.js';
 import {
   getRunningExecutablePath,
   inspectArtifactBytes,
 } from '../packaged-artifact.js';
+import { LEGACY_PACKAGED_STORAGE_ENVIRONMENT_VARIABLES } from '../packaged-app-storage.js';
 import { probeLocalServiceSession } from '../local-service-session.js';
 import {
   LinuxAbstractOperationLockBusyError,
@@ -2399,8 +2400,8 @@ function defaultPayloadStoreId(payloadPath) {
 }
 
 /**
- * Refuse service management unless the packaged bootstrap and every explicit
- * durable-storage override agree with the fixed resident layout. This turns a
+ * Refuse service management unless the resident layout and every explicit
+ * override agree with the active packaged storage authority. This turns a
  * silent split-ledger failure into an actionable boundary error.
  * @param {Readonly<Record<string, string>>} layout - Derived systemd service layout.
  * @param {Readonly<Record<string, string>> | undefined} packagedStorage - Active packaged bootstrap authority.
@@ -2426,30 +2427,23 @@ function assertSharedPackagedStorage(layout, packagedStorage, environment) {
     );
   }
 
-  const expected = Object.freeze({
-    WHARFIE_CONTROL_ADAPTER: 'lmdb',
-    WHARFIE_CONTROL_PATH: layout.controlPath,
-    WHARFIE_EXECUTION_PAYLOAD_PATH: layout.payloadPath,
-    WHARFIE_EXECUTION_PAYLOAD_STORE_ID: defaultPayloadStoreId(
-      layout.payloadPath,
-    ),
-    WHARFIE_EXECUTION_LEDGER_TABLE: layout.executionLedgerTable,
-    WHARFIE_LEDGER_SERVICE_SESSION_PATH: layout.sessionPath,
-    WHARFIE_APPLICATION_STATE_ADAPTER: 'lmdb',
-    WHARFIE_APPLICATION_STATE_PATH: layout.applicationStatePath,
-  });
-  for (const [name, expectedValue] of Object.entries(expected)) {
-    const raw = environment[name];
-    if (typeof raw !== 'string' || !raw.trim()) continue;
-    const actual = raw.trim();
-    const matches = name.endsWith('_ADAPTER')
-      ? actual.toLowerCase() === expectedValue
-      : actual === expectedValue;
-    if (!matches) {
-      throw new Error(
-        `${name} redirects packaged commands away from the fixed systemd service storage.`,
-      );
-    }
+  const legacyNames = LEGACY_PACKAGED_STORAGE_ENVIRONMENT_VARIABLES.filter(
+    (name) => environment[name] !== undefined,
+  );
+  if (legacyNames.length > 0) {
+    throw new Error(
+      `Legacy Wharfie storage overrides are not supported for packaged service management: ${legacyNames.join(', ')}.`,
+    );
+  }
+  const environmentDataRoot =
+    environment[LOCAL_APP_DATA_ROOT_ENVIRONMENT_VARIABLE];
+  if (
+    environmentDataRoot !== undefined &&
+    environmentDataRoot !== layout.dataRoot
+  ) {
+    throw new Error(
+      `${LOCAL_APP_DATA_ROOT_ENVIRONMENT_VARIABLE} disagrees with active packaged storage authority.`,
+    );
   }
 }
 
@@ -2470,9 +2464,7 @@ export function createSystemdUserServiceOperator(options = {}) {
   const getHomeDirectory =
     options.getHomeDirectory || (() => userInfo().homedir);
   const homeDirectory = getHomeDirectory();
-  const dataRoot =
-    options.dataRoot ??
-    resolveStableLocalAppDataRoot({ platform, homeDirectory });
+  const explicitDataRoot = options.dataRoot;
   const configRoot = options.configRoot ?? path.join(homeDirectory, '.config');
   const fsOps = options.fsOps || fsp;
   const readPackagedStorage =
@@ -2584,13 +2576,27 @@ export function createSystemdUserServiceOperator(options = {}) {
         'Packaged artifact target does not match the running Linux host process.',
       );
     }
+    const packagedStorage = readPackagedStorage();
+    if (!packagedStorage) {
+      throw new Error(
+        'Systemd user-service management requires packaged app storage context.',
+      );
+    }
+    if (
+      explicitDataRoot !== undefined &&
+      explicitDataRoot !== packagedStorage.dataRoot
+    ) {
+      throw new Error(
+        'Explicit systemd user-service dataRoot disagrees with active packaged storage authority.',
+      );
+    }
     const uid = Number(getUid());
     const layout = createSystemdUserServiceLayout({
       appId: pair.runtime.appId,
-      dataRoot,
+      dataRoot: explicitDataRoot ?? packagedStorage.dataRoot,
       configRoot,
     });
-    assertSharedPackagedStorage(layout, readPackagedStorage(), environment);
+    assertSharedPackagedStorage(layout, packagedStorage, environment);
     return {
       pair,
       uid,

--- a/src/core/runtime/services/systemd-user-service.js
+++ b/src/core/runtime/services/systemd-user-service.js
@@ -10,6 +10,7 @@ import {
 import { validateBuildTarget } from '../build-target.js';
 import { cloneJsonObject } from '../json-value.js';
 import {
+  LOCAL_APP_DATA_ROOT_ENVIRONMENT_VARIABLE,
   LOCAL_APP_EXECUTION_LEDGER_TABLE,
   createLocalAppStorageLayout,
 } from '../local-app-storage.js';
@@ -254,25 +255,12 @@ export function createSystemdUserServiceUnit(input) {
     'Type=exec',
     `ExecStart=${quoteSystemdExecWord(layout.currentArtifact)}`,
     `WorkingDirectory=${systemdPathSetting(layout.stateRoot)}`,
+    environmentDirective(
+      LOCAL_APP_DATA_ROOT_ENVIRONMENT_VARIABLE,
+      layout.dataRoot,
+    ),
     environmentDirective('WHARFIE_RUNTIME_COMMAND', 'ledger-service'),
     environmentDirective('WHARFIE_RUNTIME_ARGS', '[]'),
-    environmentDirective('WHARFIE_CONTROL_ADAPTER', 'lmdb'),
-    environmentDirective('WHARFIE_CONTROL_PATH', layout.controlPath),
-    environmentDirective('WHARFIE_EXECUTION_PAYLOAD_PATH', layout.payloadPath),
-    environmentDirective('WHARFIE_EXECUTION_PAYLOAD_STORE_ID', ''),
-    environmentDirective(
-      'WHARFIE_EXECUTION_LEDGER_TABLE',
-      layout.executionLedgerTable,
-    ),
-    environmentDirective(
-      'WHARFIE_LEDGER_SERVICE_SESSION_PATH',
-      layout.sessionPath,
-    ),
-    environmentDirective('WHARFIE_APPLICATION_STATE_ADAPTER', 'lmdb'),
-    environmentDirective(
-      'WHARFIE_APPLICATION_STATE_PATH',
-      layout.applicationStatePath,
-    ),
     'Restart=on-failure',
     'RestartSec=5s',
     'KillSignal=SIGTERM',

--- a/test/app-api.test.js
+++ b/test/app-api.test.js
@@ -1,0 +1,189 @@
+/* eslint-env jest */
+/* eslint-disable jsdoc/require-jsdoc */
+
+import { describe, expect, it } from '@jest/globals';
+
+import { defineApp } from '../src/app.js';
+
+/**
+ * @param {any} definition - Runtime-only authoring input.
+ * @returns {any} - Runtime facade result.
+ */
+function defineUntypedApp(definition) {
+  return defineApp(definition);
+}
+
+describe('defineApp source authoring facade', () => {
+  it('preserves a fully explicit v4 source manifest by identity', () => {
+    const explicit = {
+      schemaVersion: 4,
+      app: { id: 'explicit-app' },
+      cli: {
+        entrypoint: {
+          kind: 'node',
+          path: './src/cli.js',
+          export: 'main',
+        },
+      },
+    };
+
+    expect(defineUntypedApp(explicit)).toBe(explicit);
+  });
+
+  it('expands the smallest shorthand into mechanical v4 CLI boilerplate', () => {
+    expect(
+      defineUntypedApp({
+        id: 'small-app',
+        main: './src/cli.js',
+      }),
+    ).toEqual({
+      schemaVersion: 4,
+      app: { id: 'small-app' },
+      cli: {
+        entrypoint: {
+          kind: 'node',
+          path: './src/cli.js',
+          export: 'main',
+        },
+      },
+    });
+  });
+
+  it('uses only explicit logical IDs and unambiguous module conventions', () => {
+    expect(
+      defineUntypedApp({
+        id: 'durable-app',
+        main: './src/cli.js',
+        durable: 'greet-later',
+        activityModule: './src/activities.js',
+        targets: [
+          { nodeVersion: '24.13.1', platform: 'darwin', architecture: 'arm64' },
+        ],
+        activities: {
+          prepare: {},
+          'say-hello': { export: 'sayHello' },
+          finish: {
+            path: './src/finish.js',
+            externalPackages: [{ name: 'example', version: '1.2.3' }],
+          },
+        },
+        workflows: {
+          'greet-later': { steps: [{ id: 'done', kind: 'signal' }] },
+        },
+        schedules: {
+          nightly: {
+            cron: '0 0 * * *',
+            workflow: 'greet-later',
+            input: {},
+            missed: 'latest',
+            overlap: 'allow',
+          },
+        },
+      }),
+    ).toEqual({
+      schemaVersion: 4,
+      app: { id: 'durable-app' },
+      cli: {
+        entrypoint: {
+          kind: 'node',
+          path: './src/cli.js',
+          export: 'main',
+        },
+        durable: {
+          workflow: 'greet-later',
+          export: 'toDurableInput',
+        },
+      },
+      targets: [
+        { nodeVersion: '24.13.1', platform: 'darwin', architecture: 'arm64' },
+      ],
+      activities: {
+        prepare: {
+          entrypoint: {
+            kind: 'node',
+            path: './src/activities.js',
+            export: 'prepare',
+          },
+        },
+        'say-hello': {
+          entrypoint: {
+            kind: 'node',
+            path: './src/activities.js',
+            export: 'sayHello',
+          },
+        },
+        finish: {
+          entrypoint: {
+            kind: 'node',
+            path: './src/finish.js',
+            export: 'finish',
+          },
+          externalPackages: [{ name: 'example', version: '1.2.3' }],
+        },
+      },
+      workflows: {
+        'greet-later': { steps: [{ id: 'done', kind: 'signal' }] },
+      },
+      schedules: {
+        nightly: {
+          cron: '0 0 * * *',
+          workflow: 'greet-later',
+          input: {},
+          missed: 'latest',
+          overlap: 'allow',
+        },
+      },
+    });
+  });
+
+  it('rejects shorthand ambiguity instead of inventing application semantics', () => {
+    expect(() =>
+      defineUntypedApp({ id: 'bad-app', main: './cli.js', unsupported: true }),
+    ).toThrow(/unsupported/);
+    expect(() =>
+      defineUntypedApp({
+        id: 'bad-app',
+        main: './cli.js',
+        activityModule: './activities.js',
+        activities: {},
+      }),
+    ).toThrow(/at least one declared activity/);
+
+    expect(() =>
+      defineUntypedApp({
+        id: 'bad-app',
+        main: './cli.js',
+        activities: { greet: {} },
+      }),
+    ).toThrow(/requires path or defineApp.activityModule/);
+    expect(() =>
+      defineUntypedApp({
+        id: 'bad-app',
+        main: './cli.js',
+        activityModule: './activities.js',
+        activities: { 'say-hello': {} },
+      }),
+    ).toThrow(/export is required/);
+  });
+
+  it.each([
+    ['path', null],
+    ['path', ''],
+    ['path', 42],
+    ['export', null],
+    ['export', ''],
+    ['export', 42],
+  ])(
+    'rejects a present invalid activity %s instead of applying a convention',
+    (field, value) => {
+      expect(() =>
+        defineUntypedApp({
+          id: 'bad-app',
+          main: './cli.js',
+          activityModule: './activities.js',
+          activities: { greet: { [field]: value } },
+        }),
+      ).toThrow(new RegExp(`${field} must be a nonempty string`));
+    },
+  );
+});

--- a/test/cli/app/load-app.test.js
+++ b/test/cli/app/load-app.test.js
@@ -179,6 +179,59 @@ describe('Wharfie app loader', () => {
     });
   });
 
+  it('loads defineApp shorthand through the unchanged strict v4 compiler', async () => {
+    const appApiUrl = new URL('../../../src/app.js', import.meta.url).href;
+    await writeModule(`
+      import { defineApp } from ${JSON.stringify(appApiUrl)};
+      export default defineApp({
+        id: 'shorthand-source',
+        main: './src/cli.js',
+        durable: 'greet-later',
+        activityModule: './src/greet.js',
+        activities: { greet: {} },
+        workflows: {
+          'greet-later': {
+            steps: [{
+              id: 'greet',
+              kind: 'activity',
+              activity: 'greet',
+              input: { kind: 'workflow-input' },
+            }],
+          },
+        },
+      });
+    `);
+
+    await expect(loadApp({ dir: appDir })).resolves.toEqual({
+      appDir,
+      manifest: {
+        schemaVersion: 4,
+        app: { id: 'shorthand-source' },
+        cli: {
+          entrypoint: { kind: 'node', path: 'src/cli.js', export: 'main' },
+          durable: { workflow: 'greet-later', export: 'toDurableInput' },
+        },
+        activities: {
+          greet: {
+            entrypoint: { kind: 'node', path: 'src/greet.js', export: 'greet' },
+          },
+        },
+        workflows: {
+          'greet-later': {
+            steps: [
+              {
+                id: 'greet',
+                kind: 'activity',
+                activity: 'greet',
+                input: { kind: 'workflow-input' },
+              },
+            ],
+          },
+        },
+      },
+    });
+  });
+
   it('keeps the durable CLI handoff optional', async () => {
     const source = makeValidSource();
     delete source.cli.durable;

--- a/test/cli/app/local-app.package.test.js
+++ b/test/cli/app/local-app.package.test.js
@@ -137,6 +137,38 @@ async function writeTransactionalPackageApp(
 }
 
 /**
+ * @param {string} dir - App directory.
+ * @param {string} appName - App name.
+ */
+async function writeTargetlessPackageApp(dir, appName) {
+  await fsp.mkdir(path.join(dir, 'src'), { recursive: true });
+  await Promise.all([
+    fsp.writeFile(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ name: appName, private: true, type: 'module' }),
+      'utf8',
+    ),
+    fsp.writeFile(
+      path.join(dir, 'src', 'cli.js'),
+      'export default async function cli() {}\n',
+      'utf8',
+    ),
+    fsp.writeFile(
+      path.join(dir, 'wharfie.app.js'),
+      `export default {
+  schemaVersion: 4,
+  app: { id: ${JSON.stringify(appName)} },
+  cli: {
+    entrypoint: { kind: 'node', path: './src/cli.js', export: 'default' },
+  },
+};
+`,
+      'utf8',
+    ),
+  ]);
+}
+
+/**
  * @param {string[]} chunks - Captured UTF-8 output.
  * @returns {typeof process.stdout.write} - Stream write replacement.
  */
@@ -362,6 +394,129 @@ afterEach(() => {
 });
 
 describe('packageLocalApp', () => {
+  it('infers one exact host target when a manifest omits targets', async () => {
+    const dir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'wharfie-host-target-package-'),
+    );
+    const outputDir = path.join(dir, 'dist');
+    /** @type {Array<{phase: string, message: string}>} */
+    const progress = [];
+
+    try {
+      await writeTargetlessPackageApp(dir, 'host-target-package');
+      jest.spyOn(ActorSystem.prototype, 'reconcile').mockImplementation(
+        /** @this {ActorSystem} */ async function () {
+          const buildDir = path.join(dir, '.fake-builds');
+          const nodeBinary = this.getResources().find(
+            (resource) => resource instanceof NodeBinary,
+          );
+          const downloadProgress = nodeBinary?.onDownloadProgress;
+          expect(downloadProgress).toEqual(expect.any(Function));
+          if (typeof downloadProgress !== 'function') {
+            throw new Error('Node download progress observer was not wired.');
+          }
+          downloadProgress({
+            version: `v${process.versions.node}`,
+            downloadedBytes: 1024 * 1024,
+            totalBytes: 2 * 1024 * 1024,
+          });
+          await prepareMockArtifactProvenance(this, buildDir);
+
+          const builds = this.getResources().filter(
+            (resource) => resource instanceof SeaBuild,
+          );
+          expect(builds).toHaveLength(1);
+          for (const resource of builds) {
+            const target = {
+              nodeVersion: String(resource.get('nodeVersion')),
+              platform: String(resource.get('platform')),
+              architecture: String(resource.get('architecture')),
+              ...(resource.has('libc')
+                ? { libc: String(resource.get('libc')) }
+                : {}),
+            };
+            expect(target).toEqual(currentTarget);
+            const binaryPath = path.join(buildDir, resource.name);
+            await fsp.writeFile(binaryPath, 'host target bytes', 'utf8');
+            resource._setUNSAFE('binaryPath', binaryPath);
+          }
+        },
+      );
+
+      const result = await packageLocalApp({
+        dir,
+        outputDir,
+        onProgress: (event) => progress.push(event),
+      });
+
+      expect(result.targets).toEqual([currentTarget]);
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].target).toEqual(currentTarget);
+      expect(result.revision.contract).not.toHaveProperty('targets');
+      expect(progress.map((event) => event.phase)).toEqual([
+        'resolve',
+        'prepare',
+        'build',
+        'download',
+        'publish',
+      ]);
+      expect(progress[3].message).toBe(
+        `Downloading Node v${process.versions.node} (1.0/2.0 MiB)`,
+      );
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('requires declared targets when a public target filter is supplied', async () => {
+    const dir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'wharfie-targetless-filter-package-'),
+    );
+
+    try {
+      await writeTargetlessPackageApp(dir, 'targetless-filter-package');
+      await expect(
+        packageLocalApp({
+          dir,
+          targetFilters: [getTargetSelector(currentTarget)],
+        }),
+      ).rejects.toThrow(/no declared build targets/i);
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects targetless Linux packaging on an unknown libc before builds start', async () => {
+    const dir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'wharfie-targetless-unknown-libc-package-'),
+    );
+    const platformDescriptor = Object.getOwnPropertyDescriptor(
+      process,
+      'platform',
+    );
+    const reconcile = jest.spyOn(ActorSystem.prototype, 'reconcile');
+    jest
+      .spyOn(process.report, 'getReport')
+      .mockReturnValue(/** @type {any} */ ({ header: {} }));
+    Object.defineProperty(process, 'platform', {
+      ...platformDescriptor,
+      value: 'linux',
+    });
+
+    try {
+      await writeTargetlessPackageApp(dir, 'targetless-unknown-libc-package');
+      await expect(packageLocalApp({ dir })).rejects.toThrow(
+        /positively identified glibc.*musl.*unknown/i,
+      );
+      expect(reconcile).not.toHaveBeenCalled();
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(process, 'platform', platformDescriptor);
+      }
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('reserves command stdout for one receipt while authored setup writes diagnostics', async () => {
     const dir = await fsp.mkdtemp(
       path.join(os.tmpdir(), 'wharfie-package-command-stdout-'),
@@ -419,7 +574,7 @@ describe('packageLocalApp', () => {
 
       try {
         await createPackageCommand().parseAsync(
-          [dir, '--output-dir', outputDir, '--no-pretty'],
+          [dir, '--output-dir', outputDir, '--json', '--no-pretty'],
           { from: 'user' },
         );
       } finally {
@@ -619,11 +774,12 @@ describe('packageLocalApp', () => {
             expect(entryCode).toContain('const loadDeveloperCliModule = () =>');
             expect(entryCode).toContain('loadDeveloperCliModule,');
             expect(entryCode).not.toContain('await loadDeveloperCliModule()');
-            expect(
-              entryCode.indexOf(
-                'await preparePackagedCoreRuntimeDependencies()',
-              ),
-            ).toBeLessThan(entryCode.indexOf('await runPackagedApp({'));
+            expect(entryCode).toContain(
+              'prepareRuntime: preparePackagedCoreRuntimeDependencies',
+            );
+            expect(entryCode).not.toContain(
+              'await preparePackagedCoreRuntimeDependencies()',
+            );
             expect(entryCode).toContain(
               'const packagedAppStorage = await resolvePackagedAppStorage()',
             );
@@ -1741,12 +1897,16 @@ try {
     }
   });
 
-  it('leaves existing outputs untouched and removes staging when a staged artifact write fails', async () => {
+  it('removes package-owned SEA outputs when staged artifact writing fails', async () => {
     const dir = await fsp.mkdtemp(
       path.join(os.tmpdir(), 'wharfie-package-copy-transaction-'),
     );
     const outputDir = path.join(dir, 'dist');
     const appName = 'copy-transaction-demo';
+    const ownedBinariesDir = path.join(dir, 'actor-binaries');
+    const originalBinariesDir = SeaBuild.BINARIES_DIR;
+    /** @type {string[]} */
+    const ownedBinaryPaths = [];
     const targets = [
       {
         nodeVersion: process.versions.node,
@@ -1770,6 +1930,8 @@ try {
     );
 
     try {
+      SeaBuild.BINARIES_DIR = ownedBinariesDir;
+      await fsp.mkdir(ownedBinariesDir, { recursive: true });
       await writeTransactionalPackageApp(dir, appName, targets);
       await fsp.mkdir(outputDir, { recursive: true });
       await fsp.writeFile(previousOutput, 'previous-artifact', 'utf8');
@@ -1781,9 +1943,10 @@ try {
           let index = 0;
           for (const resource of this.getResources()) {
             if (!(resource instanceof SeaBuild)) continue;
-            const sourcePath = path.join(buildDir, `binary-${index}`);
+            const sourcePath = path.join(ownedBinariesDir, `binary-${index}`);
             await fsp.writeFile(sourcePath, `new-artifact-${index}`, 'utf8');
             resource._setUNSAFE('binaryPath', sourcePath);
+            ownedBinaryPaths.push(sourcePath);
             index += 1;
           }
         },
@@ -1818,7 +1981,12 @@ try {
       expect(await fsp.readdir(outputDir)).toEqual([
         path.basename(previousOutput),
       ]);
+      expect(ownedBinaryPaths).toHaveLength(2);
+      for (const ownedBinaryPath of ownedBinaryPaths) {
+        expect(existsSync(ownedBinaryPath)).toBe(false);
+      }
     } finally {
+      SeaBuild.BINARIES_DIR = originalBinariesDir;
       await fsp.rm(dir, { recursive: true, force: true });
     }
   });

--- a/test/cli/app/package-command-receipt.test.js
+++ b/test/cli/app/package-command-receipt.test.js
@@ -31,6 +31,11 @@ const DARWIN_TARGET = Object.freeze({
   platform: 'darwin',
   architecture: 'arm64',
 });
+const WINDOWS_TARGET = Object.freeze({
+  nodeVersion: '24.13.1',
+  platform: 'win32',
+  architecture: 'x64',
+});
 
 /** @template T @param {T} value @returns {T} */
 function clone(value) {
@@ -42,8 +47,11 @@ function digest(value) {
   return { algorithm: 'sha256', value: sha256Base64Url(value) };
 }
 
-/** @param {string} [salt] */
-function makeRevision(salt = 'primary') {
+/**
+ * @param {string} [salt]
+ * @param {boolean} [durable]
+ */
+function makeRevision(salt = 'primary', durable = false) {
   return createApplicationRevision({
     contract: {
       schemaVersion: 4,
@@ -54,6 +62,14 @@ function makeRevision(salt = 'primary') {
           path: 'src/cli.js',
           export: 'main',
         },
+        ...(durable
+          ? {
+              durable: {
+                workflow: 'serve-once',
+                export: 'toDurableInput',
+              },
+            }
+          : {}),
       },
       activities: {
         serve: {
@@ -64,6 +80,22 @@ function makeRevision(salt = 'primary') {
           },
         },
       },
+      ...(durable
+        ? {
+            workflows: {
+              'serve-once': {
+                steps: [
+                  {
+                    id: 'serve',
+                    kind: 'activity',
+                    activity: 'serve',
+                    input: { kind: 'workflow-input' },
+                  },
+                ],
+              },
+            },
+          }
+        : {}),
     },
     inputs: {
       source: {
@@ -111,8 +143,9 @@ function makeProvenance(revision, target) {
  * @param {ReturnType<typeof makeRevision>} revision
  * @param {{nodeVersion: string, platform: string, architecture: string, libc?: string}} target
  * @param {string} contents
+ * @param {string} [outputDir]
  */
-function makeArtifact(revision, target, contents) {
+function makeArtifact(revision, target, contents, outputDir = OUTPUT_DIR) {
   const bytes = Buffer.from(contents, 'utf8');
   const record = createArtifactRecord({
     bytes,
@@ -125,7 +158,7 @@ function makeArtifact(revision, target, contents) {
     target: record.target,
     byteDigest: record.byteDigest,
   });
-  const artifactPath = path.join(OUTPUT_DIR, fileName);
+  const artifactPath = path.join(outputDir, fileName);
 
   return {
     fileName,
@@ -140,17 +173,26 @@ function makeArtifact(revision, target, contents) {
   };
 }
 
-/** @returns {any} */
-function makePackageResult() {
-  const revision = makeRevision();
+/**
+ * @param {boolean} [durable]
+ * @param {string} [outputDir]
+ * @returns {any}
+ */
+function makePackageResult(durable = false, outputDir = OUTPUT_DIR) {
+  const revision = makeRevision('primary', durable);
   return {
     app: { id: APP_ID },
     revision,
     targets: [clone(LINUX_TARGET), clone(DARWIN_TARGET)],
-    outputDir: OUTPUT_DIR,
+    outputDir,
     artifacts: [
-      makeArtifact(revision, LINUX_TARGET, 'linux executable bytes'),
-      makeArtifact(revision, DARWIN_TARGET, 'darwin executable bytes'),
+      makeArtifact(revision, LINUX_TARGET, 'linux executable bytes', outputDir),
+      makeArtifact(
+        revision,
+        DARWIN_TARGET,
+        'darwin executable bytes',
+        outputDir,
+      ),
     ],
   };
 }
@@ -494,6 +536,12 @@ describe('application package command receipt', () => {
     },
     {
       label: 'compact JSON',
+      args: ['fixture-app', '--json', '--no-pretty'],
+      targetFilters: [],
+      pretty: false,
+    },
+    {
+      label: 'backward-compatible compact JSON from bare --no-pretty',
       args: ['fixture-app', '--no-pretty'],
       targetFilters: [],
       pretty: false,
@@ -504,9 +552,13 @@ describe('application package command receipt', () => {
       async (/** @type {Record<string, any>} */ _options) => result,
     );
     const writeOutput = jest.fn((/** @type {string} */ _value) => undefined);
+    const readHostTarget = jest.fn(() => {
+      throw new Error('JSON output must not inspect the command host.');
+    });
     const command = createPackageCommand({
       packageApplication,
       writeOutput,
+      readHostTarget,
     });
 
     await command.parseAsync(testCase.args, { from: 'user' });
@@ -518,6 +570,7 @@ describe('application package command receipt', () => {
       targetFilters: testCase.targetFilters,
     });
     expect(writeOutput).toHaveBeenCalledTimes(1);
+    expect(readHostTarget).not.toHaveBeenCalled();
     const output = writeOutput.mock.calls[0][0];
     expect(output.endsWith('\n')).toBe(true);
     expect(JSON.parse(output)).toEqual(createApplicationPackageReceipt(result));
@@ -525,5 +578,163 @@ describe('application package command receipt', () => {
     if (!testCase.pretty) {
       expect(output.slice(0, -1)).not.toContain('\n');
     }
+  });
+  it('writes a concise human summary and durable next command by default', async () => {
+    const result = makePackageResult(true);
+    const packageApplication = jest.fn(
+      async (/** @type {Record<string, any>} */ options) => {
+        options.onProgress({
+          phase: 'build',
+          message: 'Building executable artifacts',
+        });
+        return result;
+      },
+    );
+    const writeOutput = jest.fn((/** @type {string} */ _value) => undefined);
+    const writeDiagnostic = jest.fn(
+      (/** @type {string} */ _value) => undefined,
+    );
+    const command = createPackageCommand({
+      packageApplication,
+      writeOutput,
+      writeDiagnostic,
+      readHostTarget: () => ({ ...LINUX_TARGET, nodeVersion: '99.0.0' }),
+    });
+
+    await command.parseAsync(['fixture-app'], { from: 'user' });
+
+    expect(packageApplication).toHaveBeenCalledWith({
+      dir: 'fixture-app',
+      outputDir: undefined,
+      targetFilters: [],
+      onProgress: expect.any(Function),
+    });
+    expect(writeDiagnostic).toHaveBeenCalledWith(
+      '  Building executable artifacts\n',
+    );
+    expect(writeOutput).toHaveBeenCalledTimes(1);
+    const output = writeOutput.mock.calls[0][0];
+    expect(output).toContain(`✓ Packaged ${APP_ID} (2 artifacts)\n`);
+    expect(output).toContain('node24.13.1-linux-x64-glibc');
+    expect(output).toContain('node24.13.1-darwin-arm64');
+    expect(output).toContain(OUTPUT_DIR);
+    expect(output).toMatch(/Next: .* wharfie run --name first-run --\n$/);
+    expect(() => JSON.parse(output)).toThrow();
+  });
+
+  it('hands a non-durable app directly to its packaged artifact', async () => {
+    const result = makePackageResult();
+    const writeOutput = jest.fn((/** @type {string} */ _value) => undefined);
+    const command = createPackageCommand({
+      packageApplication: async () => result,
+      writeOutput,
+      readHostTarget: () => ({ ...LINUX_TARGET, nodeVersion: '99.0.0' }),
+    });
+
+    await command.parseAsync(['fixture-app'], { from: 'user' });
+
+    const output = writeOutput.mock.calls[0][0];
+    const nextLine = output
+      .split(String.fromCharCode(10))
+      .find((line) => line.startsWith('Next:'));
+    expect(nextLine).toBe('Next: ' + result.artifacts[0].path);
+    expect(nextLine).not.toContain(' wharfie ');
+  });
+
+  it('keeps printable artifact paths as copy-pasteable shell commands', async () => {
+    const outputDir = path.join(os.tmpdir(), "wharfie package joe's");
+    const result = makePackageResult(true, outputDir);
+    const writeOutput = jest.fn((/** @type {string} */ _value) => undefined);
+    const command = createPackageCommand({
+      packageApplication: async () => result,
+      writeOutput,
+      readHostTarget: () => ({ ...LINUX_TARGET, nodeVersion: '99.0.0' }),
+    });
+
+    await command.parseAsync(['fixture-app'], { from: 'user' });
+
+    const output = writeOutput.mock.calls[0][0];
+    const nextLine = output
+      .split(String.fromCharCode(10))
+      .find((line) => line.startsWith('Next:'));
+    const shellApostrophe = "'" + String.fromCharCode(92) + "''";
+    const expectedPath =
+      "'" + result.artifacts[0].path.replaceAll("'", shellApostrophe) + "'";
+    expect(nextLine).toBe(
+      'Next: ' + expectedPath + ' wharfie run --name first-run --',
+    );
+  });
+
+  it('renders control-bearing paths inert and omits a false shell command', async () => {
+    const escape = String.fromCharCode(0x1b);
+    const lineFeed = String.fromCharCode(10);
+    const bidiOverride = String.fromCharCode(0x202e);
+    const outputDir = path.join(
+      os.tmpdir(),
+      'wharfie-package-' + escape + '[31m-' + lineFeed + '-' + bidiOverride,
+    );
+    const result = makePackageResult(true, outputDir);
+    const writeOutput = jest.fn((/** @type {string} */ _value) => undefined);
+    const command = createPackageCommand({
+      packageApplication: async () => result,
+      writeOutput,
+      readHostTarget: () => ({ ...LINUX_TARGET, nodeVersion: '99.0.0' }),
+    });
+
+    await command.parseAsync(['fixture-app'], { from: 'user' });
+
+    const output = writeOutput.mock.calls[0][0];
+    const slash = String.fromCharCode(92);
+    expect(output).not.toContain(escape);
+    expect(output).not.toContain(bidiOverride);
+    expect(output).toContain(slash + 'u001b');
+    expect(output).toContain(slash + 'n');
+    expect(output).toContain(slash + 'u202e');
+    expect(output).toContain('path (JSON): "');
+    expect(output.split(lineFeed)).toHaveLength(7);
+
+    const nextLine = output
+      .split(lineFeed)
+      .find((line) => line.startsWith('Next:'));
+    expect(nextLine).toContain('shell command omitted');
+    expect(nextLine).toContain('--json');
+    expect(nextLine).not.toContain('wharfie run');
+  });
+
+  it('does not render POSIX quoting as a Windows shell command', async () => {
+    const revision = makeRevision();
+    const outputDir = path.join(os.tmpdir(), 'Wharfie Windows Package');
+    const artifact = makeArtifact(
+      revision,
+      WINDOWS_TARGET,
+      'windows executable bytes',
+      outputDir,
+    );
+    const result = {
+      app: { id: APP_ID },
+      revision,
+      targets: [clone(WINDOWS_TARGET)],
+      outputDir,
+      artifacts: [artifact],
+    };
+    const writeOutput = jest.fn((/** @type {string} */ _value) => undefined);
+    const command = createPackageCommand({
+      packageApplication: async () => result,
+      writeOutput,
+      readHostTarget: () => ({
+        ...WINDOWS_TARGET,
+        nodeVersion: '99.0.0',
+      }),
+    });
+
+    await command.parseAsync(['fixture-app'], { from: 'user' });
+
+    const output = writeOutput.mock.calls[0][0];
+    expect(output).toContain(artifact.path);
+    expect(output).toContain(
+      'Next: invoke the artifact shown above from your Windows shell;',
+    );
+    expect(output).toContain('cmd.exe and PowerShell');
+    expect(output).not.toContain(`Next: '${artifact.path}'`);
   });
 });

--- a/test/cli/docs-command-surface.test.js
+++ b/test/cli/docs-command-surface.test.js
@@ -378,6 +378,7 @@ describe('docs command surface', () => {
     expect(quickstart).toContain(
       'wharfie app package ./path/to/app --target linux-x64',
     );
+    expect(quickstart).toContain('--json --no-pretty > package-receipt.json');
     expect(quickstart).toContain('package-receipt.json');
     expect(quickstart).toContain('receipt.artifactCount');
     expect(quickstart).toContain('receipt.artifacts[0].path');
@@ -569,6 +570,27 @@ describe('docs command surface', () => {
 
     const packagedOperator = createPackagedOperatorProgram();
     expect(packagedOperator.name()).toBe('wharfie');
+    expectCommandShape(findCommand(packagedOperator, 'run'), {
+      name: 'run',
+      arguments: [{ name: 'appArgs', required: false, variadic: true }],
+      options: ['--name'],
+      requiredOptions: ['--name'],
+    });
+    const packagedActivity = findCommand(packagedOperator, 'activity');
+    expectCommandShape(packagedActivity, {
+      name: 'activity',
+      options: [],
+    });
+    expectCommandShape(findCommand(packagedActivity, 'run'), {
+      name: 'run',
+      options: [
+        '--activity',
+        '--input',
+        '--caller-metadata',
+        '--idempotency-key',
+        '--json',
+      ],
+    });
     expectCommandShape(findCommand(packagedOperator, 'start'), {
       name: 'start',
       arguments: [{ name: 'appArgs', required: false, variadic: true }],

--- a/test/runtime/durable-workflow-run-command.test.js
+++ b/test/runtime/durable-workflow-run-command.test.js
@@ -1,0 +1,871 @@
+/* eslint-env jest */
+/* eslint-disable jsdoc/require-jsdoc */
+
+import { describe, expect, it, jest } from '@jest/globals';
+import { createHash } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+
+import { createProgram as createPackagedOperatorProgram } from '../../src/core/resources/builds/actor-system-cli/index.js';
+import {
+  ARTIFACT_RUNTIME_KIND,
+  ARTIFACT_RUNTIME_SCHEMA_VERSION,
+} from '../../src/core/resources/builds/lib/revision-runtime-assets.js';
+import {
+  DEPENDENCY_LOCK_INPUT_FORMAT,
+  RUNTIME_INPUT_FORMAT,
+  SOURCE_TREE_INPUT_FORMAT,
+  createApplicationRevision,
+} from '../../src/core/runtime/application-revision.js';
+import { createDurableWorkflowRunCommand } from '../../src/core/runtime/operator/durable-workflow-run-command.js';
+import {
+  WORKFLOW_EXECUTION_PAYLOAD_SCHEMA_VERSION,
+  WORKFLOW_PLAN_PAYLOAD_KIND,
+  createWorkflowPlanId,
+  createWorkflowRunId,
+  normalizeWorkflowPlanPayload,
+} from '../../src/core/lib/ledger/workflow-execution-contract.js';
+
+const APP_ID = 'foreground-run-demo';
+const WORKFLOW_ID = 'main';
+const STEP_ID = 'greet-step';
+const WAIT_STEP_ID = 'wait-step';
+const FINAL_STEP_ID = 'say-hello';
+/** @typedef {import('../../src/core/runtime/durable-activity-host.js').ManifestActivityExecution} ManifestActivityExecution */
+/** @typedef {Extract<ManifestActivityExecution, {kind: 'embedded'}>} EmbeddedExecution */
+
+const TARGET = Object.freeze({
+  nodeVersion: '24.13.1',
+  platform: 'linux',
+  architecture: 'x64',
+  libc: 'glibc',
+});
+
+/** @param {string} value */
+function digest(value) {
+  return {
+    algorithm: 'sha256',
+    value: createHash('sha256').update(value).digest('base64url'),
+  };
+}
+
+/** @returns {EmbeddedExecution} */
+function makeExecution() {
+  const contract = {
+    schemaVersion: 4,
+    app: { id: APP_ID },
+    cli: {
+      entrypoint: { kind: 'node', path: 'cli.js', export: 'main' },
+      durable: { workflow: WORKFLOW_ID, export: 'toDurableInput' },
+    },
+    activities: {
+      greet: {
+        entrypoint: {
+          kind: 'node',
+          path: 'activities/greet.js',
+          export: 'greet',
+        },
+      },
+    },
+    workflows: {
+      [WORKFLOW_ID]: {
+        steps: [
+          {
+            id: STEP_ID,
+            kind: 'activity',
+            activity: 'greet',
+            input: { kind: 'workflow-input' },
+          },
+          {
+            id: WAIT_STEP_ID,
+            kind: 'timer',
+            delayMs: 5_000,
+          },
+          {
+            id: FINAL_STEP_ID,
+            kind: 'activity',
+            activity: 'greet',
+            input: { kind: 'workflow-input' },
+          },
+        ],
+      },
+    },
+  };
+  const revision = createApplicationRevision({
+    contract,
+    inputs: {
+      source: { format: SOURCE_TREE_INPUT_FORMAT, digest: digest('source') },
+      dependencies: {
+        format: DEPENDENCY_LOCK_INPUT_FORMAT,
+        digest: digest('dependencies'),
+      },
+      runtime: { format: RUNTIME_INPUT_FORMAT, digest: digest('runtime') },
+    },
+  });
+  return /** @type {EmbeddedExecution} */ ({
+    kind: 'embedded',
+    manifest: { ...contract, targets: [{ ...TARGET }] },
+    embeddedRevision: {
+      revision,
+      runtime: {
+        schemaVersion: ARTIFACT_RUNTIME_SCHEMA_VERSION,
+        kind: ARTIFACT_RUNTIME_KIND,
+        appId: APP_ID,
+        revisionId: revision.revisionId,
+        target: { ...TARGET },
+      },
+    },
+  });
+}
+
+/** @returns {{execPath: string, exitCode: number | undefined, once: EventEmitter['once'], removeListener: EventEmitter['removeListener'], emit: EventEmitter['emit']}} */
+function makeProcessRef() {
+  const emitter = new EventEmitter();
+  return {
+    execPath: '/tmp/hello',
+    exitCode: undefined,
+    once: emitter.once.bind(emitter),
+    removeListener: emitter.removeListener.bind(emitter),
+    emit: emitter.emit.bind(emitter),
+  };
+}
+
+function makeOutput() {
+  return {
+    info: jest.fn(),
+    progress: jest.fn(),
+    success: jest.fn(),
+    result: jest.fn(),
+    paused: jest.fn(),
+    failure: jest.fn(),
+  };
+}
+
+/**
+ * @param {EmbeddedExecution} execution
+ * @param {string} name
+ * @param {string} [status]
+ * @param {any} [result]
+ */
+function rawOutput(
+  execution,
+  name,
+  status = 'RUNNING',
+  result = { greeting: 'Hello, Ada!' },
+) {
+  const runId = createWorkflowRunId({ appId: APP_ID, idempotencyKey: name });
+  const completed = status === 'COMPLETED';
+  return {
+    scope: {
+      appId: APP_ID,
+      revisionId: execution.embeddedRevision.runtime.revisionId,
+      runId,
+    },
+    snapshot: {
+      runKind: 'workflow',
+      status,
+      version: completed ? 2 : 1,
+      lastSequence: completed ? 2 : 1,
+    },
+    outputs: completed
+      ? [{ stepId: STEP_ID, stepIndex: 0, value: result }]
+      : [],
+    terminal: completed ? { type: 'completed', result } : null,
+  };
+}
+/**
+ * @param {EmbeddedExecution} execution
+ * @param {string} name
+ * @param {Array<{stepId: string, value: any}>} steps
+ * @param {string} [status]
+ */
+function rawStepOutputs(execution, name, steps, status = 'RUNNING') {
+  const snapshot = rawOutput(execution, name, status, steps.at(-1)?.value);
+  snapshot.outputs = steps.map((step, stepIndex) => ({
+    stepId: step.stepId,
+    stepIndex,
+    value: step.value,
+  }));
+  snapshot.snapshot.version = Math.max(1, steps.length + 1);
+  snapshot.snapshot.lastSequence = Math.max(1, steps.length + 1);
+  return snapshot;
+}
+
+/**
+ * @param {EmbeddedExecution} execution
+ * @param {string} name
+ * @param {boolean} [applied]
+ */
+function startResult(execution, name, applied = true) {
+  const revisionId = execution.embeddedRevision.runtime.revisionId;
+  const planPayload = normalizeWorkflowPlanPayload({
+    schemaVersion: WORKFLOW_EXECUTION_PAYLOAD_SCHEMA_VERSION,
+    kind: WORKFLOW_PLAN_PAYLOAD_KIND,
+    appId: APP_ID,
+    revisionId,
+    workflowId: WORKFLOW_ID,
+    definition: execution.manifest.workflows[WORKFLOW_ID],
+  });
+  const planId = createWorkflowPlanId(planPayload);
+  const runId = createWorkflowRunId({ appId: APP_ID, idempotencyKey: name });
+  const invocationId = 'foreground-start-invocation-1';
+  const continuationId = 'foreground-start-continuation-1';
+  return {
+    appId: APP_ID,
+    revisionId,
+    workflowId: WORKFLOW_ID,
+    idempotencyKey: name,
+    runId,
+    planId,
+    outcome: {
+      applied,
+      run: {
+        runId,
+        appId: APP_ID,
+        revisionId,
+        trigger: {
+          kind: 'workflow',
+          workflowId: WORKFLOW_ID,
+          planId,
+          planRef: { payloadId: 'secret-plan-reference' },
+        },
+        requestRef: { payloadId: 'secret-start-reference' },
+        status: 'RUNNING',
+      },
+      workflowCursor: {
+        runId,
+        appId: APP_ID,
+        revisionId,
+        workflowId: WORKFLOW_ID,
+        planId,
+        planRef: { payloadId: 'secret-plan-reference' },
+        startRef: { payloadId: 'secret-start-reference' },
+        invocationId,
+        continuationId,
+        disposition: 'ACTIVITY_RUNNABLE',
+        stepId: STEP_ID,
+        stepIndex: 0,
+      },
+      invocation: {
+        runId,
+        invocationId,
+        appId: APP_ID,
+        revisionId,
+        activityId: 'greet',
+        requestRef: { payloadId: 'secret-activity-reference' },
+        status: 'RUNNABLE',
+        workflow: {
+          workflowId: WORKFLOW_ID,
+          planId,
+          continuationId,
+          stepId: STEP_ID,
+          stepIndex: 0,
+        },
+      },
+    },
+  };
+}
+/**
+ * @param {EmbeddedExecution} execution
+ * @param {string} name
+ */
+function retainedTimerStartResult(execution, name) {
+  const result = /** @type {Record<string, any>} */ (
+    startResult(execution, name, false)
+  );
+  const timerId = 'retained-timer';
+  const continuationId = 'retained-timer-continuation-1';
+  const { runId, revisionId, planId } = result;
+  result.outcome.workflowCursor = {
+    runId,
+    appId: APP_ID,
+    revisionId,
+    workflowId: WORKFLOW_ID,
+    planId,
+    continuationId,
+    stepId: WAIT_STEP_ID,
+    stepIndex: 1,
+    disposition: 'TIMER_WAITING',
+    timerId,
+  };
+  delete result.outcome.invocation;
+  result.outcome.timer = {
+    runId,
+    appId: APP_ID,
+    revisionId,
+    workflowId: WORKFLOW_ID,
+    planId,
+    continuationId,
+    stepId: WAIT_STEP_ID,
+    stepIndex: 1,
+    timerId,
+    status: 'WAITING',
+  };
+  return result;
+}
+
+function drainingWorker() {
+  return jest.fn(
+    async (
+      /** @type {{execution: ManifestActivityExecution, signal: AbortSignal}} */ {
+        signal,
+      },
+    ) => {
+      if (signal.aborted) return;
+      await new Promise((resolve) => {
+        signal.addEventListener('abort', resolve, { once: true });
+      });
+    },
+  );
+}
+
+/** @param {Record<string, any>} [options] */
+function makeCommand(options = {}) {
+  const execution = makeExecution();
+  const processRef = options.processRef || makeProcessRef();
+  const output = options.output || makeOutput();
+  return {
+    execution,
+    processRef,
+    output,
+    command: createDurableWorkflowRunCommand({
+      loadExecution: async () => ({ execution }),
+      loadCliModule: async () => ({
+        toDurableInput: (/** @type {string[]} */ args) => ({ who: args[0] }),
+      }),
+      startWorkflow:
+        options.startWorkflow ||
+        (async (/** @type {{idempotencyKey: string}} */ { idempotencyKey }) =>
+          startResult(execution, idempotencyKey)),
+      runWorker: options.runWorker || drainingWorker(),
+      readRunOutput:
+        options.readRunOutput ||
+        (async () => rawOutput(execution, 'first-run', 'COMPLETED')),
+      inspectRun: options.inspectRun || (async () => null),
+      ...(options.now === undefined ? {} : { now: options.now }),
+      ...(options.environment === undefined
+        ? {}
+        : { environment: options.environment }),
+      output,
+      processRef,
+      pollIntervalMs: options.pollIntervalMs ?? 0,
+      ownerRetryIntervalMs: 0,
+    }),
+  };
+}
+
+describe('packaged foreground durable workflow run command', () => {
+  it('owns top-level run while retaining the activity leaf under activity run', () => {
+    const program = createPackagedOperatorProgram();
+    const run = program.commands.find(
+      (candidate) => candidate.name() === 'run',
+    );
+    const activity = program.commands.find(
+      (candidate) => candidate.name() === 'activity',
+    );
+
+    expect(run?.helpInformation()).toContain('--name <stableName>');
+    expect(run?.helpInformation()).toContain('[appArgs...]');
+    expect(run?.helpInformation()).not.toContain('--activity');
+    expect(activity?.commands.map((candidate) => candidate.name())).toEqual([
+      'run',
+    ]);
+    expect(activity?.commands[0].helpInformation()).toContain(
+      '--activity <activityName>',
+    );
+  });
+
+  it('dispatches the magnetic path through the packaged operator program', async () => {
+    const execution = makeExecution();
+    const output = makeOutput();
+    const processRef = makeProcessRef();
+    const program = createPackagedOperatorProgram({
+      loadDurableWorkflowRunExecution: async () => ({ execution }),
+      loadDeveloperCliModule: async () => ({
+        toDurableInput: (/** @type {string[]} */ args) => ({ who: args[0] }),
+      }),
+      startWorkflow: async (
+        /** @type {{idempotencyKey: string}} */ { idempotencyKey },
+      ) => startResult(execution, idempotencyKey),
+      runForegroundWorker: drainingWorker(),
+      readForegroundRunOutput: async () =>
+        rawOutput(execution, 'first-run', 'COMPLETED'),
+      inspectForegroundRun: async () => null,
+      durableWorkflowRunOutput: output,
+      processRef,
+    });
+
+    await program.parseAsync(['run', '--name', 'first-run', '--', 'Ada'], {
+      from: 'user',
+    });
+
+    expect(output.success).toHaveBeenCalledWith(
+      '✓ Completed first-run; result retained.',
+    );
+    expect(output.failure).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed workflow admission before starting a resident', async () => {
+    const execution = makeExecution();
+    const output = makeOutput();
+    const runWorker = drainingWorker();
+    const readRunOutput = jest.fn(async () =>
+      rawOutput(execution, 'first-run', 'COMPLETED'),
+    );
+    const { command, processRef } = makeCommand({
+      output,
+      runWorker,
+      readRunOutput,
+      startWorkflow: async (
+        /** @type {{idempotencyKey: string}} */ { idempotencyKey },
+      ) => {
+        const result = startResult(execution, idempotencyKey);
+        result.revisionId = 'rev_sha256_unexpected';
+        return result;
+      },
+    });
+
+    await command.parseAsync([
+      'node',
+      'hello',
+      '--name',
+      'first-run',
+      '--',
+      'Ada',
+    ]);
+
+    expect(output.failure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          'Durable workflow start returned an unexpected immutable identity.',
+      }),
+    );
+    expect(output.info).not.toHaveBeenCalled();
+    expect(runWorker).not.toHaveBeenCalled();
+    expect(readRunOutput).not.toHaveBeenCalled();
+    expect(processRef.exitCode).toBe(1);
+  });
+
+  it('starts, drives, follows verified progress, and prints the retained result', async () => {
+    const execution = makeExecution();
+    const output = makeOutput();
+    const processRef = makeProcessRef();
+    const startWorkflow = jest.fn(
+      async (
+        /** @type {{execution: ManifestActivityExecution, workflowId: string, idempotencyKey: string, input: any, callerMetadata: Record<string, any>, actor?: {kind: string, id: string}}} */ {
+          idempotencyKey,
+        },
+      ) => startResult(execution, idempotencyKey),
+    );
+    let readCount = 0;
+    const readRunOutput = jest.fn(async () => {
+      readCount += 1;
+      return readCount === 1
+        ? rawOutput(execution, 'first-run')
+        : rawOutput(execution, 'first-run', 'COMPLETED');
+    });
+    const runWorker = drainingWorker();
+    const command = createDurableWorkflowRunCommand({
+      loadExecution: async () => ({ execution }),
+      loadCliModule: async () => ({
+        toDurableInput: (/** @type {string[]} */ args) => ({ who: args[0] }),
+      }),
+      startWorkflow,
+      runWorker,
+      readRunOutput,
+      inspectRun: async () => ({
+        workflowCursor: {
+          disposition: 'TIMER_WAITING',
+          timerId: 'timer-1',
+        },
+        timers: [
+          {
+            timerId: 'timer-1',
+            stepId: 'wait-step',
+            status: 'WAITING',
+            dueAt: 5_200,
+          },
+        ],
+      }),
+      now: () => 1_000,
+      output,
+      processRef,
+      pollIntervalMs: 0,
+      ownerRetryIntervalMs: 0,
+    });
+
+    await command.parseAsync([
+      'node',
+      'hello',
+      '--name',
+      'first-run',
+      '--',
+      'Ada',
+    ]);
+
+    expect(startWorkflow).toHaveBeenCalledWith({
+      execution,
+      workflowId: WORKFLOW_ID,
+      idempotencyKey: 'first-run',
+      input: { who: 'Ada' },
+      callerMetadata: {},
+      actor: {
+        kind: 'packaged-foreground',
+        id: execution.embeddedRevision.runtime.revisionId,
+      },
+    });
+    expect(runWorker).toHaveBeenCalledWith({
+      execution,
+      signal: expect.any(AbortSignal),
+    });
+    expect(output.progress).toHaveBeenCalledWith(
+      '◷ wait-step — durable timer, 4.2s remaining',
+    );
+    expect(output.progress).toHaveBeenCalledWith(`✓ ${STEP_ID} — committed`);
+    expect(output.success).toHaveBeenCalledWith(
+      '✓ Completed first-run; result retained.',
+    );
+    expect(output.result).toHaveBeenCalledWith(
+      { greeting: 'Hello, Ada!' },
+      '{"greeting":"Hello, Ada!"}',
+    );
+    expect(output.failure).not.toHaveBeenCalled();
+    expect(processRef.exitCode).toBeUndefined();
+  });
+
+  it('prints a completed string result without JSON quotes', async () => {
+    const execution = makeExecution();
+    const output = makeOutput();
+    const { command } = makeCommand({
+      output,
+      readRunOutput: async () =>
+        rawOutput(execution, 'first-run', 'COMPLETED', 'Hello, Ada!'),
+    });
+
+    await command.parseAsync([
+      'node',
+      'hello',
+      '--name',
+      'first-run',
+      '--',
+      'Ada',
+    ]);
+
+    expect(output.result).toHaveBeenCalledWith('Hello, Ada!', 'Hello, Ada!');
+  });
+
+  it('reports retained steps when the exact named run is reopened', async () => {
+    const execution = makeExecution();
+    const output = makeOutput();
+    const { command } = makeCommand({
+      output,
+      startWorkflow: async (
+        /** @type {{idempotencyKey: string}} */ { idempotencyKey },
+      ) => startResult(execution, idempotencyKey, false),
+    });
+
+    await command.parseAsync([
+      'node',
+      'hello',
+      '--name',
+      'first-run',
+      '--',
+      'Ada',
+    ]);
+
+    expect(output.info).toHaveBeenCalledWith(
+      expect.stringContaining('↻ Resuming first-run'),
+    );
+    expect(output.progress).toHaveBeenCalledWith(
+      `✓ ${STEP_ID} — retained; not run again`,
+    );
+  });
+  it('labels only pre-driver outputs as retained on a reused run', async () => {
+    const execution = makeExecution();
+    const output = makeOutput();
+    const retained = [{ stepId: STEP_ID, value: { prepared: true } }];
+    let reads = 0;
+    const { command } = makeCommand({
+      output,
+      startWorkflow: async (
+        /** @type {{idempotencyKey: string}} */ { idempotencyKey },
+      ) => retainedTimerStartResult(execution, idempotencyKey),
+      readRunOutput: async () => {
+        reads += 1;
+        const withTimer = [
+          ...retained,
+          { stepId: WAIT_STEP_ID, value: { waited: true } },
+        ];
+        if (reads === 1) {
+          return rawStepOutputs(execution, 'first-run', retained);
+        }
+        if (reads === 2) {
+          return rawStepOutputs(execution, 'first-run', withTimer);
+        }
+        return rawStepOutputs(
+          execution,
+          'first-run',
+          [...withTimer, { stepId: FINAL_STEP_ID, value: 'Hello, Ada!' }],
+          'COMPLETED',
+        );
+      },
+      inspectRun: async () => ({
+        workflowCursor: {
+          disposition: 'TIMER_WAITING',
+          timerId: 'retained-timer',
+        },
+        timers: [
+          {
+            timerId: 'retained-timer',
+            stepId: WAIT_STEP_ID,
+            status: 'WAITING',
+            dueAt: 7_500,
+          },
+        ],
+      }),
+      now: () => 2_500,
+    });
+
+    await command.parseAsync([
+      'node',
+      'hello',
+      '--name',
+      'first-run',
+      '--',
+      'Ada',
+    ]);
+
+    expect(
+      output.progress.mock.calls
+        .map(([message]) => message)
+        .filter(
+          (message) => typeof message === 'string' && message.startsWith('✓ '),
+        ),
+    ).toEqual([
+      `✓ ${STEP_ID} — retained; not run again`,
+      `✓ ${WAIT_STEP_ID} — committed`,
+      `✓ ${FINAL_STEP_ID} — committed`,
+    ]);
+  });
+
+  it('identifies a retained deadline as the same durable timer on reopen', async () => {
+    const execution = makeExecution();
+    const output = makeOutput();
+    let reads = 0;
+    const { command } = makeCommand({
+      output,
+      startWorkflow: async (
+        /** @type {{idempotencyKey: string}} */ { idempotencyKey },
+      ) => retainedTimerStartResult(execution, idempotencyKey),
+      readRunOutput: async () => {
+        reads += 1;
+        return rawOutput(
+          execution,
+          'first-run',
+          reads === 1 ? 'RUNNING' : 'COMPLETED',
+        );
+      },
+      inspectRun: async () => ({
+        workflowCursor: {
+          disposition: 'TIMER_WAITING',
+          timerId: 'retained-timer',
+        },
+        timers: [
+          {
+            timerId: 'retained-timer',
+            stepId: 'wait-step',
+            status: 'WAITING',
+            dueAt: 7_500,
+          },
+        ],
+      }),
+      now: () => 2_500,
+    });
+
+    await command.parseAsync([
+      'node',
+      'hello',
+      '--name',
+      'first-run',
+      '--',
+      'Ada',
+    ]);
+
+    expect(output.progress).toHaveBeenCalledWith(
+      '◷ wait-step — same durable timer, 5.0s remaining',
+    );
+  });
+
+  it('labels a timer reached after admission as new on a reused run', async () => {
+    const execution = makeExecution();
+    const output = makeOutput();
+    let reads = 0;
+    const { command } = makeCommand({
+      output,
+      startWorkflow: async (
+        /** @type {{idempotencyKey: string}} */ { idempotencyKey },
+      ) => startResult(execution, idempotencyKey, false),
+      readRunOutput: async () => {
+        reads += 1;
+        return rawOutput(
+          execution,
+          'first-run',
+          reads === 1 ? 'RUNNING' : 'COMPLETED',
+        );
+      },
+      inspectRun: async () => ({
+        workflowCursor: {
+          disposition: 'TIMER_WAITING',
+          timerId: 'new-timer',
+        },
+        timers: [
+          {
+            timerId: 'new-timer',
+            stepId: WAIT_STEP_ID,
+            status: 'WAITING',
+            dueAt: 7_500,
+          },
+        ],
+      }),
+      now: () => 2_500,
+    });
+
+    await command.parseAsync([
+      'node',
+      'hello',
+      '--name',
+      'first-run',
+      '--',
+      'Ada',
+    ]);
+
+    expect(output.progress).toHaveBeenCalledWith(
+      `◷ ${WAIT_STEP_ID} — durable timer, 5.0s remaining`,
+    );
+    expect(output.progress).not.toHaveBeenCalledWith(
+      `◷ ${WAIT_STEP_ID} — same durable timer, 5.0s remaining`,
+    );
+  });
+  it('follows an active resident and takes over if that owner exits', async () => {
+    const execution = makeExecution();
+    const output = makeOutput();
+    let workerCalls = 0;
+    /** @type {() => void} */
+    let markSecondWorkerStarted = () => {};
+    const secondWorkerStarted = new Promise((resolve) => {
+      markSecondWorkerStarted = () => resolve(true);
+    });
+    const runWorker = jest.fn(
+      async (
+        /** @type {{execution: ManifestActivityExecution, signal: AbortSignal}} */ {
+          signal,
+        },
+      ) => {
+        workerCalls += 1;
+        if (workerCalls === 1) {
+          const active = new Error('another resident owns this app');
+          active.name = 'LocalServiceSessionActiveError';
+          throw active;
+        }
+        markSecondWorkerStarted();
+        if (!signal.aborted) {
+          await new Promise((resolve) => {
+            signal.addEventListener('abort', resolve, { once: true });
+          });
+        }
+      },
+    );
+    let reads = 0;
+    const readRunOutput = jest.fn(async () => {
+      reads += 1;
+      if (reads === 1) return rawOutput(execution, 'first-run');
+      await secondWorkerStarted;
+      return rawOutput(execution, 'first-run', 'COMPLETED');
+    });
+    const { command } = makeCommand({
+      output,
+      runWorker,
+      readRunOutput,
+    });
+
+    await command.parseAsync([
+      'node',
+      'hello',
+      '--name',
+      'first-run',
+      '--',
+      'Ada',
+    ]);
+
+    expect(runWorker).toHaveBeenCalledTimes(2);
+    expect(output.success).toHaveBeenCalledWith(
+      '✓ Completed first-run; result retained.',
+    );
+    expect(output.failure).not.toHaveBeenCalled();
+  });
+
+  it('drains on SIGINT without cancelling and prints the exact resume command', async () => {
+    const execution = makeExecution();
+    const processRef = makeProcessRef();
+    const output = makeOutput();
+    const readRunOutput = jest.fn(async () => {
+      queueMicrotask(() => processRef.emit('SIGINT'));
+      return rawOutput(execution, 'interruptible');
+    });
+    const { command } = makeCommand({
+      processRef,
+      output,
+      readRunOutput,
+      pollIntervalMs: 10,
+    });
+
+    await command.parseAsync([
+      'node',
+      'hello',
+      '--name',
+      'interruptible',
+      '--',
+      'Ada Lovelace',
+    ]);
+
+    expect(output.paused).toHaveBeenCalledWith(
+      "Paused interruptible without cancelling durable work. Resume with: /tmp/hello wharfie run --name interruptible -- $'Ada Lovelace'",
+    );
+    expect(output.success).not.toHaveBeenCalled();
+    expect(output.failure).not.toHaveBeenCalled();
+    expect(processRef.exitCode).toBe(130);
+  });
+
+  it('keeps a one-shot data root in the quoted resume command', async () => {
+    const execution = makeExecution();
+    const processRef = makeProcessRef();
+    const output = makeOutput();
+    const readRunOutput = jest.fn(async () => {
+      queueMicrotask(() => processRef.emit('SIGINT'));
+      return rawOutput(execution, 'rooted');
+    });
+    const { command } = makeCommand({
+      processRef,
+      output,
+      readRunOutput,
+      environment: {
+        WHARFIE_DATA_ROOT: "/tmp/Wharfie Data's",
+      },
+      pollIntervalMs: 10,
+    });
+
+    await command.parseAsync([
+      'node',
+      'hello',
+      '--name',
+      'rooted',
+      '--',
+      'Ada Lovelace',
+    ]);
+
+    expect(output.paused).toHaveBeenCalledWith(
+      "Paused rooted without cancelling durable work. Resume with: WHARFIE_DATA_ROOT=$'/tmp/Wharfie Data\\x27s' /tmp/hello wharfie run --name rooted -- $'Ada Lovelace'",
+    );
+    expect(output.failure).not.toHaveBeenCalled();
+    expect(processRef.exitCode).toBe(130);
+  });
+});

--- a/test/runtime/host-build-target.test.js
+++ b/test/runtime/host-build-target.test.js
@@ -1,0 +1,52 @@
+/* eslint-env jest */
+/* eslint-disable jsdoc/require-jsdoc */
+
+import { describe, expect, it } from '@jest/globals';
+
+import { getHostBuildTarget } from '../../src/core/runtime/host-build-target.js';
+
+describe('host build target', () => {
+  it('returns a canonical Linux target only after positive glibc detection', () => {
+    expect(
+      getHostBuildTarget({
+        nodeVersion: '24.13.1',
+        platform: 'linux',
+        architecture: 'x64',
+        glibcVersionRuntime: '2.39',
+      }),
+    ).toEqual({
+      nodeVersion: '24.13.1',
+      platform: 'linux',
+      architecture: 'x64',
+      libc: 'glibc',
+    });
+  });
+
+  it.each([undefined, ''])(
+    'rejects Linux when glibc cannot be positively identified (%p)',
+    (glibcVersionRuntime) => {
+      expect(() =>
+        getHostBuildTarget({
+          nodeVersion: '24.13.1',
+          platform: 'linux',
+          architecture: 'x64',
+          glibcVersionRuntime,
+        }),
+      ).toThrow(/positively identified glibc.*musl.*unknown/i);
+    },
+  );
+
+  it('returns non-Linux hosts without a libc identity', () => {
+    expect(
+      getHostBuildTarget({
+        nodeVersion: '24.13.1',
+        platform: 'darwin',
+        architecture: 'arm64',
+      }),
+    ).toEqual({
+      nodeVersion: '24.13.1',
+      platform: 'darwin',
+      architecture: 'arm64',
+    });
+  });
+});

--- a/test/runtime/local-app-storage.test.js
+++ b/test/runtime/local-app-storage.test.js
@@ -27,6 +27,21 @@ import { resolvePackagedAppStorage } from '../../src/core/runtime/packaged-app-s
 
 const DATA_ROOT = '/var/lib/wharfie-nodejs';
 
+const LEGACY_STORAGE_OVERRIDE_NAMES = Object.freeze([
+  'WHARFIE_APPLICATION_STATE_ADAPTER',
+  'WHARFIE_APPLICATION_STATE_PATH',
+  'WHARFIE_CONTROL_ADAPTER',
+  'WHARFIE_CONTROL_PATH',
+  'WHARFIE_DB_ADAPTER',
+  'WHARFIE_DB_PATH',
+  'WHARFIE_EXECUTION_LEDGER_TABLE',
+  'WHARFIE_EXECUTION_PAYLOAD_PATH',
+  'WHARFIE_EXECUTION_PAYLOAD_STORE_ID',
+  'WHARFIE_LEDGER_SERVICE_SESSION_PATH',
+  'WHARFIE_STATE_ADAPTER',
+  'WHARFIE_STATE_DB_PATH',
+]);
+
 describe('local packaged app storage', () => {
   it('derives one immutable app-scoped durable layout', () => {
     const layout = createLocalAppStorageLayout({
@@ -69,11 +84,119 @@ describe('local packaged app storage', () => {
     expect(process.env).toEqual(environmentBefore);
   });
 
+  it('derives every packaged store from one validated foreground data-root override', async () => {
+    const foregroundRoot = '/tmp/wharfie-foreground';
+    const layout = await resolvePackagedAppStorage({
+      environment: { WHARFIE_DATA_ROOT: foregroundRoot },
+      readEmbeddedRevisionRuntimePair: async () => ({
+        runtime: { appId: 'storage-demo' },
+      }),
+    });
+
+    expect(layout).toMatchObject({
+      dataRoot: foregroundRoot,
+      appRoot: `${foregroundRoot}/applications/storage-demo`,
+      controlPath: `${foregroundRoot}/applications/storage-demo/state/control`,
+      payloadPath: `${foregroundRoot}/applications/storage-demo/state/control/execution-payloads`,
+      applicationStatePath: `${foregroundRoot}/applications/storage-demo/state/application-state`,
+      sessionPath: `${foregroundRoot}/applications/storage-demo/state/control/ledger-service-sessions`,
+    });
+  });
+
+  it.each(LEGACY_STORAGE_OVERRIDE_NAMES)(
+    'rejects legacy packaged override %s even without a custom data root',
+    async (name) => {
+      await expect(
+        resolvePackagedAppStorage({
+          environment: {
+            [name]: 'configured',
+          },
+          readEmbeddedRevisionRuntimePair: async () => ({
+            runtime: { appId: 'storage-demo' },
+          }),
+        }),
+      ).rejects.toThrow(new RegExp(`Legacy Wharfie.*${name}`));
+    },
+  );
+
+  it('lists every conflicting legacy storage environment name', async () => {
+    await expect(
+      resolvePackagedAppStorage({
+        environment: {
+          WHARFIE_DATA_ROOT: '/tmp/wharfie-foreground',
+          WHARFIE_CONTROL_PATH: '/tmp/legacy-control',
+          WHARFIE_APPLICATION_STATE_PATH: '/tmp/legacy-application',
+        },
+        readEmbeddedRevisionRuntimePair: async () => ({
+          runtime: { appId: 'storage-demo' },
+        }),
+      }),
+    ).rejects.toThrow(
+      /WHARFIE_APPLICATION_STATE_PATH, WHARFIE_CONTROL_PATH\. Unset/,
+    );
+  });
+
+  it('rejects legacy overrides with an explicit bootstrap data root', async () => {
+    await expect(
+      resolvePackagedAppStorage({
+        dataRoot: DATA_ROOT,
+        environment: { WHARFIE_CONTROL_PATH: '/tmp/legacy-control' },
+        readEmbeddedRevisionRuntimePair: async () => ({
+          runtime: { appId: 'storage-demo' },
+        }),
+      }),
+    ).rejects.toThrow(/Legacy Wharfie.*WHARFIE_CONTROL_PATH/);
+  });
+
+  it.each(['relative/data', '/tmp/../redirect', '', '/tmp/bad\nroot'])(
+    'rejects an unsafe foreground data-root override %#',
+    async (dataRoot) => {
+      await expect(
+        resolvePackagedAppStorage({
+          environment: { WHARFIE_DATA_ROOT: dataRoot },
+          readEmbeddedRevisionRuntimePair: async () => ({
+            runtime: { appId: 'storage-demo' },
+          }),
+        }),
+      ).rejects.toThrow(/canonical absolute path/);
+    },
+  );
+
+  it('requires an explicit bootstrap root to agree before reading embedded identity', async () => {
+    let readIdentity = false;
+    await expect(
+      resolvePackagedAppStorage({
+        dataRoot: DATA_ROOT,
+        environment: { WHARFIE_DATA_ROOT: '/tmp/foreground-data' },
+        readEmbeddedRevisionRuntimePair: async () => {
+          readIdentity = true;
+          return { runtime: { appId: 'storage-demo' } };
+        },
+      }),
+    ).rejects.toThrow(
+      /dataRoot must agree with active WHARFIE_DATA_ROOT packaged storage authority/,
+    );
+    expect(readIdentity).toBe(false);
+  });
+
+  it('accepts an explicit bootstrap root that agrees with the active authority', async () => {
+    const layout = await resolvePackagedAppStorage({
+      dataRoot: DATA_ROOT,
+      environment: { WHARFIE_DATA_ROOT: DATA_ROOT },
+      readEmbeddedRevisionRuntimePair: async () => ({
+        runtime: { appId: 'storage-demo' },
+      }),
+    });
+
+    expect(layout.dataRoot).toBe(DATA_ROOT);
+  });
+
   it('anchors packaged storage to the account instead of ambient XDG or HOME values', async () => {
     await withEnvironment(
       {
         HOME: '/tmp/invocation-home',
         XDG_DATA_HOME: '/tmp/invocation-data',
+        WHARFIE_DATA_ROOT: undefined,
       },
       async () => {
         const accountHome = '/home/service-user';

--- a/test/runtime/resources/node-binary.test.js
+++ b/test/runtime/resources/node-binary.test.js
@@ -6,6 +6,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, promises as fsp } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { Readable } from 'node:stream';
 import { c } from 'tar';
 
 import NodeBinary from '../../../src/core/resources/builds/node-binary.js';
@@ -41,9 +42,13 @@ function sha256(value) {
   return createHash('sha256').update(value).digest('hex');
 }
 
-function makeLinuxBinary() {
+/**
+ * @param {(progress: {version: string, downloadedBytes: number, totalBytes: number|null}) => unknown} [onDownloadProgress]
+ */
+function makeLinuxBinary(onDownloadProgress) {
   return new NodeBinary({
     name: 'node-linux',
+    onDownloadProgress,
     properties: {
       version: '24.13.1',
       platform: 'linux',
@@ -149,6 +154,49 @@ describe('NodeBinary', () => {
     ];
 
     await expect(makeLinuxBinary().getExactVersion()).resolves.toBe('v24.13.1');
+  });
+
+  it('reports bounded byte progress while streaming a Node archive', async () => {
+    setLinuxVersionMetadata();
+    const tmpRoot = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'wharfie-node-download-progress-'),
+    );
+    const destinationPath = path.join(tmpRoot, 'node.tar.gz');
+    const chunks = Array.from({ length: 5 }, () => Buffer.alloc(600 * 1024));
+    const totalBytes = chunks.reduce((total, chunk) => total + chunk.length, 0);
+    const onDownloadProgress = jest.fn();
+    const binary = makeLinuxBinary(onDownloadProgress);
+    const response = /** @type {import('node:http').IncomingMessage} */ (
+      Object.assign(Readable.from(chunks), {
+        statusCode: 200,
+        headers: {
+          'content-type': 'application/gzip',
+          'content-length': String(totalBytes),
+        },
+      })
+    );
+    jest.spyOn(binary, 'requestUrl').mockResolvedValue(response);
+
+    try {
+      await binary.downloadUrlToFile(
+        'https://nodejs.org/node.tar.gz',
+        destinationPath,
+      );
+
+      await expect(fsp.stat(destinationPath)).resolves.toMatchObject({
+        size: totalBytes,
+      });
+      expect(
+        onDownloadProgress.mock.calls.map(([progress]) => progress),
+      ).toEqual([
+        { version: TEST_VERSION, downloadedBytes: 0, totalBytes },
+        { version: TEST_VERSION, downloadedBytes: 1_228_800, totalBytes },
+        { version: TEST_VERSION, downloadedBytes: 2_457_600, totalBytes },
+        { version: TEST_VERSION, downloadedBytes: 3_072_000, totalBytes },
+      ]);
+    } finally {
+      await fsp.rm(tmpRoot, { recursive: true, force: true });
+    }
   });
 
   it('extracts a local unix node archive without downloading anything', async () => {

--- a/test/runtime/services/actor-system-cli-runtime.test.js
+++ b/test/runtime/services/actor-system-cli-runtime.test.js
@@ -578,6 +578,7 @@ describe('packaged application dispatch', () => {
   it('honors the private ledger-service runtime command and arguments', async () => {
     const { runPackagedApp } = await import(PACKAGED_APP_ENTRY_IMPORT);
     const parseAsync = jest.fn(async (_argv, _options) => undefined);
+    const prepareRuntime = jest.fn(async () => undefined);
     const loadDeveloperCliModule = jest.fn(async () => ({
       default: jest.fn(),
     }));
@@ -590,6 +591,7 @@ describe('packaged application dispatch', () => {
       runtimeModules: {
         'ledger-service': { parseAsync },
       },
+      prepareRuntime,
       argv: ['node', 'wharfie-artifact'],
     });
 
@@ -598,6 +600,7 @@ describe('packaged application dispatch', () => {
       { from: 'node' },
     );
     expect(loadDeveloperCliModule).not.toHaveBeenCalled();
+    expect(prepareRuntime).toHaveBeenCalledTimes(1);
   });
 
   it('does not let retired bootstrap variables hijack application argv', async () => {
@@ -736,13 +739,15 @@ describe('packaged application dispatch', () => {
     const loadDeveloperCliModule = jest.fn(async () => ({
       default: developerCli,
     }));
+    const prepareRuntime = jest.fn(async () => undefined);
     const argv = ['node', 'wharfie-artifact', 'serve'];
     clearRuntimeEnvironment();
 
-    await runPackagedApp({ loadDeveloperCliModule, argv });
+    await runPackagedApp({ loadDeveloperCliModule, prepareRuntime, argv });
 
     expect(loadDeveloperCliModule).toHaveBeenCalledTimes(1);
     expect(developerCli).toHaveBeenCalledWith(argv);
+    expect(prepareRuntime).not.toHaveBeenCalled();
   });
 
   it('isolates developer CLI loader failures from runtime and operator dispatch', async () => {

--- a/test/runtime/services/systemd-user-service-manager.test.js
+++ b/test/runtime/services/systemd-user-service-manager.test.js
@@ -74,7 +74,7 @@ async function createTestControlDBClient(adapterName, options) {
 }
 
 /**
- * @param {{artifactBytes?: Buffer, target?: Readonly<Record<string, string>>, linger?: boolean, runtimeMode?: 'matching'|'null'|'stopped'|'unavailable'|'wrong-artifact'|'wrong-revision'|'stale-session'|'wrong-process'|'starting', systemdMode?: 'normal'|'failed', platform?: string, uid?: number, filesystemUid?: number, environment?: Record<string, string | undefined>, packagedStorage?: boolean, managerUnitPaths?: string[], managerDiscoversUnitPathAfterReload?: boolean, managerFragmentPath?: string, unitInitiallyUnknown?: boolean, deriveConfigRoot?: boolean, deriveDataRoot?: boolean, useDefaultXdgConfigHome?: boolean, retainActiveWhenUnitMissingOnReload?: boolean, useProductionControlDB?: boolean, fsOps?: typeof fsp, inspectArtifactBytes?: typeof inspectArtifactBytes, listRuns?: (input: Record<string, any>) => Promise<Record<string, any>>}} [options] - Harness overrides.
+ * @param {{artifactBytes?: Buffer, target?: Readonly<Record<string, string>>, linger?: boolean, runtimeMode?: 'matching'|'null'|'stopped'|'unavailable'|'wrong-artifact'|'wrong-revision'|'stale-session'|'wrong-process'|'starting', systemdMode?: 'normal'|'failed', platform?: string, uid?: number, filesystemUid?: number, environment?: Record<string, string | undefined>, packagedStorage?: boolean, packagedDataRoot?: string, operatorDataRoot?: string, useExplicitDataRoot?: boolean, managerUnitPaths?: string[], managerDiscoversUnitPathAfterReload?: boolean, managerFragmentPath?: string, unitInitiallyUnknown?: boolean, deriveConfigRoot?: boolean, deriveDataRoot?: boolean, useDefaultXdgConfigHome?: boolean, retainActiveWhenUnitMissingOnReload?: boolean, useProductionControlDB?: boolean, fsOps?: typeof fsp, inspectArtifactBytes?: typeof inspectArtifactBytes, listRuns?: (input: Record<string, any>) => Promise<Record<string, any>>}} [options] - Harness overrides.
  * @returns {Promise<Record<string, any>>} - Isolated manager harness.
  */
 async function createHarness(options = {}) {
@@ -90,12 +90,20 @@ async function createHarness(options = {}) {
   );
   const sourceArtifact = await inspectArtifactBytes(artifactPath);
   const homeDirectory = path.join(root, 'account-home');
-  const dataRoot = options.deriveDataRoot
-    ? path.join(homeDirectory, '.local', 'share', 'wharfie-nodejs')
-    : path.join(root, 'data');
   const configRoot = options.deriveConfigRoot
     ? path.join(homeDirectory, '.config')
     : path.join(root, 'config');
+  const environment =
+    options.environment ||
+    (options.useDefaultXdgConfigHome
+      ? { XDG_CONFIG_HOME: `${configRoot}/` }
+      : {});
+  const dataRoot =
+    options.packagedDataRoot ??
+    environment.WHARFIE_DATA_ROOT ??
+    (options.deriveDataRoot
+      ? path.join(homeDirectory, '.local', 'share', 'wharfie-nodejs')
+      : path.join(root, 'data'));
   const layout = createSystemdUserServiceLayout({
     appId: APP_ID,
     dataRoot,
@@ -386,16 +394,16 @@ async function createHarness(options = {}) {
       architecture: target.architecture,
       nodeVersion: target.nodeVersion,
       artifactPath,
-      ...(options.deriveDataRoot ? {} : { dataRoot }),
+      ...(options.useExplicitDataRoot
+        ? { dataRoot }
+        : options.operatorDataRoot !== undefined
+          ? { dataRoot: options.operatorDataRoot }
+          : {}),
       ...(options.deriveConfigRoot ? {} : { configRoot }),
       ...(options.deriveConfigRoot || options.deriveDataRoot
         ? { getHomeDirectory: () => homeDirectory }
         : {}),
-      environment:
-        options.environment ||
-        (options.useDefaultXdgConfigHome
-          ? { XDG_CONFIG_HOME: `${configRoot}/` }
-          : {}),
+      environment,
       getLocalAppStorageLayout: () =>
         options.packagedStorage === false
           ? undefined
@@ -446,6 +454,7 @@ async function createHarness(options = {}) {
     artifactPath,
     dataRoot,
     configRoot,
+    environment,
     layout,
     state,
     calls,
@@ -2345,9 +2354,104 @@ describe('systemd user service manager', () => {
     });
 
     await expect(harness.operator.install()).rejects.toThrow(
-      /WHARFIE_CONTROL_PATH redirects packaged commands/,
+      /Legacy Wharfie storage overrides.*WHARFIE_CONTROL_PATH/,
     );
     expect(harness.calls).toEqual([]);
+  });
+
+  it('keeps the complete service lifecycle under a custom packaged data root', async () => {
+    const customParent = await fsp.mkdtemp(
+      path.join(tmpdir(), 'wharfie-custom-packaged-root-'),
+    );
+    roots.push(customParent);
+    const customDataRoot = path.join(customParent, 'durable');
+    const harness = await createHarness({
+      packagedDataRoot: customDataRoot,
+      environment: { WHARFIE_DATA_ROOT: customDataRoot },
+    });
+
+    expect(harness.layout.dataRoot).toBe(customDataRoot);
+    for (const storagePath of [
+      harness.layout.serviceRoot,
+      harness.layout.stateRoot,
+      harness.layout.controlPath,
+      harness.layout.payloadPath,
+      harness.layout.applicationStatePath,
+      harness.layout.sessionPath,
+      harness.layout.releasesRoot,
+      harness.layout.installationPath,
+    ]) {
+      expect(storagePath.startsWith(`${customDataRoot}${path.sep}`)).toBe(true);
+    }
+
+    await expect(harness.operator.status()).resolves.toMatchObject({
+      health: 'absent',
+    });
+    await expect(harness.operator.install()).resolves.toMatchObject({
+      health: 'healthy',
+    });
+    await expect(harness.operator.converge()).resolves.toMatchObject({
+      health: 'healthy',
+    });
+    await expect(harness.operator.restart()).resolves.toMatchObject({
+      health: 'healthy',
+    });
+    await expect(
+      fsp.readFile(harness.layout.unitPath, 'utf8'),
+    ).resolves.toContain(`Environment="WHARFIE_DATA_ROOT=${customDataRoot}"`);
+
+    await fsp.writeFile(harness.artifactPath, 'packaged-artifact-v2');
+    await expect(harness.operator.update()).resolves.toMatchObject({
+      health: 'healthy',
+    });
+    await expect(harness.operator.prune()).resolves.toMatchObject({
+      outcome: 'nothing-to-prune',
+    });
+    await expect(harness.operator.rollback()).resolves.toMatchObject({
+      health: 'healthy',
+    });
+    await expect(harness.operator.recover()).resolves.toMatchObject({
+      health: 'healthy',
+    });
+
+    await fsp.writeFile(harness.artifactPath, 'packaged-artifact-v1');
+    await expect(harness.operator.uninstall()).resolves.toMatchObject({
+      health: 'absent',
+    });
+    await expect(
+      harness.operator.purge({ confirmation: APP_ID }),
+    ).resolves.toMatchObject({
+      outcome: 'purged',
+    });
+    await expect(fsp.stat(harness.layout.serviceRoot)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('accepts an explicit service data root only when it agrees with packaged storage', async () => {
+    const agreeing = await createHarness({ useExplicitDataRoot: true });
+    await expect(agreeing.operator.status()).resolves.toMatchObject({
+      health: 'absent',
+    });
+
+    const conflictParent = await fsp.mkdtemp(
+      path.join(tmpdir(), 'wharfie-conflicting-packaged-root-'),
+    );
+    roots.push(conflictParent);
+    const conflictingDataRoot = path.join(conflictParent, 'must-not-exist');
+    const conflicting = await createHarness({
+      operatorDataRoot: conflictingDataRoot,
+    });
+    await expect(conflicting.operator.install()).rejects.toThrow(
+      /Explicit systemd user-service dataRoot disagrees with active packaged storage authority/,
+    );
+    expect(conflicting.calls).toEqual([]);
+    await expect(
+      fsp.stat(conflicting.layout.serviceRoot),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.stat(conflictingDataRoot)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
   });
 
   it('is idempotent for the same verified release', async () => {

--- a/test/runtime/services/systemd-user-service.test.js
+++ b/test/runtime/services/systemd-user-service.test.js
@@ -107,16 +107,28 @@ describe('systemd user service contract', () => {
       'WorkingDirectory=/srv/wharfie data%%$/applications/example-app/state',
     );
     expect(unit).toContain(
+      'Environment="WHARFIE_DATA_ROOT=/srv/wharfie data%%$"',
+    );
+    expect(unit).toContain(
       'Environment="WHARFIE_RUNTIME_COMMAND=ledger-service"',
     );
     expect(unit).toContain('Environment="WHARFIE_RUNTIME_ARGS=[]"');
-    expect(unit).toContain('Environment="WHARFIE_EXECUTION_PAYLOAD_STORE_ID="');
-    expect(unit).toContain(
-      'Environment="WHARFIE_EXECUTION_LEDGER_TABLE=wharfie-execution-ledger-v10"',
-    );
-    expect(unit).toContain(
-      'Environment="WHARFIE_CONTROL_PATH=/srv/wharfie data%%$/applications/example-app/state/control"',
-    );
+    for (const name of [
+      'WHARFIE_APPLICATION_STATE_ADAPTER',
+      'WHARFIE_APPLICATION_STATE_PATH',
+      'WHARFIE_CONTROL_ADAPTER',
+      'WHARFIE_CONTROL_PATH',
+      'WHARFIE_DB_ADAPTER',
+      'WHARFIE_DB_PATH',
+      'WHARFIE_EXECUTION_LEDGER_TABLE',
+      'WHARFIE_EXECUTION_PAYLOAD_PATH',
+      'WHARFIE_EXECUTION_PAYLOAD_STORE_ID',
+      'WHARFIE_LEDGER_SERVICE_SESSION_PATH',
+      'WHARFIE_STATE_ADAPTER',
+      'WHARFIE_STATE_DB_PATH',
+    ]) {
+      expect(unit).not.toContain(`Environment="${name}=`);
+    }
     expect(unit).toContain('Restart=on-failure');
     expect(unit).toContain('KillSignal=SIGTERM');
     expect(unit).toContain('KillMode=mixed');

--- a/test/types/app-api.ts
+++ b/test/types/app-api.ts
@@ -20,6 +20,117 @@ const cliOnlyApp = defineApp({
 const cliOnlySchemaVersion: 4 = cliOnlyApp.schemaVersion;
 void cliOnlySchemaVersion;
 
+const shorthandApp = defineApp({
+  id: 'shorthand-app',
+  main: './src/cli.ts',
+  durable: 'greet-later',
+  activityModule: './src/activities.ts',
+  activities: {
+    prepare: {},
+    'say-hello': { export: 'sayHello' },
+    finish: { path: './src/finish.ts' },
+  },
+  workflows: {
+    'greet-later': {
+      steps: [{ id: 'ready', kind: 'signal' }],
+    },
+  },
+});
+const shorthandSchemaVersion: 4 = shorthandApp.schemaVersion;
+const shorthandId: 'shorthand-app' = shorthandApp.app.id;
+const shorthandMainPath: './src/cli.ts' = shorthandApp.cli.entrypoint.path;
+const shorthandMainExport: 'main' = shorthandApp.cli.entrypoint.export;
+const shorthandDurableWorkflow: 'greet-later' =
+  shorthandApp.cli.durable.workflow;
+const shorthandDurableExport: 'toDurableInput' =
+  shorthandApp.cli.durable.export;
+const shorthandSharedActivityPath: './src/activities.ts' =
+  shorthandApp.activities.prepare.entrypoint.path;
+const shorthandDefaultActivityExport: 'prepare' =
+  shorthandApp.activities.prepare.entrypoint.export;
+const shorthandExplicitActivityExport: 'sayHello' =
+  shorthandApp.activities['say-hello'].entrypoint.export;
+const shorthandOverrideActivityPath: './src/finish.ts' =
+  shorthandApp.activities.finish.entrypoint.path;
+void shorthandSchemaVersion;
+void shorthandId;
+void shorthandMainPath;
+void shorthandMainExport;
+void shorthandDurableWorkflow;
+void shorthandDurableExport;
+void shorthandSharedActivityPath;
+void shorthandDefaultActivityExport;
+void shorthandExplicitActivityExport;
+void shorthandOverrideActivityPath;
+
+const shorthandActivityModuleWithoutActivities = {
+  id: 'unused-activity-module',
+  main: './src/cli.ts',
+  activityModule: './src/activities.ts',
+} as const;
+// @ts-expect-error A shared activityModule requires nonempty activities.
+defineApp(shorthandActivityModuleWithoutActivities);
+
+const shorthandActivityModuleWithEmptyActivities = {
+  id: 'empty-shared-activities',
+  main: './src/cli.ts',
+  activityModule: './src/activities.ts',
+  activities: {},
+} as const;
+// @ts-expect-error A shared activityModule requires nonempty activities.
+defineApp(shorthandActivityModuleWithEmptyActivities);
+
+const shorthandWithUndefinedActivityPath = {
+  id: 'undefined-activity-path',
+  main: './src/cli.ts',
+  activityModule: './src/activities.ts',
+  activities: { greet: { path: undefined } },
+} as const;
+// @ts-expect-error A present activity path must be a string.
+defineApp(shorthandWithUndefinedActivityPath);
+
+const shorthandWithUndefinedActivityExport = {
+  id: 'undefined-activity-export',
+  main: './src/cli.ts',
+  activityModule: './src/activities.ts',
+  activities: { greet: { export: undefined } },
+} as const;
+// @ts-expect-error A present activity export must be a string.
+defineApp(shorthandWithUndefinedActivityExport);
+
+const shorthandWithoutActivityPath = {
+  id: 'missing-activity-path',
+  main: './src/cli.ts',
+  activities: { greet: {} },
+} as const;
+// @ts-expect-error Activities need their own path or one shared activityModule.
+defineApp(shorthandWithoutActivityPath);
+
+const shorthandWithoutExplicitExport = {
+  id: 'missing-activity-export',
+  main: './src/cli.ts',
+  activityModule: './src/activities.ts',
+  activities: { 'say-hello': {} },
+} as const;
+// @ts-expect-error Hyphenated logical IDs are not conventional JavaScript export names.
+defineApp(shorthandWithoutExplicitExport);
+
+const shorthandDurableWithoutWorkflow = {
+  id: 'missing-shorthand-workflow',
+  main: './src/cli.ts',
+  durable: 'missing',
+} as const;
+// @ts-expect-error A shorthand durable handoff requires its explicitly named workflow.
+defineApp(shorthandDurableWithoutWorkflow);
+
+const shorthandWithExtraKey = {
+  id: 'extra-shorthand-key',
+  main: './src/cli.ts',
+  description: 'unsupported',
+} as const;
+// @ts-expect-error Shorthand accepts only its exact supported source fields.
+defineApp(shorthandWithExtraKey);
+
 const emptyWorkflowMapApp = {
   schemaVersion: 4,
   app: { id: 'empty-workflow-map' },


### PR DESCRIPTION
## What changed

- adds the compact `defineApp({ id, main })` authoring path and targetless exact-host packaging
- makes package output human-first while retaining the versioned JSON receipt, including backward-compatible bare `--no-pretty`
- lazily prepares native runtime dependencies so ordinary packaged argv stays fast
- adds the named foreground durable workflow command and moves expert activity execution under `wharfie activity run`
- unifies packaged durable storage under one `WHARFIE_DATA_ROOT` and makes that active root authoritative for the systemd user-service lifecycle
- migrates the real SEA verifier to the canonical layout, updates beginner documentation, and records the release-acceptance work honestly

## Why

This turns Wharfie's smallest application into a comprehensible first run and exposes the distinctive interruption/resume experience without forcing beginners through the full manifest or low-level operator surface.

## Root cause fixed

The service manager and packaged verifier still depended on split per-store storage routing. That allowed foreground and resident commands to address different roots and made the new single-root contract fail during real packaged verification. The service now pins the active packaged root, rejects conflicting legacy overrides, and all packaged verifier processes use the same derived layout.

## User impact

A developer can define an ordinary CLI with two manifest fields, package for the current host without a target matrix, receive a useful next step, and run or resume a named durable workflow from the standalone artifact. Custom packaged storage stays coherent across foreground and systemd-managed execution.

## Validation

- `npm run lint`
- all four TypeScript programs
- 9 focused suites: 271 passed, 2 skipped
- package/docs command suites: 54 passed
- packed-package contents: 296 files verified
- two independent read-only diff audits
- local `verify:package:sea` was stopped after exceeding 30 minutes without output; the required hosted Linux SEA check remains authoritative

Closes #138
Advances #139
