### PR TITLE
Make the magnetic demo the canonical quickstart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,18 @@ jobs:
         # Keep portability evidence visible when another validation gate fails.
         if: ${{ always() }}
         run: npm run verify:package:sea
+
+  magnetic-first-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+      - name: install pinned npm
+        working-directory: ${{ runner.temp }}
+        run: npm install --global "$(node --print "require('${GITHUB_WORKSPACE}/package.json').packageManager")"
+      - run: npm ci
+      - name: verify copied starter against packed Wharfie
+        run: npm run verify:magnetic-first-run

--- a/README.md
+++ b/README.md
@@ -26,27 +26,31 @@ The product goal is continuity:
 
 No separate service rewrite, preinstalled Node runtime, Dockerfile, Kubernetes cluster, or hosted orchestration service should be required on the target machine.
 
-The shortest product-level walkthrough is the
-[single-host developer preview](docs/guides/developer-preview.md). Its
+The shortest product moment is now versioned in
+[the hello-world starter](examples/hello-world/README.md). It begins with the
+complete `defineApp({ id, main })` application, then packages a separate
+resumable greeting, kills its foreground durable run, repeats the identical
+command, and verifies the retained terminal result from a later process. The
+repository gate copies that starter and installs only Wharfie's packed npm
+tarball, then hides the copied builder before relocated execution:
+
+```bash
+npm run verify:magnetic-first-run
+```
+
+This is release-candidate evidence, not a published-install claim; final
+acceptance still requires the same gate to pass against the published preview.
+The deeper [single-host developer preview](docs/guides/developer-preview.md)
+and its
 [accepted split builder/clean-target checkpoint](llm/checkpoints/2026-07-29-single-host-developer-preview.md)
-is the strongest current product evidence: unfinished durable work crosses an
-initiating-controller exit on a clean no-Node target. Its result remains
-inspectable through update, rollback, and uninstall; explicit purge then removes
-the application root and completes proof-owned cleanup. The full
-[steady-file golden path](docs/guides/golden-path.md) covers a useful local file
-comparison CLI, the same logic carried through two observations separated by a
-durable timer and a portable control-store reopen, and a verified retained
-result. Its hermetic proof stops before native LMDB, SEA construction, systemd,
-and cloud execution. A separate
-[checksummed Darwin observation](llm/checkpoints/2026-07-28-steady-file-native-sea-proof.md)
-runs the source LMDB resident and generated SEA. A
-[checksummed disposable-Ubuntu arm64 walkthrough](llm/checkpoints/2026-07-28-steady-file-systemd-walkthrough.md)
-now joins the literal source and packaged CLI, default durable start, systemd
-install, later-process history/output reads, meaningful update, rollback,
-uninstall, and VM cleanup with Node absent from the packaged command `PATH`.
-The separate
-[service-substrate proof](llm/checkpoints/2026-07-28-systemd-lifecycle-proof.md)
-covers crash and reboot recovery with a purpose-built fixture.
+cover service installation, unfinished work across controller exit, update,
+rollback, uninstall, purge, and proof-owned cleanup. The full
+[steady-file golden path](docs/guides/golden-path.md) covers the corresponding
+application and operator boundaries. Separate
+[Darwin SEA](llm/checkpoints/2026-07-28-steady-file-native-sea-proof.md),
+[Ubuntu systemd](llm/checkpoints/2026-07-28-steady-file-systemd-walkthrough.md),
+and [service-substrate](llm/checkpoints/2026-07-28-systemd-lifecycle-proof.md)
+proofs retain the deeper native, crash, and reboot evidence.
 
 Inside a packaged application, normal argv belongs to the application. Wharfie
 reserves only `<app> wharfie <command>` for operator commands; internal service

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 **Status:** product-outcome rebaseline
 
-**Last updated:** 2026-08-01
+**Last updated:** 2026-08-06
 
 Wharfie's roadmap now tracks three user-visible outcomes. Historical
 implementation detail belongs in the
@@ -97,13 +97,14 @@ teaching sequence for this outcome. A deliberately tiny canonical application
 answers "What is a Wharfie application?" A separate polished showcase answers
 "Why Wharfie?" by packaging ordinary JavaScript, interrupting durable work after
 one committed step, and resuming it from the standalone artifact without
-repeating that step. An external prototype exercises that path in under
-30 seconds on Darwin arm64, including relocated Node-absent execution and an
-abrupt process kill. Release acceptance remains open until the starter and
-complete retained-output gate are versioned here and run against the published
-preview. The target remains one obvious journey that finishes in under two
-minutes after prerequisites, with experimental machinery outside the beginner
-path.
+repeating that step. The versioned copied-starter gate hides its disposable
+builder, then exercises relocation, Node-absent execution, abrupt process
+death, exact-command resumption, and a later-process verified output read
+against Wharfie's packed npm tarball.
+Release acceptance remains open until the same gate passes against the
+published preview. The target remains one obvious journey that finishes in
+under two minutes after prerequisites, with experimental machinery outside the
+beginner path.
 
 ### What is already concrete
 
@@ -132,10 +133,10 @@ path.
 
 ### Work next
 
-1. Version the magnetic copied starter and complete harness as a release
-   regression gate.
-2. Reduce the beginner-path weight: the current install expands to 202 npm
-   packages (about 138 MB) and the Darwin arm64 artifact is 119 MiB.
+1. Run the versioned magnetic copied-starter gate against the published
+   preview package.
+2. Reduce the beginner-path weight: the versioned gate currently installs 205
+   npm packages and produces a 148.5 MiB Darwin arm64 artifact.
 3. Keep the split builder/clean-target `steady-file` acceptance proof as the
    regression gate for this outcome.
 4. Preserve the irreducible canonical hello-world app and keep failure probes,

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,21 +12,21 @@ without an architectural rewrite.
 The project is being reset around that goal. Wharfie v1's Athena and table
 framework is no longer part of the product, and breaking changes are expected.
 
-The implementation candidate in the
+The versioned
 [magnetic first-run experience](./product/magnetic-first-run.md) turns that
-product promise into a concrete two-minute teaching sequence: a
+product promise into a concrete two-minute teaching sequence: a complete
 `defineApp({ id, main })` ordinary CLI first, followed by one visible durable
-interruption and repeat-to-resume. An external prototype proves relocation,
-Node-absent execution, `SIGKILL`, and exact-command resumption; release
-acceptance remains open until the complete starter and later-process output
-check are versioned here and run against the published preview.
+interruption and repeat-to-resume. Its copied-starter gate proves relocation,
+builder-source unavailability, Node-absent execution, `SIGKILL`, exact-command
+resumption, and a later-process verified output read against Wharfie's packed
+npm tarball. Release acceptance remains open until the same gate passes against
+the published preview.
 
-The shortest concrete walkthrough is the
-[single-host developer preview](./guides/developer-preview.md): install a
-verified package tarball in a clean builder workspace, copy the supported
-starter, package it as an SEA, and promote that artifact to a Linux service.
-The longer [steady-file golden path](./guides/golden-path.md) covers the full
-source and operator surface.
+The deeper
+[single-host developer preview](./guides/developer-preview.md) installs the
+`steady-file` artifact as a Linux service and exercises its lifecycle. The
+longer [steady-file golden path](./guides/golden-path.md) covers the full source
+and operator surface.
 Contributors should use the
 [development validation guide](./guides/development-validation.md) for the
 authoritative clean-install gates and the exact scope and exit condition of

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -18,17 +18,28 @@ Use the exact Node version in `package.json#engines` and the npm version in
 the project reset. The examples below use `wharfie` as shorthand for
 `node ./bin/wharfie` from the repository root.
 
-The [magnetic first-run](../product/magnetic-first-run.md) defines the intended
-shortest product journey. Until its canonical starter is versioned here, the
-[single-host developer preview](./developer-preview.md) is the runnable,
-advanced walkthrough. It packages an SEA and exercises a durable
-activity/timer/activity workflow. The longer
-[golden-path guide](./golden-path.md) records the current command and evidence
-boundaries. A clean Ubuntu walkthrough proves the same-host packaged service
-lifecycle, and the
-[accepted split builder/clean-target proof](../../llm/checkpoints/2026-07-29-single-host-developer-preview.md)
-closes the preview milestone with unfinished work at caller exit, explicit
-purge, and complete cleanup.
+## Run the magnetic starter
+
+The versioned [hello-world starter](../../examples/hello-world/README.md) is the
+shortest product journey. Its repository gate packs the current Wharfie package,
+copies only the starter into a temporary workspace, installs that tarball, and
+runs the complete ordinary-CLI, package, relocate, `SIGKILL`, exact-resume, and
+later-process output proof:
+
+```bash
+npm run verify:magnetic-first-run
+```
+
+The copied starter's first supported journey is `npm install` followed by
+`npm run demo -- Ada` on Node 24.13.1 or newer within Node 24; it does not pin
+an npm patch. That published-package journey remains a release acceptance
+condition until the preview exists; the repository command above tests the
+same files and harness against the locally packed candidate, then hides the
+disposable builder before relocated execution.
+
+The advanced [single-host developer preview](./developer-preview.md) and
+[golden-path guide](./golden-path.md) cover service lifecycle and operator
+boundaries after this first run.
 
 ## Create an app
 

--- a/docs/product/magnetic-first-run.md
+++ b/docs/product/magnetic-first-run.md
@@ -1,12 +1,13 @@
 # Magnetic first-run experience
 
-**Status:** Implementation candidate · **Last updated:** 2026-08-05
+**Status:** Versioned release candidate · **Last updated:** 2026-08-06
 
 This note defines Wharfie's north-star promise as a concrete first-run
-experience. The authoring, packaging, storage, and foreground-resume surfaces
-described here are implemented. An external dogfood project exercises the
-journey, but release acceptance remains open until the starter and its complete
-harness are versioned here and run against the published preview package.
+experience. The authoring, packaging, storage, and foreground-resume surfaces,
+canonical starter, and complete copied-starter harness are versioned here. The
+repository gate runs them against Wharfie's packed npm tarball. Release
+acceptance remains open until that same gate passes against the published
+preview package.
 
 ## The product moment
 
@@ -176,25 +177,30 @@ pinned Wharfie package:
 6. Interrupt the foreground process before the timer becomes due.
 7. Repeat the exact command with the same artifact and data root.
 8. Observe the greeting complete without the first step running twice.
-9. Inspect the retained terminal result from a later process.
+9. Read and verify the retained terminal result from a later process with the
+   explicit sensitive-output command.
 
 The harness is evidence for the experience, not part of the application users
 must understand.
 
-**Prototype evidence (2026-08-01, Darwin arm64):** the external harness passed
-the ordinary, packaging, relocation, interruption, exact-resume, completion,
-and redacted-inspection path against a checksum-pinned working-tree package.
-It inferred `node24.13.1-darwin-arm64`, packaged in 8.3 seconds, produced one
-119.0 MiB artifact, and launched the relocated ordinary CLI in 1.414 seconds
-with Node absent from `PATH` and no durable-runtime extraction. After
-`SIGKILL`, the same artifact, data root, command, run identity, preparation
-attempt, timer identity, and deadline were retained. Repeating the exact
-command completed `wait` and `say-hello`; later-process inspection proved
-one `prepare` invocation and one physical attempt. The complete disposable
-run took under 30 seconds and cleaned up its state. This is useful
-implementation evidence, not the acceptance above: the harness is not yet in
-this repository and it does not yet perform the final later-process
-retained-output read.
+**Versioned candidate gate:** `npm run verify:magnetic-first-run` packs
+Wharfie, copies only `examples/hello-world` into a temporary workspace,
+installs that tarball rather than linking a source checkout, and invokes the
+starter's `npm run demo -- Ada`. The demo begins with the root two-field
+manifest, packages the separate durable showcase, relocates one artifact,
+hides the disposable copied builder and its installed dependencies, runs with
+Node absent from `PATH`, kills the first foreground process with
+`SIGKILL`, repeats the exact artifact/name/arguments/data-root command, proves
+one physical preparation attempt and the original timer, and finally runs
+`wharfie output --confirm-sensitive-output --json` from a later process to
+verify `Hello, Ada!` as the retained terminal result. CI runs this gate in its
+own visible job.
+
+The 2026-08-06 versioned gate passed on Darwin arm64 against the locally
+packed 0.0.15 candidate. Installation added 205 packages, packaging took 9.7
+seconds and produced one 148.5 MiB artifact, and the relocated ordinary CLI
+started in 1.764 seconds. The earlier 2026-08-01 external prototype established
+the 119.0 MiB baseline before the final magnetic runtime slice.
 
 ## Dogfood baseline
 
@@ -209,17 +215,20 @@ private-package tarball and exact Node/npm pins were visible setup concerns,
 and the canonical application demonstrated packaging but not Wharfie's durable
 continuity.
 
-The 2026-08-01 implementation candidate addresses the product-side friction:
+The versioned implementation candidate addresses the product-side friction:
 compact `defineApp()` authoring, automatic exact-host targeting for a
 targetless manifest, human-first package output with an unchanged `--json`
 receipt, lazy native-runtime preparation for ordinary argv, one
 `WHARFIE_DATA_ROOT`, and the repeatable packaged
-`wharfie run --name <name> -- <args>` foreground workflow. The external
-hello-world showcase exercises that path with the measurements above.
+`wharfie run --name <name> -- <args>` foreground workflow. The consumer starter
+accepts Node 24.13.1 or newer within Node 24 without pinning an npm patch. The
+canonical app, polished showcase, hidden harness, and explicitly noncanonical
+playground now have separate in-repository boundaries.
 
-The prototype is an **A- / 9 out of 10 candidate**: the beginner path preserves
-the small application and adds the polished interruption-and-resumption moment
-without exposing the harness machinery. It earns that grade as a shipped
-experience only after the versioned gate passes against the published preview.
-The other main first-run objection is weight: 202 installed npm packages
-(about 138 MB) and a 119 MiB executable.
+The versioned path is an **A- / 9 out of 10 release candidate**: the beginner
+path preserves the small application and adds the polished
+interruption-and-resumption moment without presenting harness machinery as
+application architecture. It earns that grade as a shipped experience only
+after the same gate passes against the published preview.
+The other main first-run objection is weight: this candidate installed 205 npm
+packages and produced a 148.5 MiB Darwin executable.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,23 +1,42 @@
-# Supported Wharfie example
+# Supported Wharfie examples
 
-`steady-file/` is the supported single-host developer-preview starter. It is a
-normal JavaScript CLI plus a schema-version 4 Wharfie manifest, two durable
-activities, and one activity/timer/activity workflow. The normal CLI waits 250
-milliseconds; the durable workflow waits one minute so its work meaningfully
-outlives an initiating shell.
+## Magnetic hello world
 
-The example is included in the Wharfie npm tarball. From a clean builder
-workspace containing an installed Wharfie tarball, copy it without retaining a
-repository checkout:
+`hello-world/` is the canonical first-run starter included in the Wharfie npm
+tarball. It keeps the smallest app, polished durable showcase, acceptance
+harness, and noncanonical playground visibly separate.
+
+From this repository, exercise the copied-starter boundary against a freshly
+packed Wharfie tarball:
+
+```bash
+npm run verify:magnetic-first-run
+```
+
+From an installed preview package, copy the starter without retaining a Wharfie
+source checkout. With Node 24.13.1 or newer within Node 24, install its exact
+pinned Wharfie dependency with any compatible npm and run the same demo:
+
+```bash
+cp -R node_modules/@wharfie/wharfie/examples/hello-world ./hello-world
+cd hello-world
+npm install
+npm run demo -- Ada
+```
+
+That published-package journey remains release acceptance work until the
+preview exists.
+
+## Single-host developer preview
+
+`steady-file/` is the supported deeper single-host starter. It is a normal
+JavaScript CLI plus a schema-version 4 manifest, two durable activities, and
+one activity/timer/activity workflow. Its durable workflow waits one minute so
+work meaningfully outlives an initiating shell.
 
 ```bash
 cp -R node_modules/@wharfie/wharfie/examples/steady-file ./steady-file
 ./node_modules/.bin/wharfie app manifest ./steady-file
-```
-
-Run the ordinary CLI:
-
-```bash
 node ./steady-file/local.js /absolute/path/to/artifact.tar
 ```
 

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,92 @@
+# Hello world with Wharfie
+
+This starter teaches Wharfie in two steps: the smallest understandable
+application, then one interruption-and-resumption moment that shows why Wharfie
+exists.
+
+## See the product moment
+
+Use Node 24.13.1 or newer within Node 24; the starter does not require one
+exact npm patch. Then install the pinned preview dependency:
+
+```bash
+npm install
+npm run demo -- Ada
+```
+
+The demo first runs and compiles the canonical two-field application manifest.
+It then packages the separate resumable showcase as one executable, moves only
+that executable away from its source, and runs it with Node absent from
+`PATH`. Ordinary application argv does not extract the durable runtime.
+The repository acceptance gate additionally hides its disposable copied
+builder and installed dependencies before any relocated command runs.
+
+Next, the demo commits greeting preparation, waits on a Wharfie timer, kills
+the foreground process with `SIGKILL`, and repeats the exact same command:
+
+```text
+./hello wharfie run --name first-run -- Ada
+```
+
+It passes only when the original preparation attempt and timer survive,
+preparation is not repeated, the workflow completes, and a later process
+verifies the retained terminal output:
+
+```text
+Hello, Ada!
+```
+
+All executable copies, durable state, and deliberately interrupted runtime
+files live under one disposable temporary directory. Successful runs remove
+it; a cleanup failure reports the retained path.
+
+## Read the smallest application
+
+`app/hello.js` is ordinary JavaScript:
+
+```js
+export function hello(name = 'world') {
+  return `Hello, ${name}!`;
+}
+
+export function main(argv = process.argv) {
+  process.stdout.write(`${hello(argv[2])}\n`);
+}
+```
+
+`app/wharfie.app.js` is the complete beginner-facing Wharfie declaration:
+
+```js
+import { defineApp } from '@wharfie/wharfie/app';
+
+export default defineApp({
+  id: 'hello-world',
+  main: './hello.js',
+});
+```
+
+Run the ordinary CLI, tests, manifest, and package command separately when you
+want to inspect each piece:
+
+```bash
+npm run hello -- Ada
+npm test
+npm run manifest
+npm run package
+```
+
+The package command infers the exact compatible host and shows its phases,
+target, size, executable path, and next command. Scripts that need the stable
+machine receipt can add `--json`.
+
+## What belongs where
+
+- `app/` is the canonical example. Its manifest has only `id` and `main`.
+- `test/` tests that application without becoming packaged source.
+- `showcase/resumable-hello/` is the polished durable example.
+- `scripts/demo.js` is acceptance machinery, not application architecture.
+- `playground/` is explicitly noncanonical space for unfinished ideas.
+
+Nothing in the playground or repository checkout is required by the packaged
+artifact. The dependency is the exact published Wharfie preview, never a source
+import from a sibling checkout.

--- a/examples/hello-world/app/hello.js
+++ b/examples/hello-world/app/hello.js
@@ -1,0 +1,7 @@
+export function hello(name = 'world') {
+  return `Hello, ${name}!`;
+}
+
+export function main(argv = process.argv) {
+  process.stdout.write(`${hello(argv[2])}\n`);
+}

--- a/examples/hello-world/app/local.js
+++ b/examples/hello-world/app/local.js
@@ -1,0 +1,3 @@
+import { main } from './hello.js';
+
+main();

--- a/examples/hello-world/app/wharfie.app.js
+++ b/examples/hello-world/app/wharfie.app.js
@@ -1,0 +1,6 @@
+import { defineApp } from '@wharfie/wharfie/app';
+
+export default defineApp({
+  id: 'hello-world',
+  main: './hello.js',
+});

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "wharfie-hello-world-demo",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=24.13.1 <25"
+  },
+  "scripts": {
+    "hello": "node ./app/local.js",
+    "test": "node --test ./test/hello.test.js ./showcase/resumable-hello/test/hello.test.js",
+    "demo": "node ./scripts/demo.js",
+    "wharfie": "wharfie",
+    "manifest": "wharfie app manifest ./app",
+    "package": "wharfie app package ./app --output-dir ./dist"
+  },
+  "devDependencies": {
+    "@wharfie/wharfie": "0.0.15"
+  }
+}

--- a/examples/hello-world/playground/README.md
+++ b/examples/hello-world/playground/README.md
@@ -1,0 +1,8 @@
+# Playground
+
+This directory is for experiments, not onboarding. Code here may be verbose,
+temporary, redundant, or deliberately incomplete.
+
+The canonical application in `../app/`, the polished showcase in
+`../showcase/`, and the automated demo do not depend on anything here. Add new
+folders freely without preserving a polished public interface.

--- a/examples/hello-world/scripts/demo.js
+++ b/examples/hello-world/scripts/demo.js
@@ -1,0 +1,889 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  access,
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  stat,
+} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { hello as canonicalHello } from '../app/hello.js';
+import {
+  hello,
+  toDurableInput,
+} from '../showcase/resumable-hello/app/hello.js';
+
+const COMMAND_DIAGNOSTIC_TAIL = 8 * 1024;
+const COMMAND_OUTPUT_LIMIT = 2 * 1024 * 1024;
+const COMMAND_TIMEOUT_MS = 45_000;
+const PACKAGE_TIMEOUT_MS = 240_000;
+const POLL_TIMEOUT_MS = 20_000;
+const CHILD_STOP_TIMEOUT_MS = 15_000;
+const DEMO_PREFIX = 'wharfie-first-run-';
+const ACCEPTANCE_PROOF_PREFIX = 'wharfie-magnetic-first-run-';
+const ACCEPTANCE_BUILDER_ROOT_ENVIRONMENT_VARIABLE =
+  'WHARFIE_MAGNETIC_ACCEPTANCE_BUILDER_ROOT';
+const SUPPORTED_NODE_RANGE = '>=24.13.1 <25';
+const RUN_NAME = 'first-run';
+
+const scriptRoot = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(scriptRoot, '..');
+const canonicalAppRoot = path.join(projectRoot, 'app');
+const canonicalManifestPath = path.join(canonicalAppRoot, 'wharfie.app.js');
+const canonicalTestPath = path.join(projectRoot, 'test', 'hello.test.js');
+const canonicalLocalPath = path.join(canonicalAppRoot, 'local.js');
+const showcaseRoot = path.join(projectRoot, 'showcase', 'resumable-hello');
+const showcaseAppRoot = path.join(showcaseRoot, 'app');
+const showcaseTestPath = path.join(showcaseRoot, 'test', 'hello.test.js');
+const packageJsonPath = path.join(projectRoot, 'package.json');
+const wharfieCliPath = path.join(
+  projectRoot,
+  'node_modules',
+  '@wharfie',
+  'wharfie',
+  'bin',
+  'wharfie',
+);
+
+const activeChildren = new Map();
+let interrupted;
+let retainedTemporaryRoot;
+let temporaryRoot;
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function asError(error) {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function failureMessages(error) {
+  if (error instanceof AggregateError) {
+    return error.errors.flatMap((nestedError) => failureMessages(nestedError));
+  }
+  return [asError(error).message];
+}
+
+function checkInterrupted() {
+  if (interrupted) throw interrupted;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function formatMiB(bytes) {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+function assertSupportedNodeVersion(actual, declaredRange) {
+  invariant(
+    declaredRange === SUPPORTED_NODE_RANGE,
+    `package.json engines.node must remain ${SUPPORTED_NODE_RANGE}.`,
+  );
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/u.exec(actual);
+  invariant(match, `Could not parse the current Node version ${actual}.`);
+  const [, majorSource, minorSource, patchSource] = match;
+  const [major, minor, patch] = [majorSource, minorSource, patchSource].map(
+    Number,
+  );
+  invariant(
+    major === 24 && (minor > 13 || (minor === 13 && patch >= 1)),
+    `This demo requires Node ${SUPPORTED_NODE_RANGE}; found ${actual}.`,
+  );
+}
+
+function createArtifactEnvironment(overrides) {
+  /** @type {Record<string, string>} */
+  const environment = {};
+  const preservedNames = new Set([
+    'COMSPEC',
+    'HOME',
+    'HOMEDRIVE',
+    'HOMEPATH',
+    'LANG',
+    'LANGUAGE',
+    'LOGNAME',
+    'PATHEXT',
+    'SYSTEMROOT',
+    'TZ',
+    'USER',
+    'USERPROFILE',
+    'WINDIR',
+  ]);
+  for (const [name, value] of Object.entries(process.env)) {
+    const normalizedName = name.toUpperCase();
+    if (
+      typeof value === 'string' &&
+      (preservedNames.has(normalizedName) || normalizedName.startsWith('LC_'))
+    ) {
+      environment[name] = value;
+    }
+  }
+  return { ...environment, ...overrides };
+}
+
+async function hideDisposableAcceptanceBuilder() {
+  const configured = process.env[ACCEPTANCE_BUILDER_ROOT_ENVIRONMENT_VARIABLE];
+  if (!configured) return false;
+
+  const [resolvedProjectRoot, resolvedConfiguredRoot, resolvedTemporaryRoot] =
+    await Promise.all([
+      realpath(projectRoot),
+      realpath(configured),
+      realpath(os.tmpdir()),
+    ]);
+  invariant(
+    resolvedConfiguredRoot === resolvedProjectRoot,
+    `${ACCEPTANCE_BUILDER_ROOT_ENVIRONMENT_VARIABLE} must identify this copied starter.`,
+  );
+  const proofRoot = path.dirname(resolvedProjectRoot);
+  invariant(
+    path.dirname(proofRoot) === resolvedTemporaryRoot &&
+      path.basename(proofRoot).startsWith(ACCEPTANCE_PROOF_PREFIX),
+    'Refusing to hide a builder outside a disposable magnetic proof root.',
+  );
+
+  const hiddenBuilderRoot = path.join(proofRoot, 'builder-hidden');
+  await rename(resolvedProjectRoot, hiddenBuilderRoot);
+  try {
+    await access(resolvedProjectRoot);
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return true;
+    }
+    throw error;
+  }
+  throw new Error('The disposable builder remained available after hiding it.');
+}
+
+function parseJson(stdout, label) {
+  try {
+    return JSON.parse(stdout.trim());
+  } catch {
+    throw new Error(`${label} did not emit one JSON document.`);
+  }
+}
+
+function stopChild(child, signal = 'SIGKILL') {
+  const metadata = activeChildren.get(child);
+  if (!metadata || child.exitCode !== null || child.signalCode !== null) return;
+  try {
+    if (metadata.grouped && process.platform !== 'win32') {
+      process.kill(-child.pid, signal);
+    } else {
+      child.kill(signal);
+    }
+  } catch (error) {
+    if (
+      typeof error !== 'object' ||
+      error === null ||
+      !('code' in error) ||
+      error.code !== 'ESRCH'
+    ) {
+      throw error;
+    }
+  }
+}
+
+async function stopActiveChildren() {
+  const children = [...activeChildren.keys()];
+  const failures = [];
+  for (const child of children) {
+    try {
+      stopChild(child);
+    } catch (error) {
+      failures.push(asError(error));
+    }
+  }
+
+  const deadline = Date.now() + CHILD_STOP_TIMEOUT_MS;
+  while (
+    children.some((child) => activeChildren.has(child)) &&
+    Date.now() < deadline
+  ) {
+    await delay(25);
+  }
+  const remaining = children.filter((child) => activeChildren.has(child));
+  if (remaining.length > 0) {
+    failures.push(
+      new Error(
+        `Timed out reaping ${remaining.length} demo child process(es).`,
+      ),
+    );
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      'Could not stop every demo child process.',
+    );
+  }
+}
+
+function capture(stream, state, child, writeThrough) {
+  stream.setEncoding('utf8');
+  stream.on('data', (chunk) => {
+    state.value += chunk;
+    writeThrough?.(chunk);
+    if (Buffer.byteLength(state.value) > COMMAND_OUTPUT_LIMIT) {
+      state.overflow = true;
+      stopChild(child);
+    }
+  });
+}
+
+function waitForStreamEnd(stream) {
+  return new Promise((resolve) => {
+    stream.once('end', resolve);
+    stream.once('close', resolve);
+    stream.once('error', resolve);
+  });
+}
+
+function startCommand(executable, args, options = {}) {
+  checkInterrupted();
+  const grouped = process.platform !== 'win32';
+  const startedAt = Date.now();
+  const timeoutMs = options.timeoutMs ?? COMMAND_TIMEOUT_MS;
+  const child = spawn(executable, args, {
+    cwd: options.cwd ?? projectRoot,
+    detached: grouped,
+    env: options.env ?? process.env,
+    shell: false,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  activeChildren.set(child, { grouped });
+
+  const stdout = { value: '', overflow: false };
+  const stderr = { value: '', overflow: false };
+  capture(child.stdout, stdout, child, options.writeStdout);
+  capture(child.stderr, stderr, child, options.writeStderr);
+  const streamsEnded = Promise.all([
+    waitForStreamEnd(child.stdout),
+    waitForStreamEnd(child.stderr),
+  ]);
+
+  let result;
+  let settled = false;
+  let timedOut = false;
+  let spawnError;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    stopChild(child);
+  }, timeoutMs);
+
+  const closed = new Promise((resolve) => {
+    const finish = async (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      await Promise.race([streamsEnded, delay(500)]);
+      child.stdout.destroy();
+      child.stderr.destroy();
+      activeChildren.delete(child);
+      result = {
+        code,
+        command: [executable, ...args],
+        elapsedMs: Date.now() - startedAt,
+        timeoutMs,
+        signal,
+        stdout: stdout.value,
+        stderr: stderr.value,
+        overflow: stdout.overflow || stderr.overflow,
+        timedOut,
+        error: spawnError,
+      };
+      resolve(result);
+    };
+    child.once('error', (error) => {
+      spawnError = error;
+      finish(null, null);
+    });
+    child.once('close', (code, signal) => {
+      finish(code, signal);
+    });
+  });
+
+  return {
+    child,
+    stdout,
+    stderr,
+    closed,
+    get result() {
+      return result;
+    },
+  };
+}
+
+function commandFailure(executable, result) {
+  if (result.error) return asError(result.error);
+  const rawDetail = (result.stderr || result.stdout || '').trim();
+  const detail =
+    rawDetail.length > COMMAND_DIAGNOSTIC_TAIL
+      ? `…\n${rawDetail.slice(-COMMAND_DIAGNOSTIC_TAIL)}`
+      : rawDetail;
+  const command = (result.command ?? [executable])
+    .map((value) => JSON.stringify(value))
+    .join(' ');
+  if (result.overflow) {
+    return new Error(
+      `${command} output exceeded 2 MiB${detail ? `:\n${detail}` : '.'}`,
+    );
+  }
+  if (result.timedOut) {
+    return new Error(
+      `${command} timed out after ${(result.elapsedMs / 1000).toFixed(1)}s${detail ? `:\n${detail}` : '.'}`,
+    );
+  }
+  return new Error(
+    `${command} exited ${
+      result.signal ? `from ${result.signal}` : `with status ${result.code}`
+    }${detail ? `:\n${detail}` : '.'}`,
+  );
+}
+
+async function runCommand(executable, args, options = {}) {
+  const command = startCommand(executable, args, options);
+  const result = await command.closed;
+  if (interrupted) throw interrupted;
+  if (
+    result.error ||
+    result.overflow ||
+    result.timedOut ||
+    result.code !== 0 ||
+    result.signal
+  ) {
+    throw commandFailure(executable, result);
+  }
+  return result;
+}
+
+async function waitForOutput(command, pattern, label) {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    checkInterrupted();
+    if (pattern.test(command.stdout.value)) return;
+    if (command.result)
+      throw commandFailure(command.child.spawnfile, command.result);
+    await delay(25);
+  }
+  throw new Error(`Timed out waiting for ${label}.`);
+}
+
+async function crashCommand(command) {
+  stopChild(command.child);
+  const result = await command.closed;
+  invariant(
+    result.signal === 'SIGKILL' || result.code === 137,
+    'The foreground run did not exit from the deliberate SIGKILL.',
+  );
+}
+
+async function sha256Base64Url(filePath) {
+  const bytes = await readFile(filePath);
+  return createHash('sha256').update(bytes).digest('base64url');
+}
+
+function assertInspection(view, runId) {
+  invariant(
+    view?.schemaVersion === 8 &&
+      view?.kind === 'wharfie.execution-ledger.run' &&
+      view?.integrity?.verified === true &&
+      view?.run?.runId === runId &&
+      view?.run?.appId === 'resumable-hello',
+    'Wharfie returned an unexpected durable inspection.',
+  );
+}
+
+function waitingEvidence(view) {
+  invariant(view.run.status === 'RUNNING', 'The durable run is not RUNNING.');
+  invariant(
+    view.workflowCursor?.disposition === 'TIMER_WAITING' &&
+      view.workflowCursor?.stepId === 'wait' &&
+      view.workflowCursor?.stepIndex === 1 &&
+      view.workflowCursor.outputs?.some(
+        (output) => output.stepId === 'prepare',
+      ),
+    'The workflow did not retain preparation at its timer.',
+  );
+  const preparation = view.invocations.filter(
+    (invocation) => invocation.activityId === 'prepare-greeting',
+  );
+  invariant(
+    preparation.length === 1 && preparation[0].status === 'COMPLETED',
+    'Preparation was not represented by one completed invocation.',
+  );
+  const attempts = view.attempts.filter(
+    (attempt) => attempt.invocationId === preparation[0].invocationId,
+  );
+  invariant(
+    attempts.length === 1 && attempts[0].status === 'COMPLETED',
+    'Preparation was not represented by one completed physical attempt.',
+  );
+  const timers = view.timers.filter((timer) => timer.stepId === 'wait');
+  invariant(
+    timers.length === 1 && timers[0].status === 'WAITING',
+    'The durable timer is not waiting.',
+  );
+  return {
+    invocationId: preparation[0].invocationId,
+    attemptId: attempts[0].attemptId,
+    timerId: timers[0].timerId,
+    scheduledAt: timers[0].scheduledAt,
+    dueAt: timers[0].dueAt,
+  };
+}
+
+function assertSameWaitingEvidence(before, after) {
+  for (const key of [
+    'invocationId',
+    'attemptId',
+    'timerId',
+    'scheduledAt',
+    'dueAt',
+  ]) {
+    invariant(
+      after[key] === before[key],
+      `The retained ${key} changed after the foreground crash.`,
+    );
+  }
+}
+
+function assertCompleted(view, runId, before) {
+  assertInspection(view, runId);
+  invariant(
+    view.run.status === 'COMPLETED' &&
+      view.workflowCursor?.disposition === 'COMPLETED',
+    'The repeated foreground command did not complete the retained run.',
+  );
+  const timer = view.timers.find(
+    (candidate) => candidate.timerId === before.timerId,
+  );
+  invariant(
+    timer?.status === 'FIRED' && timer.dueAt === before.dueAt,
+    'The repeated command did not fire the original durable timer.',
+  );
+  const preparations = view.invocations.filter(
+    (invocation) => invocation.activityId === 'prepare-greeting',
+  );
+  const preparationAttempts = view.attempts.filter(
+    (attempt) => attempt.invocationId === before.invocationId,
+  );
+  invariant(
+    preparations.length === 1 &&
+      preparations[0].invocationId === before.invocationId &&
+      preparationAttempts.length === 1 &&
+      preparationAttempts[0].attemptId === before.attemptId &&
+      preparationAttempts[0].status === 'COMPLETED',
+    'The committed preparation was repeated after restart.',
+  );
+  const completions = view.invocations.filter(
+    (invocation) => invocation.activityId === 'say-hello',
+  );
+  invariant(
+    completions.length === 1 && completions[0].status === 'COMPLETED',
+    'The final greeting activity did not complete exactly once.',
+  );
+}
+
+async function safelyRemoveTemporaryRoot(root) {
+  const resolvedRoot = path.resolve(root);
+  const resolvedTemporaryDirectory = path.resolve(os.tmpdir());
+  invariant(
+    path.dirname(resolvedRoot) === resolvedTemporaryDirectory &&
+      path.basename(resolvedRoot).startsWith(DEMO_PREFIX),
+    'Refusing to remove an unrecognized demo directory.',
+  );
+  await rm(resolvedRoot, {
+    recursive: true,
+    force: true,
+    maxRetries: 3,
+    retryDelay: 100,
+  });
+}
+
+async function findPackagedArtifact(packageDir) {
+  const entries = await readdir(packageDir, { withFileTypes: true });
+  const artifacts = entries.filter(
+    (entry) =>
+      entry.isFile() &&
+      entry.name.startsWith('resumable-hello-sha256-') &&
+      !entry.name.endsWith('.artifact.json'),
+  );
+  invariant(
+    artifacts.length === 1,
+    'Packaging did not publish exactly one host artifact.',
+  );
+  return path.join(packageDir, artifacts[0].name);
+}
+
+async function runDemo() {
+  const packageJson = parseJson(
+    await readFile(packageJsonPath, 'utf8'),
+    'package.json',
+  );
+  const supportedNodeRange = packageJson.engines?.node;
+  assertSupportedNodeVersion(process.versions.node, supportedNodeRange);
+  const nodeVersion = process.versions.node;
+  await access(wharfieCliPath);
+
+  const name = toDurableInput(process.argv.slice(2)).name;
+  const expectedGreeting = hello(name);
+  const expectedCanonicalGreeting = canonicalHello(name);
+  temporaryRoot = await mkdtemp(path.join(os.tmpdir(), DEMO_PREFIX));
+  const packageDir = path.join(temporaryRoot, 'package');
+  const relocatedDir = path.join(temporaryRoot, 'away-from-source');
+  const emptyPath = path.join(temporaryRoot, 'empty-path');
+  const packageTemp = path.join(temporaryRoot, 'package-tmp');
+  const packageDatabase = path.join(temporaryRoot, 'package-database.json');
+  const packageStateDatabase = path.join(
+    temporaryRoot,
+    'package-state-database.json',
+  );
+  const runtimeTemp = path.join(temporaryRoot, 'runtime-tmp');
+  const dataRoot = path.join(temporaryRoot, 'data');
+  await Promise.all(
+    [
+      packageDir,
+      relocatedDir,
+      emptyPath,
+      packageTemp,
+      runtimeTemp,
+      dataRoot,
+    ].map(async (directory) => await mkdir(directory, { recursive: true })),
+  );
+
+  process.stdout.write('Wharfie magnetic first run\n\n');
+  process.stdout.write('1. Start with the smallest Wharfie application\n');
+  await runCommand(process.execPath, ['--test', canonicalTestPath]);
+  const local = await runCommand(process.execPath, [canonicalLocalPath, name]);
+  invariant(
+    local.stdout === `${expectedCanonicalGreeting}\n`,
+    'Canonical local CLI output changed.',
+  );
+  const manifestSource = await readFile(canonicalManifestPath, 'utf8');
+  invariant(
+    manifestSource.includes('defineApp({') &&
+      manifestSource.includes("id: 'hello-world'") &&
+      manifestSource.includes("main: './hello.js'"),
+    'The canonical manifest is no longer the compact beginner contract.',
+  );
+  process.stdout.write(
+    manifestSource
+      .trimEnd()
+      .split('\n')
+      .map((line) => `   ${line}\n`)
+      .join(''),
+  );
+  const manifestResult = await runCommand(process.execPath, [
+    wharfieCliPath,
+    'app',
+    'manifest',
+    canonicalAppRoot,
+    '--no-pretty',
+  ]);
+  const manifest = parseJson(manifestResult.stdout, 'Wharfie manifest');
+  invariant(
+    manifest?.schemaVersion === 4 &&
+      manifest?.app?.id === 'hello-world' &&
+      manifest?.cli?.entrypoint?.kind === 'node' &&
+      manifest?.cli?.entrypoint?.path === 'hello.js' &&
+      manifest?.cli?.entrypoint?.export === 'main' &&
+      manifest?.cli?.durable === undefined &&
+      manifest?.activities === undefined &&
+      manifest?.workflows === undefined &&
+      manifest?.targets === undefined,
+    'The compact canonical definition did not expand to the expected v4 contract.',
+  );
+  process.stdout.write(`   ${expectedCanonicalGreeting}\n`);
+  process.stdout.write(
+    '   ✓ Canonical test passed; two-field source expanded to strict v4\n\n',
+  );
+
+  process.stdout.write('2. Add durability, then package the host\n');
+  await runCommand(process.execPath, ['--test', showcaseTestPath]);
+  process.stdout.write(
+    `$ wharfie app package ${showcaseAppRoot} --output-dir ${packageDir}\n`,
+  );
+  const packageStartedAt = process.hrtime.bigint();
+  const packaged = await runCommand(
+    process.execPath,
+    [
+      wharfieCliPath,
+      'app',
+      'package',
+      showcaseAppRoot,
+      '--output-dir',
+      packageDir,
+    ],
+    {
+      env: {
+        ...process.env,
+        TMPDIR: packageTemp,
+        WHARFIE_DB_ADAPTER: 'vanilla',
+        WHARFIE_DB_PATH: packageDatabase,
+        WHARFIE_STATE_ADAPTER: 'vanilla',
+        WHARFIE_STATE_DB_PATH: packageStateDatabase,
+      },
+      timeoutMs: PACKAGE_TIMEOUT_MS,
+      writeStderr: (chunk) => process.stderr.write(chunk),
+    },
+  );
+  const packageMilliseconds =
+    Number(process.hrtime.bigint() - packageStartedAt) / 1e6;
+  invariant(
+    packaged.stdout.includes('✓ Packaged resumable-hello') &&
+      packaged.stdout.includes('Next:') &&
+      packaged.stdout.includes('wharfie run --name first-run'),
+    'Wharfie did not emit the expected human package handoff.',
+  );
+  process.stdout.write(packaged.stdout);
+
+  const packagedPath = await findPackagedArtifact(packageDir);
+  process.stdout.write(
+    `   ✓ Packaged in ${(packageMilliseconds / 1000).toFixed(1)}s\n`,
+  );
+  const artifactRecord = parseJson(
+    await readFile(`${packagedPath}.artifact.json`, 'utf8'),
+    'artifact record',
+  );
+  const packagedStats = await stat(packagedPath);
+  invariant(
+    artifactRecord?.target?.nodeVersion === nodeVersion &&
+      artifactRecord?.target?.platform === process.platform &&
+      artifactRecord?.target?.architecture === process.arch &&
+      artifactRecord?.size === packagedStats.size &&
+      artifactRecord?.byteDigest?.value ===
+        (await sha256Base64Url(packagedPath)),
+    'The packaged host artifact did not match its canonical sidecar.',
+  );
+
+  const relocatedArtifact = path.join(relocatedDir, 'hello');
+  await copyFile(packagedPath, relocatedArtifact);
+  await chmod(relocatedArtifact, 0o755);
+  if (await hideDisposableAcceptanceBuilder()) {
+    process.stdout.write(
+      '   ✓ Hid the disposable builder and installed dependencies\n',
+    );
+  }
+  const artifactEnvironment = createArtifactEnvironment({
+    PATH: emptyPath,
+    TMPDIR: runtimeTemp,
+    TMP: runtimeTemp,
+    TEMP: runtimeTemp,
+    NO_COLOR: '1',
+    FORCE_COLOR: '0',
+    WHARFIE_DATA_ROOT: dataRoot,
+  });
+  const runArtifact = async (args, options = {}) =>
+    await runCommand(relocatedArtifact, args, {
+      cwd: relocatedDir,
+      env: artifactEnvironment,
+      ...options,
+    });
+  const ordinaryStartedAt = process.hrtime.bigint();
+  const ordinary = await runArtifact([name]);
+  const ordinaryMilliseconds =
+    Number(process.hrtime.bigint() - ordinaryStartedAt) / 1e6;
+  invariant(
+    ordinary.stdout === `${expectedGreeting}\n`,
+    'The relocated application output changed.',
+  );
+  invariant(
+    (await readdir(dataRoot)).length === 0,
+    'Ordinary application argv unexpectedly materialized durable runtime state.',
+  );
+  invariant(
+    (await readdir(runtimeTemp)).length === 0,
+    'Ordinary application argv unexpectedly extracted the durable runtime.',
+  );
+  process.stdout.write(
+    `   ✓ Copied one ${formatMiB(packagedStats.size)} executable away from source\n`,
+  );
+  process.stdout.write(
+    '   ✓ Ran it with Node absent from PATH and no durable extraction\n',
+  );
+  process.stdout.write(
+    `   ${expectedGreeting} (${ordinaryMilliseconds.toFixed(0)} ms)\n\n`,
+  );
+
+  process.stdout.write('3. Kill it, then repeat the exact command\n');
+  const foregroundArgs = ['wharfie', 'run', '--name', RUN_NAME, '--', name];
+  process.stdout.write(`$ ./hello ${foregroundArgs.join(' ')}\n`);
+  const first = startCommand(relocatedArtifact, foregroundArgs, {
+    cwd: relocatedDir,
+    env: artifactEnvironment,
+    writeStdout: (chunk) => process.stdout.write(chunk),
+    writeStderr: (chunk) => process.stderr.write(chunk),
+  });
+  await waitForOutput(first, /◷ wait — durable timer,/, 'the durable timer');
+  const runIdMatch = /new durable run first-run \(([^)]+)\)\./u.exec(
+    first.stdout.value,
+  );
+  invariant(
+    runIdMatch,
+    'The foreground command did not report its retained run identity.',
+  );
+  const runId = runIdMatch[1];
+  const readInspection = async () => {
+    const inspected = await runArtifact([
+      'wharfie',
+      'inspect',
+      '--run-id',
+      runId,
+      '--json',
+    ]);
+    const view = parseJson(inspected.stdout, 'Wharfie inspection');
+    assertInspection(view, runId);
+    return view;
+  };
+  const beforeCrash = waitingEvidence(await readInspection());
+  const crashedPid = first.child.pid;
+  await crashCommand(first);
+  process.stdout.write(`   ✕ SIGKILL (pid ${crashedPid})\n`);
+
+  const afterCrash = waitingEvidence(await readInspection());
+  assertSameWaitingEvidence(beforeCrash, afterCrash);
+  const remainingSeconds = Math.max(0, beforeCrash.dueAt - Date.now()) / 1000;
+  process.stdout.write(
+    `   ✓ Same preparation attempt and timer retained (${remainingSeconds.toFixed(1)}s remaining)\n\n`,
+  );
+
+  process.stdout.write(`$ ./hello ${foregroundArgs.join(' ')}\n`);
+  const resumed = await runArtifact(foregroundArgs, {
+    writeStdout: (chunk) => process.stdout.write(chunk),
+    writeStderr: (chunk) => process.stderr.write(chunk),
+  });
+  invariant(
+    resumed.stdout.includes(`↻ Resuming ${RUN_NAME}`) &&
+      resumed.stdout.includes('✓ prepare — retained; not run again') &&
+      resumed.stdout.includes(expectedGreeting) &&
+      resumed.stdout.includes(`✓ Completed ${RUN_NAME}; result retained.`),
+    'Repeating the foreground command did not visibly resume and complete.',
+  );
+  const completedView = await readInspection();
+  assertCompleted(completedView, runId, beforeCrash);
+  const retainedOutputResult = await runArtifact([
+    'wharfie',
+    'output',
+    '--run-id',
+    runId,
+    '--confirm-sensitive-output',
+    '--json',
+  ]);
+  const retainedOutput = parseJson(
+    retainedOutputResult.stdout,
+    'Wharfie retained output',
+  );
+  invariant(
+    retainedOutput?.schemaVersion === 1 &&
+      retainedOutput?.kind === 'wharfie.execution-ledger.run-output' &&
+      retainedOutput?.authority === 'none' &&
+      retainedOutput?.authoritative === false &&
+      retainedOutput?.disclosure === 'application-sensitive-unredacted' &&
+      retainedOutput?.integrity?.verified === true &&
+      retainedOutput?.scope?.appId === 'resumable-hello' &&
+      retainedOutput?.scope?.revisionId === completedView.run.revisionId &&
+      retainedOutput?.scope?.runId === runId &&
+      retainedOutput?.snapshot?.runKind === 'workflow' &&
+      retainedOutput?.snapshot?.status === 'COMPLETED' &&
+      retainedOutput?.outputs?.at(-1)?.stepId === 'say-hello' &&
+      retainedOutput?.outputs?.at(-1)?.value === expectedGreeting &&
+      retainedOutput?.terminal?.type === 'completed' &&
+      retainedOutput?.terminal?.result === expectedGreeting,
+    'A later process did not verify the retained terminal greeting.',
+  );
+  process.stdout.write(
+    '   ✓ Later process verified the retained terminal output\n',
+  );
+  process.stdout.write(
+    '   ✓ One command owns start, execution, recovery, and result\n',
+  );
+  process.stdout.write(
+    '   ✓ prepare-greeting: 1 invocation, 1 physical attempt\n',
+  );
+}
+
+const signalHandlers = new Map();
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  const handler = () => {
+    if (interrupted) {
+      process.removeListener(signal, handler);
+      process.kill(process.pid, signal);
+      return;
+    }
+    interrupted = new Error(`Interrupted by ${signal}.`);
+    for (const child of activeChildren.keys()) stopChild(child, 'SIGTERM');
+  };
+  signalHandlers.set(signal, handler);
+  process.on(signal, handler);
+}
+
+let failure;
+try {
+  await runDemo();
+} catch (error) {
+  failure = asError(error);
+} finally {
+  let childrenStopped = true;
+  try {
+    await stopActiveChildren();
+  } catch (error) {
+    childrenStopped = false;
+    failure = failure
+      ? new AggregateError([failure, error], 'Demo and cleanup failed.')
+      : asError(error);
+  }
+  if (temporaryRoot && childrenStopped) {
+    retainedTemporaryRoot = temporaryRoot;
+    try {
+      await safelyRemoveTemporaryRoot(temporaryRoot);
+      retainedTemporaryRoot = undefined;
+    } catch (error) {
+      failure = failure
+        ? new AggregateError([failure, error], 'Demo and cleanup failed.')
+        : asError(error);
+    }
+  } else if (temporaryRoot) {
+    retainedTemporaryRoot = temporaryRoot;
+  }
+  for (const [signal, handler] of signalHandlers) {
+    process.removeListener(signal, handler);
+  }
+}
+
+if (failure) {
+  const messages = failureMessages(failure);
+  process.stderr.write(`\nDemo failed: ${messages[0]}\n`);
+  for (const message of messages.slice(1)) {
+    process.stderr.write(`  - ${message}\n`);
+  }
+  if (retainedTemporaryRoot) {
+    process.stderr.write(
+      `Cleanup incomplete; temporary files retained at:\n${retainedTemporaryRoot}\n`,
+    );
+  }
+  process.exitCode = 1;
+} else {
+  process.stdout.write(
+    '\n✓ The identical foreground command resumed committed work.\n',
+  );
+  process.stdout.write('✓ Disposable demo state was cleaned up.\n');
+}

--- a/examples/hello-world/showcase/resumable-hello/README.md
+++ b/examples/hello-world/showcase/resumable-hello/README.md
@@ -1,0 +1,23 @@
+# Resumable hello
+
+This showcase answers "Why Wharfie?" with one linear workflow:
+
+```text
+prepare greeting -> wait on a durable timer -> say hello
+```
+
+The root `npm run demo -- Ada` command packages this application, moves only
+the executable into a clean temporary directory, and runs it with Node absent
+from `PATH`. It starts the workflow, waits until preparation is committed,
+kills the resident with `SIGKILL`, and inspects the retained state from a new
+process. It then restarts the same executable and reads the terminal greeting
+after the replacement resident exits.
+
+The final proof requires exactly one `prepare-greeting` invocation and one
+physical attempt with the same identities before and after the crash. It also
+requires the original timer identity and deadline to survive.
+
+This demonstrates that work committed before this interruption is not
+redispatched. It does not claim that arbitrary activity code physically
+executes exactly once if a process dies while that activity is running.
+

--- a/examples/hello-world/showcase/resumable-hello/app/hello.js
+++ b/examples/hello-world/showcase/resumable-hello/app/hello.js
@@ -1,0 +1,56 @@
+export const DURABLE_DELAY_MS = 15_000;
+
+const DEFAULT_NAME = 'world';
+const USAGE = 'Usage: resumable-hello [name]';
+
+function normalizeName(value = DEFAULT_NAME) {
+  if (typeof value !== 'string') throw new TypeError(USAGE);
+  const name = value.trim();
+  if (!name || name.length > 80) throw new TypeError(USAGE);
+  return name;
+}
+
+export function hello(name = DEFAULT_NAME) {
+  return `Hello, ${normalizeName(name)}!`;
+}
+
+/**
+ * @param {string[]} args - Application-owned arguments.
+ * @returns {{name: string}} - Durable workflow input.
+ */
+export function toDurableInput(args) {
+  if (!Array.isArray(args) || args.length > 1) throw new TypeError(USAGE);
+  return { name: normalizeName(args[0]) };
+}
+
+export function main(argv = process.argv) {
+  const message = hello(toDurableInput(argv.slice(2)).name);
+  process.stdout.write(`${message}\n`);
+  return message;
+}
+
+/**
+ * @param {{name?: string}} input - Workflow input.
+ * @param {{logger: {info: (message: string, fields: Record<string, string>) => void}}} runtime - Activity runtime.
+ * @returns {{name: string, message: string}} - Prepared greeting.
+ */
+export function prepareGreeting(input, runtime) {
+  const name = normalizeName(input?.name);
+  runtime.logger.info('Prepared greeting', { name });
+  return { name, message: hello(name) };
+}
+
+/**
+ * @param {{name?: string, message?: string}} input - Prepared greeting.
+ * @param {{logger: {info: (message: string, fields: Record<string, string>) => void}}} runtime - Activity runtime.
+ * @returns {string} - Completed greeting.
+ */
+export function sayHello(input, runtime) {
+  const name = normalizeName(input?.name);
+  const message = hello(name);
+  if (input?.message !== message) {
+    throw new TypeError('The prepared greeting is invalid.');
+  }
+  runtime.logger.info('Completed greeting', { name });
+  return message;
+}

--- a/examples/hello-world/showcase/resumable-hello/app/local.js
+++ b/examples/hello-world/showcase/resumable-hello/app/local.js
@@ -1,0 +1,3 @@
+import { main } from './hello.js';
+
+main();

--- a/examples/hello-world/showcase/resumable-hello/app/wharfie.app.js
+++ b/examples/hello-world/showcase/resumable-hello/app/wharfie.app.js
@@ -1,0 +1,37 @@
+import { defineApp } from '@wharfie/wharfie/app';
+
+import { DURABLE_DELAY_MS } from './hello.js';
+
+export default defineApp({
+  id: 'resumable-hello',
+  main: './hello.js',
+  durable: 'hello-after-delay',
+  activityModule: './hello.js',
+  activities: {
+    'prepare-greeting': {
+      export: 'prepareGreeting',
+    },
+    'say-hello': {
+      export: 'sayHello',
+    },
+  },
+  workflows: {
+    'hello-after-delay': {
+      steps: [
+        {
+          id: 'prepare',
+          kind: 'activity',
+          activity: 'prepare-greeting',
+          input: { kind: 'workflow-input' },
+        },
+        { id: 'wait', kind: 'timer', delayMs: DURABLE_DELAY_MS },
+        {
+          id: 'say-hello',
+          kind: 'activity',
+          activity: 'say-hello',
+          input: { kind: 'step-output', step: 'prepare' },
+        },
+      ],
+    },
+  },
+});

--- a/examples/hello-world/showcase/resumable-hello/test/hello.test.js
+++ b/examples/hello-world/showcase/resumable-hello/test/hello.test.js
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  hello,
+  main,
+  prepareGreeting,
+  sayHello,
+  toDurableInput,
+} from '../app/hello.js';
+
+test('the ordinary CLI and durable adapter share greeting input', () => {
+  assert.equal(hello(), 'Hello, world!');
+  assert.deepEqual(toDurableInput(['  Ada  ']), { name: 'Ada' });
+
+  let output = '';
+  const originalWrite = process.stdout.write;
+  process.stdout.write = (value) => {
+    output += value;
+    return true;
+  };
+  try {
+    assert.equal(main(['node', 'hello', 'Ada']), 'Hello, Ada!');
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  assert.equal(output, 'Hello, Ada!\n');
+});
+
+test('the two activities pass one prepared greeting through the timer', () => {
+  /** @type {Array<{message: string, fields: Record<string, string>}>} */
+  const logs = [];
+  /** @type {{logger: {info: (message: string, fields: Record<string, string>) => void}}} */
+  const runtime = {
+    logger: {
+      info(message, fields) {
+        logs.push({ message, fields });
+      },
+    },
+  };
+
+  const prepared = prepareGreeting({ name: 'Ada' }, runtime);
+  assert.deepEqual(prepared, { name: 'Ada', message: 'Hello, Ada!' });
+  assert.equal(sayHello(prepared, runtime), 'Hello, Ada!');
+  assert.deepEqual(logs, [
+    { message: 'Prepared greeting', fields: { name: 'Ada' } },
+    { message: 'Completed greeting', fields: { name: 'Ada' } },
+  ]);
+});
+
+test('invalid names and altered prepared greetings are rejected', () => {
+  assert.throws(() => toDurableInput(['Ada', 'Lovelace']), /Usage/);
+  assert.throws(() => toDurableInput(['   ']), /Usage/);
+  assert.throws(
+    () =>
+      sayHello(
+        { name: 'Ada', message: 'Goodbye, Ada!' },
+        { logger: { info() {} } },
+      ),
+    /prepared greeting is invalid/,
+  );
+});

--- a/examples/hello-world/test/hello.test.js
+++ b/examples/hello-world/test/hello.test.js
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { hello } from '../app/hello.js';
+
+test('says hello', () => {
+  assert.equal(hello(), 'Hello, world!');
+  assert.equal(hello('Ada'), 'Hello, Ada!');
+});

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "src/core/**",
     "src/cli/**",
     "examples/README.md",
+    "examples/hello-world/",
     "examples/steady-file/"
   ],
   "scripts": {
@@ -78,6 +79,7 @@
     "lint": "npm run lint:js",
     "lint:fix": "eslint --max-warnings=0 --fix . && prettier --write \"{*,**/*}.{js,json}\"",
     "verify:package": "node ./scripts/verify-package-contents.js",
+    "verify:magnetic-first-run": "node ./scripts/verify-magnetic-first-run.js",
     "verify:package:sea": "node ./scripts/verify-package-sea.js",
     "verify:service:systemd:lima": "./scripts/run-systemd-user-service-lima.sh",
     "verify:steady-file:systemd:lima": "./scripts/run-steady-file-preview-lima.sh",
@@ -133,6 +135,23 @@
       "coverage/"
     ],
     "overrides": [
+      {
+        "files": [
+          "examples/hello-world/**"
+        ],
+        "rules": {
+          "jsdoc/require-jsdoc": 0
+        }
+      },
+      {
+        "files": [
+          "examples/hello-world/**/wharfie.app.js"
+        ],
+        "rules": {
+          "import/no-unresolved": 0,
+          "n/no-missing-import": 0
+        }
+      },
       {
         "files": [
           "test/**"

--- a/scripts/package-verification.js
+++ b/scripts/package-verification.js
@@ -18,6 +18,19 @@ export const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
 export const NPM_COMMAND = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const REQUIRED_PREVIEW_FILES = Object.freeze([
   'examples/README.md',
+  'examples/hello-world/README.md',
+  'examples/hello-world/app/hello.js',
+  'examples/hello-world/app/local.js',
+  'examples/hello-world/app/wharfie.app.js',
+  'examples/hello-world/package.json',
+  'examples/hello-world/playground/README.md',
+  'examples/hello-world/scripts/demo.js',
+  'examples/hello-world/showcase/resumable-hello/README.md',
+  'examples/hello-world/showcase/resumable-hello/app/hello.js',
+  'examples/hello-world/showcase/resumable-hello/app/local.js',
+  'examples/hello-world/showcase/resumable-hello/app/wharfie.app.js',
+  'examples/hello-world/showcase/resumable-hello/test/hello.test.js',
+  'examples/hello-world/test/hello.test.js',
   'examples/steady-file/README.md',
   'examples/steady-file/activities.js',
   'examples/steady-file/cli.js',
@@ -196,6 +209,25 @@ export function assertPackageContents(manifest) {
     private: true,
     type: 'module',
   });
+  const helloMetadata = readJson(
+    path.join(REPO_ROOT, 'examples', 'hello-world', 'package.json'),
+  );
+  assert.equal(helloMetadata.name, 'wharfie-hello-world-demo');
+  assert.equal(helloMetadata.version, '0.0.0');
+  assert.equal(helloMetadata.private, true);
+  assert.equal(helloMetadata.type, 'module');
+  assert.deepEqual(helloMetadata.engines, { node: '>=24.13.1 <25' });
+  assert.equal(
+    Object.hasOwn(helloMetadata, 'packageManager'),
+    false,
+    'the consumer starter must not require an exact npm patch',
+  );
+  assert.equal(
+    helloMetadata.devDependencies?.['@wharfie/wharfie'],
+    packageMetadata.version,
+    'magnetic starter must pin the exact Wharfie package version',
+  );
+  assert.equal(helloMetadata.scripts?.demo, 'node ./scripts/demo.js');
 
   for (const relativePath of [
     'apps/wharfie-v1',

--- a/scripts/verify-magnetic-first-run.js
+++ b/scripts/verify-magnetic-first-run.js
@@ -1,0 +1,204 @@
+import assert from 'node:assert/strict';
+import {
+  cpSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { x as extractTarball } from 'tar';
+
+import {
+  createPackageTarball,
+  NPM_COMMAND,
+  readJson,
+  REPO_ROOT,
+  runCommand,
+} from './package-verification.js';
+
+const PROOF_PREFIX = 'wharfie-magnetic-first-run-';
+const PACKAGE_NAME = '@wharfie/wharfie';
+
+/**
+ * @returns {string | null} - Exact published package spec, or null for the
+ * current working-tree tarball.
+ */
+function parsePackageSpec() {
+  const args = process.argv.slice(2);
+  if (args.length === 0) return null;
+  if (args.length !== 2 || args[0] !== '--package') {
+    throw new TypeError(
+      'Usage: node scripts/verify-magnetic-first-run.js [--package @wharfie/wharfie@<exact-version>]',
+    );
+  }
+  return args[1];
+}
+
+/**
+ * @param {string} root - Candidate proof root.
+ */
+function removeProofRoot(root) {
+  const resolved = path.resolve(root);
+  assert.equal(path.dirname(resolved), path.resolve(os.tmpdir()));
+  assert.ok(path.basename(resolved).startsWith(PROOF_PREFIX));
+  rmSync(resolved, { recursive: true, force: true });
+}
+
+/**
+ * @param {string} packageSpec - Exact published package spec.
+ * @param {string} root - Disposable proof root.
+ * @param {string} npmCache - Isolated npm cache.
+ * @returns {{manifest: Record<string, any>, tarballPath: string}} - Packed
+ * published dependency.
+ */
+function packPublishedDependency(packageSpec, root, npmCache) {
+  const { stdout } = runCommand(
+    NPM_COMMAND,
+    [
+      'pack',
+      '--json',
+      '--ignore-scripts',
+      '--pack-destination',
+      root,
+      packageSpec,
+    ],
+    {
+      cwd: root,
+      capture: true,
+      env: {
+        ...process.env,
+        npm_config_cache: npmCache,
+        npm_config_update_notifier: 'false',
+      },
+    },
+  );
+  const results = JSON.parse(stdout);
+  assert.ok(Array.isArray(results) && results.length === 1);
+  const manifest = results[0];
+  return {
+    manifest,
+    tarballPath: path.join(root, manifest.filename),
+  };
+}
+
+const packageSpec = parsePackageSpec();
+const packageMetadata = readJson(path.join(REPO_ROOT, 'package.json'));
+const exactPublishedSpec = `${PACKAGE_NAME}@${packageMetadata.version}`;
+if (packageSpec !== null && packageSpec !== exactPublishedSpec) {
+  throw new TypeError(
+    `Magnetic acceptance requires the exact package spec ${exactPublishedSpec}.`,
+  );
+}
+
+const proofRoot = mkdtempSync(path.join(os.tmpdir(), PROOF_PREFIX));
+const unpackedRoot = path.join(proofRoot, 'unpacked-package');
+const starterRoot = path.join(proofRoot, 'hello-world');
+const npmCache = path.join(proofRoot, 'npm-cache');
+let localPackage;
+
+try {
+  const packed =
+    packageSpec === null
+      ? (localPackage = createPackageTarball())
+      : packPublishedDependency(packageSpec, proofRoot, npmCache);
+  assert.equal(packed.manifest.name, PACKAGE_NAME);
+  assert.equal(packed.manifest.version, packageMetadata.version);
+  assert.equal(lstatSync(packed.tarballPath).isFile(), true);
+
+  mkdirSync(unpackedRoot);
+  await extractTarball({
+    cwd: unpackedRoot,
+    file: packed.tarballPath,
+    strict: true,
+  });
+  const packedStarterRoot = path.join(
+    unpackedRoot,
+    'package',
+    'examples',
+    'hello-world',
+  );
+  cpSync(packedStarterRoot, starterRoot, {
+    recursive: true,
+    errorOnExist: true,
+    force: false,
+  });
+
+  const starterMetadataPath = path.join(starterRoot, 'package.json');
+  const starterMetadataBefore = readFileSync(starterMetadataPath, 'utf8');
+  const starterMetadata = JSON.parse(starterMetadataBefore);
+  assert.equal(
+    starterMetadata.devDependencies?.[PACKAGE_NAME],
+    packageMetadata.version,
+    'the copied starter must pin the exact Wharfie preview version',
+  );
+
+  const installArgs =
+    packageSpec === null
+      ? [
+          'install',
+          '--no-audit',
+          '--no-fund',
+          '--no-save',
+          '--package-lock=false',
+          packed.tarballPath,
+        ]
+      : ['install', '--no-audit', '--no-fund'];
+  process.stdout.write(
+    packageSpec === null
+      ? `Installing ${PACKAGE_NAME}@${packageMetadata.version} from one packed tarball\n`
+      : `Running the copied starter's npm install for ${packageSpec}\n`,
+  );
+  runCommand(NPM_COMMAND, installArgs, {
+    cwd: starterRoot,
+    env: {
+      ...process.env,
+      npm_config_cache: npmCache,
+      npm_config_update_notifier: 'false',
+    },
+  });
+  assert.equal(
+    readFileSync(starterMetadataPath, 'utf8'),
+    starterMetadataBefore,
+    'acceptance installation must not rewrite the copied starter',
+  );
+
+  const installedPackageRoot = path.join(
+    starterRoot,
+    'node_modules',
+    '@wharfie',
+    'wharfie',
+  );
+  const installedMetadata = readJson(
+    path.join(installedPackageRoot, 'package.json'),
+  );
+  assert.equal(installedMetadata.name, PACKAGE_NAME);
+  assert.equal(installedMetadata.version, packageMetadata.version);
+  assert.ok(
+    realpathSync(installedPackageRoot).startsWith(
+      `${realpathSync(starterRoot)}${path.sep}`,
+    ),
+    'the starter resolved Wharfie outside its copied workspace',
+  );
+
+  process.stdout.write('Running the copied magnetic starter\n');
+  runCommand(NPM_COMMAND, ['run', 'demo', '--', 'Ada'], {
+    cwd: starterRoot,
+    env: {
+      ...process.env,
+      NODE_PATH: undefined,
+      WHARFIE_MAGNETIC_ACCEPTANCE_BUILDER_ROOT: starterRoot,
+      npm_config_cache: npmCache,
+      npm_config_update_notifier: 'false',
+    },
+  });
+  process.stdout.write(
+    `Verified magnetic first run with ${packed.manifest.filename}\n`,
+  );
+} finally {
+  localPackage?.cleanup();
+  removeProofRoot(proofRoot);
+}

--- a/test/cli/docs-command-surface.test.js
+++ b/test/cli/docs-command-surface.test.js
@@ -102,6 +102,80 @@ function expectCommandShape(
 }
 
 describe('docs command surface', () => {
+  it('keeps the magnetic copied starter small, separated, and release-gated', async () => {
+    const [
+      rootMetadataSource,
+      starterMetadataSource,
+      starterReadme,
+      canonicalManifest,
+      demoSource,
+      verificationSource,
+      playgroundReadme,
+      quickstart,
+      workflow,
+    ] = await Promise.all(
+      [
+        'package.json',
+        'examples/hello-world/package.json',
+        'examples/hello-world/README.md',
+        'examples/hello-world/app/wharfie.app.js',
+        'examples/hello-world/scripts/demo.js',
+        'scripts/verify-magnetic-first-run.js',
+        'examples/hello-world/playground/README.md',
+        'docs/guides/quickstart.md',
+        '.github/workflows/ci.yml',
+      ].map((relativePath) =>
+        fsp.readFile(path.join(repoRoot, relativePath), 'utf8'),
+      ),
+    );
+    const rootMetadata = JSON.parse(rootMetadataSource);
+    const starterMetadata = JSON.parse(starterMetadataSource);
+
+    expect(starterMetadata.devDependencies['@wharfie/wharfie']).toBe(
+      rootMetadata.version,
+    );
+    expect(starterMetadata.engines).toEqual({ node: '>=24.13.1 <25' });
+    expect(starterMetadata).not.toHaveProperty('packageManager');
+    expect(starterMetadata.scripts.demo).toBe('node ./scripts/demo.js');
+    expect(rootMetadata.scripts['verify:magnetic-first-run']).toBe(
+      'node ./scripts/verify-magnetic-first-run.js',
+    );
+    expect(rootMetadata.files).toContain('examples/hello-world/');
+    expect(canonicalManifest.trim()).toBe(
+      [
+        "import { defineApp } from '@wharfie/wharfie/app';",
+        '',
+        'export default defineApp({',
+        "  id: 'hello-world',",
+        "  main: './hello.js',",
+        '});',
+      ].join('\n'),
+    );
+    expect(starterReadme.indexOf('npm run demo -- Ada')).toBeLessThan(
+      starterReadme.indexOf('npm run hello -- Ada'),
+    );
+    expect(demoSource).toContain('canonicalAppRoot');
+    expect(demoSource).toContain('showcaseAppRoot');
+    expect(demoSource).toContain('hideDisposableAcceptanceBuilder');
+    expect(demoSource).toContain('createArtifactEnvironment');
+    expect(verificationSource).toContain(
+      'WHARFIE_MAGNETIC_ACCEPTANCE_BUILDER_ROOT: starterRoot',
+    );
+    expect(verificationSource).toContain(
+      ": ['install', '--no-audit', '--no-fund'];",
+    );
+    expect(demoSource).toContain("'--confirm-sensitive-output'");
+    expect(demoSource).toContain(
+      'Later process verified the retained terminal output',
+    );
+    expect(demoSource).not.toContain('/Users/');
+    expect(demoSource).not.toContain('file:');
+    expect(playgroundReadme).toContain('not onboarding');
+    expect(quickstart).toContain('npm run verify:magnetic-first-run');
+    expect(workflow).toContain('magnetic-first-run:');
+    expect(workflow).toContain('npm run verify:magnetic-first-run');
+  });
+
   it('keeps the runtime app API aligned with its declared public exports', async () => {
     const runtimeModule = await import('../../src/app.js');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,11 @@
     "scripts/run-aws-host-retained-storage-host-preflight-sea-linux-docker.js",
     "scripts/sea-inspector.js",
     "scripts/verify-package-contents.js",
+    "scripts/verify-magnetic-first-run.js",
     "types/**/*.d.ts"
+  ],
+  "exclude": [
+    "examples/hello-world/scripts/demo.js",
+    "examples/hello-world/**/wharfie.app.js"
   ]
 }

--- a/tsconfig.sea-verifier.json
+++ b/tsconfig.sea-verifier.json
@@ -7,6 +7,7 @@
   "files": [
     "scripts/verify-aws-host-retained-storage-host-preflight-sea-linux.js",
     "scripts/verify-package-sea.js",
+    "examples/hello-world/scripts/demo.js",
     "scripts/steady-file-preview-handoff.js",
     "scripts/verify-steady-file-preview-target.js",
     "scripts/verify-steady-file-systemd-linux.js",


### PR DESCRIPTION
## What this ships

- versions the smallest `defineApp({ id, main })` hello-world starter
- keeps the canonical app, durable showcase, acceptance harness, and messy playground separate
- makes `npm run demo -- Ada` the first supported journey
- adds a visible CI gate that packs Wharfie, copies the starter, installs only that candidate, packages and relocates one executable, kills it with `SIGKILL`, repeats the exact command, and verifies retained output from a later process
- removes exact npm/toolchain ceremony from the consumer starter
- hides the copied builder and installed dependencies and scrubs builder paths before standalone execution

## Evidence

- lint and all four typecheck programs pass
- focused docs/example tests: 19/19
- package verification: 309 files
- full magnetic first-run gate passes on Darwin arm64, including builder hiding, Node-absent ordinary argv, exact kill/resume identity, one physical preparation attempt, retained timer, and later-process `Hello, Ada!`

The repository gate uses a freshly packed candidate. The same gate's `--package` mode uses the starter's bare `npm install`; #140 remains responsible for running that mode against the actual published preview and pinning registry integrity.

Closes #139.