### PR TITLE
Keep AWS dependencies out of the magnetic first run

### DIFF
--- a/bin/wharfie
+++ b/bin/wharfie
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { main } from '../src/cli/entry.js';
+import { AwsProviderUnavailableError } from '../src/core/runtime/aws-provider-module.js';
 
 main(process.argv).catch((err) => {
   // eslint-disable-next-line no-console
-  console.error(err);
+  console.error(err instanceof AwsProviderUnavailableError ? err.message : err);
   process.exitCode = 1;
 });

--- a/docs/guides/developer-preview.md
+++ b/docs/guides/developer-preview.md
@@ -24,9 +24,8 @@ The proof creates a builder VM, installs the repository tarball into a clean
 consumer, packages revisions A and B, and copies an exact checksummed six-file
 handoff to the host. It deletes the builder before creating a separate target
 VM with no Node, npm, repository mount, or container runtime. Two distinct host
-controller processes then prepare unfinished durable work and return to
-observe and complete it before exercising update, rollback, uninstall, prune,
-and purge.
+controller processes then prepare unfinished durable work and return to observe
+and complete it before exercising update, rollback, uninstall, prune, and purge.
 
 Builder and target VMs run sequentially. The proof keeps its Lima home and
 cache inside one owned temporary directory and removes the VMs, cache, package
@@ -39,8 +38,7 @@ before Lima creates a VM or downloads an image.
 The accepted commit is `39be8d604fedb99ee798c64dcf50a74c456606c4`;
 its [receipt directory](../../llm_artifacts/steady-file-systemd-proof/39be8d604fedb99ee798c64dcf50a74c456606c4/)
 and [checkpoint](../../llm/checkpoints/2026-07-29-single-host-developer-preview.md)
-are retained. The command remains a reusable regression gate for later
-commits.
+are retained. The command remains a reusable regression gate for later commits.
 
 ## Create the Wharfie handoff
 
@@ -50,18 +48,26 @@ using the exact Node and npm versions in `package.json`:
 ```bash
 npm ci
 npm run verify:package
+npm run verify:provider-boundary
 mkdir -p /absolute/path/to/wharfie-handoff
 npm pack --ignore-scripts \
   --pack-destination /absolute/path/to/wharfie-handoff
+npm pack --workspace @wharfie/aws --ignore-scripts \
+  --pack-destination /absolute/path/to/wharfie-handoff
 ```
 
-`verify:package` creates and removes its own temporary tarball and npm cache.
-The final `npm pack` command creates the intentional handoff artifact only in
-the explicit directory.
+The commands create two intentional handoff artifacts:
+
+- `wharfie-wharfie-0.0.15.tgz` is the provider-free core builder.
+- `wharfie-aws-0.0.15.tgz` is the version-matched AWS companion.
+
+The verification commands create and remove their own temporary tarballs, npm
+caches, clean consumers, and relocated SEA proof. The final `npm pack` commands
+write only to the explicit handoff directory.
 
 ## Build from the installed starter
 
-In a clean builder workspace:
+In a clean builder workspace, install core without bypassing package scripts:
 
 ```bash
 npm init -y
@@ -79,6 +85,23 @@ node ./steady-file/local.js /absolute/path/to/artifact.tar
   --output-dir ./dist \
   --json
 ```
+
+This core-only path creates a provider-free SEA. If the application must expose
+working AWS deployment operations, install both handoff artifacts before
+packaging:
+
+```bash
+npm install --no-audit --no-fund \
+  /absolute/path/to/wharfie-handoff/wharfie-wharfie-0.0.15.tgz \
+  /absolute/path/to/wharfie-handoff/wharfie-aws-0.0.15.tgz
+```
+
+Wharfie accepts only the exact matching companion and embeds it into the
+generated app. The finished executable remains relocatable and does not need
+the builder's `node_modules`. Omitting the companion keeps the AWS SDK graph
+out of the SEA. It permanently seals deployment operations unavailable while
+leaving deployment help available. Adding a companion beside that executable
+later cannot change its packaged capability decision.
 
 Use `node24.13.1-linux-arm64-glibc` for an arm64 target. The package receipt
 names the generated executable and its content-addressed verification record.

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -32,16 +32,45 @@ and any default coverage output in one owned OS-temporary root and removes it
 after success, failure, or a child signal. Use `npm run test:coverage` when
 coverage is wanted explicitly. The clean-install path `npm run test:ci` invokes
 that coverage run, along with lint and type checks, package-tarball
-verification, and a production dependency audit. Native LMDB and generated-SEA
-proofs are separate because they exercise host file-locking and platform
-packaging behavior.
+verification, the provider-boundary receipt, and a production dependency audit.
+Native LMDB and generated-SEA proofs are separate because they exercise host
+file-locking and platform packaging behavior.
 
-Local `app` and `ops` commands do not require cloud credentials or global
-Wharfie configuration. The source CLI now also mounts an experimental
-`deployment` group, and generated application SEAs mount the same group at
-`<app> wharfie deployment ...`. These commands use the operator's ordinary AWS
-credential chain. They do not accept or persist credentials in the app
-manifest, DeploymentProfileV2, plan, or artifact.
+## AWS deployment companion
+
+The core `@wharfie/wharfie` production install deliberately contains no AWS SDK
+or Smithy packages. Local `app` and `ops` commands, provider-free application
+builds, and deployment help need only the core package. AWS deployment
+operations use the one version-matched `@wharfie/aws` companion. A source
+checkout receives it through `npm ci`; a clean tarball consumer installs the
+matching companion tarball next to the core tarball. Neither package is
+registry-published in this developer preview.
+
+If the companion is absent, malformed, or version-incompatible, a deployment
+operation stops before Wharfie creates local state or contacts AWS and prints
+one matching-version install instruction. The companion exposes an exact,
+validated set of AWS constructors and functions; it is not a generic provider
+or plugin API.
+
+Application packaging follows the same explicit boundary:
+
+- A builder with core only creates a provider-free SEA whose bundle contains no
+  AWS SDK or Smithy graph. That executable is sealed provider-free: placing a
+  companion beside it later cannot enable deployment operations.
+- A builder with the exact companion installed beside core validates and embeds
+  that companion into the generated app SEA. The relocated executable does not
+  resolve `node_modules` at runtime.
+
+Build provenance observes the prepared entry after this decision, followed by
+the bundled JavaScript, SEA blob, and final executable bytes. Therefore provider
+embedding changes the recorded entry-code evidence and all downstream artifact
+digests. `npm run verify:provider-boundary` exercises both clean installs, keeps
+the canonical core install within its dependency and 85 MiB limits, and runs a
+provider-enabled SEA after hiding its source install and clearing `PATH`.
+
+The source CLI mounts the experimental `deployment` group. These commands use
+the operator's ordinary AWS credential chain. They do not accept or persist
+credentials in the app manifest, DeploymentProfileV2, plan, or artifact.
 
 Deployment profiles are canonical `wpr2` operator-input JSON documents supplied
 with `--profile`; they remain separate from `wharfie.app.js`. Authors create
@@ -50,11 +79,11 @@ Source plan and direct apply package and durably pre-stage a selected SEA;
 source prepared-plan apply and reconcile consume exact durable staged evidence.
 Packaged plan, direct apply, prepared-plan apply, and non-destroy reconcile
 instead validate the SEA running the command. Source and packaged plan JSON are
-not interchangeable. Active destroy recovery remains durable-only.
-Packaged commands accept neither source `--dir` nor `--output-dir`. This command
-surface has focused automated evidence but no clean-account lifecycle proof or
-complete service-readiness claim. Wharfie provisions only its fixed capability
-substrate and is not a general infrastructure-as-code system.
+not interchangeable. Active destroy recovery remains durable-only. Packaged
+commands accept neither source `--dir` nor `--output-dir`. This command surface
+has focused automated evidence but no clean-account lifecycle proof or complete
+service-readiness claim. Wharfie provisions only its fixed capability substrate
+and is not a general infrastructure-as-code system.
 
 See the [Quickstart](./quickstart.md) for the working local and experimental
 deployment command surfaces.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,19 +8,13 @@
       "name": "@wharfie/wharfie",
       "version": "0.0.15",
       "license": "Apache-2.0",
+      "workspaces": [
+        "packages/aws"
+      ],
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.1090.0",
-        "@aws-sdk/client-ec2": "^3.1091.0",
-        "@aws-sdk/client-iam": "^3.1092.0",
-        "@aws-sdk/client-s3": "^3.1091.0",
-        "@aws-sdk/client-ssm": "^3.1091.0",
-        "@aws-sdk/client-sts": "^3.1091.0",
-        "@aws-sdk/credential-providers": "^3.1090.0",
-        "@aws-sdk/lib-dynamodb": "^3.1090.0",
         "@babel/parser": "^7.28.5",
         "@npmcli/arborist": "^9.9.0",
         "@paralleldrive/cuid2": "^2.2.2",
-        "@smithy/util-retry": "^3.0.3",
         "chalk": "^4.1.0",
         "commander": "^12.1.0",
         "diff": "^5.2.0",
@@ -46,6 +40,7 @@
         "@types/jest": "^30.0.0",
         "@types/node": "^24.0.0",
         "@types/npmcli__arborist": "^6.3.1",
+        "@wharfie/aws": "0.0.15",
         "eslint": "^8.45.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-config-standard": "^17.1.0",
@@ -59,6 +54,14 @@
       },
       "engines": {
         "node": "24.13.1"
+      },
+      "peerDependencies": {
+        "@wharfie/aws": "0.0.15"
+      },
+      "peerDependenciesMeta": {
+        "@wharfie/aws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/checksums": {
@@ -4065,6 +4068,10 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@wharfie/aws": {
+      "resolved": "packages/aws",
+      "link": true
     },
     "node_modules/abbrev": {
       "version": "4.0.0",
@@ -11155,6 +11162,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/aws": {
+      "name": "@wharfie/aws",
+      "version": "0.0.15",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "3.1090.0",
+        "@aws-sdk/client-ec2": "3.1091.0",
+        "@aws-sdk/client-iam": "3.1092.0",
+        "@aws-sdk/client-s3": "3.1091.0",
+        "@aws-sdk/client-ssm": "3.1091.0",
+        "@aws-sdk/client-sts": "3.1091.0",
+        "@aws-sdk/credential-providers": "3.1090.0",
+        "@aws-sdk/lib-dynamodb": "3.1090.0",
+        "@smithy/util-retry": "3.0.11"
+      },
+      "engines": {
+        "node": "24.13.1"
+      },
+      "peerDependencies": {
+        "@wharfie/wharfie": "0.0.15"
+      },
+      "peerDependenciesMeta": {
+        "@wharfie/wharfie": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   },
   "homepage": "https://github.com/wharfie/wharfie#readme",
   "packageManager": "npm@11.12.0",
+  "workspaces": [
+    "packages/aws"
+  ],
   "engines": {
     "node": "24.13.1"
   },
@@ -71,7 +74,7 @@
     "test:update": "TZ=UTC node ./test/run-jest.js --silent --updateSnapshot",
     "test": "TZ=UTC node ./test/run-jest.js --silent",
     "test:coverage": "TZ=UTC node ./test/run-jest.js --silent --coverage",
-    "test:ci": "npm run lint && npm run typecheck && npm run test:coverage && npm run verify:package && npm run audit:prod",
+    "test:ci": "npm run lint && npm run typecheck && npm run test:coverage && npm run verify:package && npm run verify:provider-boundary && npm run audit:prod",
     "test:native": "WHARFIE_RUN_NATIVE_EXTERNALS=1 TZ=UTC node ./test/run-jest.js --silent --runInBand test/cli/app/kitchen-sink-native-externals.test.js",
     "test:full": "npm run test:ci && npm run test:native && npm run verify:package:sea",
     "audit:prod": "npm audit --omit=dev --audit-level=moderate",
@@ -80,6 +83,7 @@
     "lint:fix": "eslint --max-warnings=0 --fix . && prettier --write \"{*,**/*}.{js,json}\"",
     "verify:package": "node ./scripts/verify-package-contents.js",
     "verify:magnetic-first-run": "node ./scripts/verify-magnetic-first-run.js",
+    "verify:provider-boundary": "node ./scripts/verify-provider-boundary.js",
     "verify:package:sea": "node ./scripts/verify-package-sea.js",
     "verify:service:systemd:lima": "./scripts/run-systemd-user-service-lima.sh",
     "verify:steady-file:systemd:lima": "./scripts/run-steady-file-preview-lima.sh",
@@ -219,6 +223,7 @@
     }
   },
   "devDependencies": {
+    "@wharfie/aws": "0.0.15",
     "@babel/eslint-parser": "^7.28.5",
     "@babel/plugin-syntax-import-attributes": "^7.27.1",
     "@jest/globals": "^30.4.1",
@@ -237,19 +242,18 @@
     "prettier": "^3.7.4",
     "typescript": "^5.0.4"
   },
+  "peerDependencies": {
+    "@wharfie/aws": "0.0.15"
+  },
+  "peerDependenciesMeta": {
+    "@wharfie/aws": {
+      "optional": true
+    }
+  },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.1090.0",
-    "@aws-sdk/client-ec2": "^3.1091.0",
-    "@aws-sdk/client-iam": "^3.1092.0",
-    "@aws-sdk/client-s3": "^3.1091.0",
-    "@aws-sdk/client-ssm": "^3.1091.0",
-    "@aws-sdk/client-sts": "^3.1091.0",
-    "@aws-sdk/credential-providers": "^3.1090.0",
-    "@aws-sdk/lib-dynamodb": "^3.1090.0",
     "@babel/parser": "^7.28.5",
     "@npmcli/arborist": "^9.9.0",
     "@paralleldrive/cuid2": "^2.2.2",
-    "@smithy/util-retry": "^3.0.3",
     "chalk": "^4.1.0",
     "commander": "^12.1.0",
     "diff": "^5.2.0",

--- a/packages/aws/LICENSE
+++ b/packages/aws/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/aws/README.md
+++ b/packages/aws/README.md
@@ -1,0 +1,18 @@
+# `@wharfie/aws`
+
+This is Wharfie's version-matched AWS deployment companion. In the current
+unpublished preview, install both locally packed artifacts into the same clean
+builder:
+
+```bash
+npm install \
+  /absolute/path/to/wharfie-wharfie-0.0.15.tgz \
+  /absolute/path/to/wharfie-aws-0.0.15.tgz
+```
+
+Wharfie validates the package identity and its exact SDK binding contract
+before use. Generated applications embed this companion only when it is
+present and compatible; provider-free applications do not include its AWS SDK
+graph. The generated entry, bundle, SEA blob, and executable evidence bind the
+graph actually bundled for that artifact. This package is not a generic
+provider or plugin API.

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@wharfie/aws",
+  "version": "0.0.15",
+  "description": "Version-matched AWS deployment companion for Wharfie",
+  "type": "module",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wharfie/wharfie.git",
+    "directory": "packages/aws"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": "24.13.1"
+  },
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "src/"
+  ],
+  "peerDependencies": {
+    "@wharfie/wharfie": "0.0.15"
+  },
+  "peerDependenciesMeta": {
+    "@wharfie/wharfie": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "3.1090.0",
+    "@aws-sdk/client-ec2": "3.1091.0",
+    "@aws-sdk/client-iam": "3.1092.0",
+    "@aws-sdk/client-s3": "3.1091.0",
+    "@aws-sdk/client-ssm": "3.1091.0",
+    "@aws-sdk/client-sts": "3.1091.0",
+    "@aws-sdk/credential-providers": "3.1090.0",
+    "@aws-sdk/lib-dynamodb": "3.1090.0",
+    "@smithy/util-retry": "3.0.11"
+  }
+}

--- a/packages/aws/src/index.js
+++ b/packages/aws/src/index.js
@@ -1,0 +1,47 @@
+/**
+ * @typedef {Readonly<{
+ *   clientDynamoDB: typeof import('@aws-sdk/client-dynamodb'),
+ *   clientEC2: typeof import('@aws-sdk/client-ec2'),
+ *   clientIAM: typeof import('@aws-sdk/client-iam'),
+ *   clientS3: typeof import('@aws-sdk/client-s3'),
+ *   clientSSM: typeof import('@aws-sdk/client-ssm'),
+ *   clientSTS: typeof import('@aws-sdk/client-sts'),
+ *   credentialProviders: typeof import('@aws-sdk/credential-providers'),
+ *   libDynamoDB: typeof import('@aws-sdk/lib-dynamodb'),
+ *   utilRetry: typeof import('@smithy/util-retry'),
+ * }>} AwsSdkBindings
+ */
+
+import * as clientDynamoDB from '@aws-sdk/client-dynamodb';
+import * as clientEC2 from '@aws-sdk/client-ec2';
+import * as clientIAM from '@aws-sdk/client-iam';
+import * as clientS3 from '@aws-sdk/client-s3';
+import * as clientSSM from '@aws-sdk/client-ssm';
+import * as clientSTS from '@aws-sdk/client-sts';
+import * as credentialProviders from '@aws-sdk/credential-providers';
+import * as libDynamoDB from '@aws-sdk/lib-dynamodb';
+import * as utilRetry from '@smithy/util-retry';
+
+export const WHARFIE_AWS_PROVIDER_CONTRACT_VERSION = 1;
+export const WHARFIE_AWS_PROVIDER_PACKAGE_VERSION = '0.0.15';
+
+/** @type {AwsSdkBindings} */
+const BINDINGS = Object.freeze({
+  clientDynamoDB,
+  clientEC2,
+  clientIAM,
+  clientS3,
+  clientSSM,
+  clientSTS,
+  credentialProviders,
+  libDynamoDB,
+  utilRetry,
+});
+
+/**
+ * Return the versioned SDK binding contract understood by this Wharfie version.
+ * @returns {AwsSdkBindings} - Frozen AWS SDK namespaces.
+ */
+export function getAwsSdkBindings() {
+  return BINDINGS;
+}

--- a/scripts/verify-magnetic-first-run.js
+++ b/scripts/verify-magnetic-first-run.js
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
 import {
   cpSync,
+  existsSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
 } from 'node:fs';
@@ -22,6 +24,39 @@ import {
 
 const PROOF_PREFIX = 'wharfie-magnetic-first-run-';
 const PACKAGE_NAME = '@wharfie/wharfie';
+const DEPENDENCY_PACKAGE_BUDGET = 170;
+const INSTALLED_LOGICAL_BYTE_BUDGET = 85 * 1024 * 1024;
+
+/**
+ * @param {string} directory - Installed tree to measure.
+ * @returns {number} - Logical bytes in regular files below the tree.
+ */
+function logicalFileBytes(directory) {
+  let bytes = 0;
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      bytes += logicalFileBytes(entryPath);
+    } else if (entry.isFile()) {
+      bytes += lstatSync(entryPath).size;
+    }
+  }
+  return bytes;
+}
+
+/**
+ * @param {string} directory - Installed starter directory.
+ * @param {NodeJS.ProcessEnv} env - Isolated npm environment.
+ * @returns {number} - Installed dependency package directories.
+ */
+function dependencyPackageCount(directory, env) {
+  const listed = runCommand(NPM_COMMAND, ['ls', '--all', '--parseable'], {
+    cwd: directory,
+    env,
+    capture: true,
+  }).stdout;
+  return Math.max(0, listed.split(/\r?\n/u).filter(Boolean).length - 1);
+}
 
 /**
  * @returns {string | null} - Exact published package spec, or null for the
@@ -147,6 +182,11 @@ try {
           packed.tarballPath,
         ]
       : ['install', '--no-audit', '--no-fund'];
+  const installEnvironment = {
+    ...process.env,
+    npm_config_cache: npmCache,
+    npm_config_update_notifier: 'false',
+  };
   process.stdout.write(
     packageSpec === null
       ? `Installing ${PACKAGE_NAME}@${packageMetadata.version} from one packed tarball\n`
@@ -154,11 +194,7 @@ try {
   );
   runCommand(NPM_COMMAND, installArgs, {
     cwd: starterRoot,
-    env: {
-      ...process.env,
-      npm_config_cache: npmCache,
-      npm_config_update_notifier: 'false',
-    },
+    env: installEnvironment,
   });
   assert.equal(
     readFileSync(starterMetadataPath, 'utf8'),
@@ -183,6 +219,30 @@ try {
     ),
     'the starter resolved Wharfie outside its copied workspace',
   );
+  const installedNodeModules = path.join(starterRoot, 'node_modules');
+  assert.equal(
+    existsSync(path.join(installedNodeModules, '@aws-sdk')),
+    false,
+    'the canonical starter must not install @aws-sdk packages',
+  );
+  assert.equal(
+    existsSync(path.join(installedNodeModules, '@smithy')),
+    false,
+    'the canonical starter must not install @smithy packages',
+  );
+  const dependencyPackages = dependencyPackageCount(
+    starterRoot,
+    installEnvironment,
+  );
+  const installedLogicalBytes = logicalFileBytes(installedNodeModules);
+  assert.ok(
+    dependencyPackages <= DEPENDENCY_PACKAGE_BUDGET,
+    `canonical starter dependency count ${dependencyPackages} exceeds ${DEPENDENCY_PACKAGE_BUDGET}`,
+  );
+  assert.ok(
+    installedLogicalBytes <= INSTALLED_LOGICAL_BYTE_BUDGET,
+    `canonical starter logical bytes ${installedLogicalBytes} exceed ${INSTALLED_LOGICAL_BYTE_BUDGET}`,
+  );
 
   process.stdout.write('Running the copied magnetic starter\n');
   runCommand(NPM_COMMAND, ['run', 'demo', '--', 'Ada'], {
@@ -196,7 +256,19 @@ try {
     },
   });
   process.stdout.write(
-    `Verified magnetic first run with ${packed.manifest.filename}\n`,
+    `${JSON.stringify(
+      {
+        magneticFirstRun: 'ok',
+        package: packed.manifest.filename,
+        dependencyPackages,
+        dependencyPackageBudget: DEPENDENCY_PACKAGE_BUDGET,
+        installedLogicalBytes,
+        installedLogicalByteBudget: INSTALLED_LOGICAL_BYTE_BUDGET,
+        providerSdkPackages: 0,
+      },
+      null,
+      2,
+    )}\n`,
   );
 } finally {
   localPackage?.cleanup();

--- a/scripts/verify-provider-boundary.js
+++ b/scripts/verify-provider-boundary.js
@@ -1,0 +1,666 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { build } from 'esbuild';
+import { inject } from 'postject';
+
+import { withEmbeddedAwsProvider } from '../src/core/lib/esbuild.js';
+import {
+  AWS_PROVIDER_CONTRACT_VERSION,
+  AWS_PROVIDER_PACKAGE_VERSION,
+} from '../src/core/runtime/aws-provider-module.js';
+import { verifyRelocatedProviderFreeSea } from './verify-provider-free-sea.js';
+import {
+  createPackageTarball,
+  NPM_COMMAND,
+  readJson,
+  REPO_ROOT,
+  runCommand,
+} from './package-verification.js';
+
+const MISSING_PROVIDER_MESSAGE = `AWS deployment support is not installed. Install '@wharfie/aws@${AWS_PROVIDER_PACKAGE_VERSION}' next to '@wharfie/wharfie@${AWS_PROVIDER_PACKAGE_VERSION}' and retry.`;
+const NOT_EMBEDDED_PROVIDER_MESSAGE =
+  "AWS deployment support was not embedded. Install matching '@wharfie/aws@0.0.15' beside '@wharfie/wharfie@0.0.15' in the builder, rebuild the application, and retry.";
+const DEPENDENCY_PACKAGE_BUDGET = 170;
+const INSTALLED_LOGICAL_BYTE_BUDGET = 85 * 1024 * 1024;
+const DEPLOYMENT_ID = `wdi1_${'A'.repeat(43)}`;
+const ENTRYPOINTS = Object.freeze({
+  source: 'src/cli/entry.js',
+  packaged: 'src/core/resources/builds/actor-system-cli/index.js',
+});
+const GENERATED_ENTRY_FIXTURE = `
+import runtimeOperatorCli from './operator.js';
+const ledgerServiceCmd = {};
+async function runPackagedApp() {}
+(async () => {
+  await runPackagedApp({
+    runtimeModules: {
+      operatorCli: runtimeOperatorCli,
+      'ledger-service': ledgerServiceCmd,
+    },
+  });
+})();
+`;
+
+/**
+ * @param {string} directory - Directory to measure.
+ * @returns {number} - Logical bytes for regular files below the directory.
+ */
+function logicalFileBytes(directory) {
+  let bytes = 0;
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      bytes += logicalFileBytes(entryPath);
+    } else if (entry.isFile()) {
+      bytes += statSync(entryPath).size;
+    }
+  }
+  return bytes;
+}
+
+/**
+ * @param {string} directory - Installed consumer directory.
+ * @param {NodeJS.ProcessEnv} env - Isolated environment.
+ * @returns {number} - Installed production dependency package directories.
+ */
+function dependencyPackageCount(directory, env) {
+  const listed = runCommand(
+    NPM_COMMAND,
+    ['ls', '--omit=dev', '--all', '--parseable'],
+    { cwd: directory, env, capture: true },
+  ).stdout;
+  return Math.max(0, listed.split(/\r?\n/u).filter(Boolean).length - 1);
+}
+
+/**
+ * @param {string} label - Receipt label.
+ * @param {string} command - Executable path.
+ * @param {string[]} args - Command arguments.
+ * @param {{cwd: string, env: NodeJS.ProcessEnv}} options - Child options.
+ * @returns {void}
+ */
+function assertMissingProviderFailure(label, command, args, options) {
+  const result = spawnSync(command, args, {
+    ...options,
+    encoding: 'utf8',
+  });
+  if (result.error) throw result.error;
+  const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+  assert.equal(result.status, 1, `${label} must fail with status 1`);
+  assert.equal(output, MISSING_PROVIDER_MESSAGE, `${label} failure drifted`);
+}
+
+/**
+ * @returns {Promise<Record<string, number>>} - Input counts by provider-free graph.
+ */
+async function verifyProviderFreeGraphs() {
+  /** @type {Record<string, number>} */
+  const inputCounts = {};
+  for (const [label, entrypoint] of Object.entries(ENTRYPOINTS)) {
+    const result = await build({
+      absWorkingDir: REPO_ROOT,
+      entryPoints: [entrypoint],
+      bundle: true,
+      platform: 'node',
+      format: 'esm',
+      metafile: true,
+      write: false,
+      logLevel: 'silent',
+      loader: { '.worker.js': 'text' },
+      external: ['esbuild', 'node-gyp/bin/node-gyp.js', 'lmdb'],
+    });
+    const inputs = Object.keys(result.metafile.inputs);
+    const providerInputs = inputs.filter((input) =>
+      /[/\\]node_modules[/\\](?:@aws-sdk|@smithy)[/\\]/u.test(input),
+    );
+    assert.deepEqual(
+      providerInputs,
+      [],
+      `${label} application graph absorbed provider SDK files`,
+    );
+    inputCounts[label] = inputs.length;
+  }
+  return inputCounts;
+}
+
+/**
+ * @param {string} directory - Destination owned by the core package temp root.
+ * @returns {{manifest: Record<string, any>, tarballPath: string}} - Provider tarball.
+ */
+function createAwsProviderTarball(directory) {
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const result = runCommand(
+    NPM_COMMAND,
+    [
+      'pack',
+      '--workspace',
+      '@wharfie/aws',
+      '--json',
+      '--ignore-scripts',
+      '--pack-destination',
+      directory,
+    ],
+    {
+      cwd: REPO_ROOT,
+      capture: true,
+      env: {
+        ...process.env,
+        npm_config_cache: path.join(directory, 'npm-cache'),
+      },
+    },
+  );
+  const manifests = JSON.parse(result.stdout);
+  assert.ok(Array.isArray(manifests) && manifests.length === 1);
+  const manifest =
+    /** @type {{name: string, version: string, filename: string, files: {path: string}[]}} */ manifests[0];
+  assert.equal(manifest.name, '@wharfie/aws');
+  assert.equal(manifest.version, AWS_PROVIDER_PACKAGE_VERSION);
+  const packedFilePaths = [];
+  for (const file of manifest.files) packedFilePaths.push(file.path);
+  assert.deepEqual(packedFilePaths.sort(), [
+    'LICENSE',
+    'README.md',
+    'package.json',
+    'src/index.js',
+  ]);
+  const tarballPath = path.join(directory, manifest.filename);
+  assert.ok(existsSync(tarballPath), 'missing AWS companion tarball');
+  return { manifest, tarballPath };
+}
+
+/**
+ * Prove the same narrow generated-entry transform omits or embeds the provider
+ * solely according to peer resolution beside the installed core package.
+ * @param {string} installedCoreRoot - Provider-free installed core root.
+ * @returns {Promise<void>}
+ */
+async function verifyGeneratedEntryBoundary(installedCoreRoot) {
+  const embedded = await withEmbeddedAwsProvider({
+    stdin: { contents: GENERATED_ENTRY_FIXTURE, resolveDir: REPO_ROOT },
+  });
+  const embeddedContents = embedded.stdin?.contents;
+  if (typeof embeddedContents !== 'string') {
+    throw new TypeError('embedded provider entry must be a string');
+  }
+  assert.match(embeddedContents, /wharfieEmbeddedAwsProvider/u);
+  assert.match(embeddedContents, /registerWharfieEmbeddedAwsProvider/u);
+  assert.match(embeddedContents, /\.catch\(\(error\)/u);
+  const embeddedAgain = await withEmbeddedAwsProvider(embedded);
+  const embeddedAgainContents = embeddedAgain.stdin?.contents;
+  if (typeof embeddedAgainContents !== 'string') {
+    throw new TypeError('idempotent provider entry must be a string');
+  }
+  assert.equal(
+    embeddedAgainContents,
+    embeddedContents,
+    'provider entry preparation must be idempotent',
+  );
+
+  const installedWrapper = await import(
+    `${pathToFileURL(path.join(installedCoreRoot, 'src/core/lib/esbuild.js')).href}?provider-free`
+  );
+  const providerFree = await installedWrapper.withEmbeddedAwsProvider({
+    stdin: {
+      contents: GENERATED_ENTRY_FIXTURE,
+      resolveDir: path.dirname(installedCoreRoot),
+    },
+  });
+  assert.doesNotMatch(
+    providerFree.stdin.contents,
+    /wharfieEmbeddedAwsProvider/u,
+  );
+  assert.match(
+    providerFree.stdin.contents,
+    /sealWharfieAwsProviderUnavailable\(\)/u,
+  );
+  assert.match(providerFree.stdin.contents, /\.catch\(\(error\)/u);
+  const providerFreeAgain =
+    await installedWrapper.withEmbeddedAwsProvider(providerFree);
+  assert.equal(
+    providerFreeAgain.stdin.contents,
+    providerFree.stdin.contents,
+    'provider-free entry preparation must be idempotent',
+  );
+}
+
+/**
+ * Resolve the installed version-matched companion through installed core, run
+ * the generated-entry transform, relocate the resulting SEA, and prove its
+ * embedded bindings load without node_modules.
+ * @param {string} root - Owned temporary root.
+ * @param {string} installedCoreRoot - Installed core package root.
+ * @param {string} providerConsumerDirectory - Installed consumer hidden before SEA execution.
+ * @returns {Promise<number>} - Relocated SEA byte size.
+ */
+async function verifyRelocatedProviderSea(
+  root,
+  installedCoreRoot,
+  providerConsumerDirectory,
+) {
+  const seaRoot = path.join(root, 'provider-sea');
+  const relocatedRoot = path.join(root, 'provider-sea-relocated');
+  mkdirSync(seaRoot, { recursive: true, mode: 0o700 });
+  mkdirSync(relocatedRoot, { recursive: true, mode: 0o700 });
+  const loaderEntrypoint = path.join(
+    installedCoreRoot,
+    'src/core/runtime/aws-provider-module.js',
+  );
+  const operatorEntrypoint = path.join(seaRoot, 'operator.js');
+  writeFileSync(operatorEntrypoint, 'export default null;\n');
+  const bundlePath = path.join(seaRoot, 'provider-entry.cjs');
+  const blobPath = path.join(seaRoot, 'provider.blob');
+  const configPath = path.join(seaRoot, 'sea-config.json');
+  const injectedPath = path.join(
+    seaRoot,
+    process.platform === 'win32' ? 'provider-sea.exe' : 'provider-sea',
+  );
+  const relocatedPath = path.join(relocatedRoot, path.basename(injectedPath));
+  const source = [
+    'import runtimeOperatorCli from ' +
+      JSON.stringify(operatorEntrypoint) +
+      ';',
+    'import { AWS_PROVIDER_CONTRACT_VERSION, AWS_PROVIDER_PACKAGE_VERSION, loadAwsProviderBindings } from ' +
+      JSON.stringify(loaderEntrypoint) +
+      ';',
+    'const ledgerServiceCmd = {};',
+    'async function runPackagedApp() {',
+    '  const loaded = await loadAwsProviderBindings();',
+    '  process.stdout.write(JSON.stringify({',
+    '    providerEmbedded: true,',
+    '    version: AWS_PROVIDER_PACKAGE_VERSION,',
+    '    contract: AWS_PROVIDER_CONTRACT_VERSION,',
+    '    stsClient: typeof loaded.clientSTS.STSClient,',
+    '  }));',
+    '}',
+    '(async () => {',
+    '  await runPackagedApp({',
+    '    runtimeModules: {',
+    '      operatorCli: runtimeOperatorCli,',
+    "      'ledger-service': ledgerServiceCmd,",
+    '    },',
+    '  });',
+    '})();',
+    '',
+  ].join('\n');
+  const installedWrapper = await import(
+    pathToFileURL(path.join(installedCoreRoot, 'src/core/lib/esbuild.js'))
+      .href + '?provider-sea'
+  );
+  const prepared = await installedWrapper.withEmbeddedAwsProvider({
+    stdin: { contents: source, resolveDir: seaRoot, sourcefile: 'index.js' },
+  });
+  assert.match(prepared.stdin.contents, /registerWharfieEmbeddedAwsProvider/u);
+  assert.doesNotMatch(
+    prepared.stdin.contents,
+    /sealWharfieAwsProviderUnavailable/u,
+  );
+  await build({
+    ...prepared,
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    outfile: bundlePath,
+    target: 'node' + process.versions.node,
+    logLevel: 'silent',
+  });
+  writeFileSync(
+    configPath,
+    `${JSON.stringify(
+      {
+        main: bundlePath,
+        output: blobPath,
+        disableExperimentalSEAWarning: true,
+        useSnapshot: false,
+        useCodeCache: false,
+        execArgv: [],
+        execArgvExtension: 'cli',
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  runCommand(
+    process.execPath,
+    ['--no-warnings', '--experimental-sea-config', configPath],
+    { cwd: seaRoot },
+  );
+  copyFileSync(process.execPath, injectedPath);
+  chmodSync(injectedPath, 0o700);
+  if (process.platform === 'darwin') {
+    const removal = spawnSync(
+      'codesign',
+      ['--remove-signature', injectedPath],
+      {
+        encoding: 'utf8',
+      },
+    );
+    if (
+      removal.status !== 0 &&
+      !String(removal.stderr || '').includes('code object is not signed at all')
+    ) {
+      throw new Error(`codesign signature removal failed: ${removal.stderr}`);
+    }
+  }
+  await inject(injectedPath, 'NODE_SEA_BLOB', readFileSync(blobPath), {
+    sentinelFuse: Buffer.from(
+      'Tk9ERV9TRUFfRlVTRV9mY2U2ODBhYjJjYzQ2N2I2ZTA3MmI4YjVkZjE5OTZiMg==',
+      'base64',
+    ).toString(),
+    ...(process.platform === 'darwin' ? { machoSegmentName: 'NODE_SEA' } : {}),
+  });
+  if (process.platform === 'darwin') {
+    runCommand('codesign', ['--sign', '-', '--force', injectedPath], {
+      cwd: seaRoot,
+    });
+  }
+  copyFileSync(injectedPath, relocatedPath);
+  chmodSync(relocatedPath, 0o700);
+  renameSync(
+    providerConsumerDirectory,
+    path.join(root, 'provider-consumer-hidden'),
+  );
+  assert.equal(
+    existsSync(providerConsumerDirectory),
+    false,
+    'relocated SEA source install must be unavailable',
+  );
+  const result = spawnSync(relocatedPath, [], {
+    cwd: relocatedRoot,
+    encoding: 'utf8',
+    env: {
+      PATH: '',
+      HOME: path.join(relocatedRoot, 'home'),
+      XDG_CACHE_HOME: path.join(relocatedRoot, 'cache'),
+      XDG_CONFIG_HOME: path.join(relocatedRoot, 'config'),
+      XDG_DATA_HOME: path.join(relocatedRoot, 'data'),
+      XDG_STATE_HOME: path.join(relocatedRoot, 'state'),
+    },
+    timeout: 60_000,
+  });
+  if (result.error) throw result.error;
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stderr, '');
+  assert.deepEqual(JSON.parse(result.stdout), {
+    providerEmbedded: true,
+    version: AWS_PROVIDER_PACKAGE_VERSION,
+    contract: AWS_PROVIDER_CONTRACT_VERSION,
+    stsClient: 'function',
+  });
+  return statSync(relocatedPath).size;
+}
+
+const graphInputCounts = await verifyProviderFreeGraphs();
+const packaged = createPackageTarball();
+
+try {
+  const providerPackage = createAwsProviderTarball(
+    path.join(packaged.directory, 'provider-package'),
+  );
+  const consumerDirectory = path.join(packaged.directory, 'clean-consumer');
+  const providerConsumerDirectory = path.join(
+    packaged.directory,
+    'provider-consumer',
+  );
+  const runtimeDirectory = path.join(packaged.directory, 'runtime-state');
+  /** @type {NodeJS.ProcessEnv} */
+  const runtimeEnvironment = {
+    ...process.env,
+    HOME: path.join(runtimeDirectory, 'home'),
+    XDG_CACHE_HOME: path.join(runtimeDirectory, 'cache'),
+    XDG_CONFIG_HOME: path.join(runtimeDirectory, 'config'),
+    XDG_DATA_HOME: path.join(runtimeDirectory, 'data'),
+    XDG_STATE_HOME: path.join(runtimeDirectory, 'state'),
+    npm_config_cache: path.join(packaged.directory, 'npm-cache'),
+  };
+  delete runtimeEnvironment.CONFIG_DIR;
+
+  for (const [directory, name] of [
+    [consumerDirectory, 'wharfie-provider-boundary-receipt'],
+    [providerConsumerDirectory, 'wharfie-provider-enabled-receipt'],
+  ]) {
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      path.join(directory, 'package.json'),
+      `${JSON.stringify(
+        { name, version: '0.0.0', private: true, type: 'module' },
+        null,
+        2,
+      )}\n`,
+    );
+  }
+
+  runCommand(
+    NPM_COMMAND,
+    ['install', '--omit=dev', '--no-audit', '--no-fund', packaged.tarballPath],
+    { cwd: consumerDirectory, env: runtimeEnvironment },
+  );
+  const nodeModules = path.join(consumerDirectory, 'node_modules');
+  assert.equal(existsSync(path.join(nodeModules, '@aws-sdk')), false);
+  assert.equal(existsSync(path.join(nodeModules, '@smithy')), false);
+  const dependencyPackages = dependencyPackageCount(
+    consumerDirectory,
+    runtimeEnvironment,
+  );
+  assert.ok(dependencyPackages <= DEPENDENCY_PACKAGE_BUDGET);
+  const installedLogicalBytes = logicalFileBytes(nodeModules);
+  assert.ok(
+    installedLogicalBytes <= INSTALLED_LOGICAL_BYTE_BUDGET,
+    'canonical core logical bytes ' +
+      installedLogicalBytes +
+      ' exceed ' +
+      INSTALLED_LOGICAL_BYTE_BUDGET,
+  );
+
+  const installedRoot = path.join(nodeModules, '@wharfie', 'wharfie');
+  assertMissingProviderFailure(
+    'source CLI',
+    process.execPath,
+    [
+      path.join(installedRoot, 'bin', 'wharfie'),
+      'deployment',
+      'inspect',
+      DEPLOYMENT_ID,
+      '--region',
+      'us-east-1',
+    ],
+    { cwd: consumerDirectory, env: runtimeEnvironment },
+  );
+  assert.equal(existsSync(runtimeDirectory), false);
+
+  const packagedEntrypoint = pathToFileURL(
+    path.join(
+      installedRoot,
+      'src/core/resources/builds/actor-system-cli/index.js',
+    ),
+  ).href;
+  const packagedProbe = [
+    `import entrypoint from ${JSON.stringify(packagedEntrypoint)};`,
+    'try {',
+    `  await entrypoint(['node', 'wharfie', 'deployment', 'inspect', ${JSON.stringify(
+      DEPLOYMENT_ID,
+    )}, '--region', 'us-east-1']);`,
+    '} catch (error) {',
+    '  console.error(error instanceof Error ? error.message : String(error));',
+    '  process.exitCode = 1;',
+    '}',
+  ].join('\n');
+  assertMissingProviderFailure(
+    'packaged command',
+    process.execPath,
+    ['--input-type=module', '--eval', packagedProbe],
+    { cwd: consumerDirectory, env: runtimeEnvironment },
+  );
+  assert.equal(existsSync(runtimeDirectory), false);
+  await verifyGeneratedEntryBoundary(installedRoot);
+  const relocatedProviderFreeSeaBytes = await verifyRelocatedProviderFreeSea({
+    coreConsumerDirectory: consumerDirectory,
+    installedCoreRoot: installedRoot,
+    expectedProviderMessage: NOT_EMBEDDED_PROVIDER_MESSAGE,
+    root: packaged.directory,
+  });
+
+  const providerEnvironment = {
+    ...runtimeEnvironment,
+    npm_config_cache: path.join(packaged.directory, 'provider-npm-cache'),
+  };
+  runCommand(
+    NPM_COMMAND,
+    [
+      'install',
+      '--omit=dev',
+      '--no-audit',
+      '--no-fund',
+      packaged.tarballPath,
+      providerPackage.tarballPath,
+    ],
+    { cwd: providerConsumerDirectory, env: providerEnvironment },
+  );
+  const providerNodeModules = path.join(
+    providerConsumerDirectory,
+    'node_modules',
+  );
+  const installedProviderRoot = path.join(
+    providerNodeModules,
+    '@wharfie',
+    'aws',
+  );
+  const installedProviderCoreRoot = path.join(
+    providerNodeModules,
+    '@wharfie',
+    'wharfie',
+  );
+  const coreMetadata = readJson(
+    path.join(installedProviderCoreRoot, 'package.json'),
+  );
+  const providerMetadata = readJson(
+    path.join(installedProviderRoot, 'package.json'),
+  );
+  assert.equal(
+    coreMetadata.peerDependencies['@wharfie/aws'],
+    coreMetadata.version,
+  );
+  assert.equal(
+    providerMetadata.peerDependencies['@wharfie/wharfie'],
+    providerMetadata.version,
+  );
+  assert.equal(providerMetadata.private, undefined);
+  assert.equal(providerMetadata.publishConfig.access, 'public');
+  assert.equal(providerMetadata.engines.node, coreMetadata.engines.node);
+  assert.ok(
+    Object.values(providerMetadata.dependencies).every(
+      (specifier) =>
+        typeof specifier === 'string' &&
+        /^\d+\.\d+\.\d+/u.test(specifier) &&
+        !/[<>=~^*xX| ]/u.test(specifier),
+    ),
+    'AWS companion dependency specs must be exact versions',
+  );
+  assert.ok(existsSync(path.join(installedProviderRoot, 'LICENSE')));
+  assert.ok(existsSync(path.join(installedProviderRoot, 'README.md')));
+
+  const installedProviderBuildWrapper = await import(
+    pathToFileURL(
+      path.join(installedProviderCoreRoot, 'src/core/lib/esbuild.js'),
+    ).href + '?provider-enabled'
+  );
+  const installedProviderEntry =
+    await installedProviderBuildWrapper.withEmbeddedAwsProvider({
+      stdin: {
+        contents: GENERATED_ENTRY_FIXTURE,
+        resolveDir: providerConsumerDirectory,
+      },
+    });
+  assert.match(
+    installedProviderEntry.stdin.contents,
+    /registerWharfieEmbeddedAwsProvider/u,
+  );
+  assert.doesNotMatch(
+    installedProviderEntry.stdin.contents,
+    /sealWharfieAwsProviderUnavailable/u,
+  );
+
+  const providerLoader = pathToFileURL(
+    path.join(
+      installedProviderCoreRoot,
+      'src/core/runtime/aws-provider-module.js',
+    ),
+  ).href;
+  const providerProbe = [
+    `import * as provider from '@wharfie/aws';`,
+    `import * as boundary from ${JSON.stringify(providerLoader)};`,
+    'const validated = boundary.validateAwsProviderModule(provider);',
+    'const loaded = await boundary.loadAwsProviderBindings();',
+    "if (validated !== loaded) throw new Error('provider identity drifted');",
+    'process.stdout.write(JSON.stringify({',
+    '  version: provider.WHARFIE_AWS_PROVIDER_PACKAGE_VERSION,',
+    '  contract: provider.WHARFIE_AWS_PROVIDER_CONTRACT_VERSION,',
+    '  stsClient: typeof loaded.clientSTS.STSClient,',
+    '}));',
+  ].join('\n');
+  const providerResult = runCommand(
+    process.execPath,
+    ['--input-type=module', '--eval', providerProbe],
+    {
+      cwd: providerConsumerDirectory,
+      env: providerEnvironment,
+      capture: true,
+    },
+  );
+  assert.deepEqual(JSON.parse(providerResult.stdout), {
+    version: AWS_PROVIDER_PACKAGE_VERSION,
+    contract: AWS_PROVIDER_CONTRACT_VERSION,
+    stsClient: 'function',
+  });
+  const providerDependencyPackages = dependencyPackageCount(
+    providerConsumerDirectory,
+    providerEnvironment,
+  );
+  const providerInstalledLogicalBytes = logicalFileBytes(providerNodeModules);
+  const relocatedProviderSeaBytes = await verifyRelocatedProviderSea(
+    packaged.directory,
+    installedProviderCoreRoot,
+    providerConsumerDirectory,
+  );
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        providerBoundary: 'ok',
+        dependencyPackages,
+        dependencyPackageBudget: DEPENDENCY_PACKAGE_BUDGET,
+        installedLogicalBytes,
+        installedLogicalByteBudget: INSTALLED_LOGICAL_BYTE_BUDGET,
+        providerDependencyPackages,
+        providerInstalledLogicalBytes,
+        removedDependencyPackages:
+          providerDependencyPackages - dependencyPackages,
+        removedInstalledLogicalBytes:
+          providerInstalledLogicalBytes - installedLogicalBytes,
+        companionTarball: providerPackage.manifest.filename,
+        companionVersion: providerPackage.manifest.version,
+        graphInputCounts,
+        providerSdkGraphInputs: 0,
+        relocatedProviderFreeSeaBytes,
+        relocatedProviderSeaBytes,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+} finally {
+  packaged.cleanup();
+}

--- a/scripts/verify-provider-free-sea.js
+++ b/scripts/verify-provider-free-sea.js
@@ -1,0 +1,241 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { build } from 'esbuild';
+import { inject } from 'postject';
+
+import { runCommand } from './package-verification.js';
+
+/**
+ * Turn one bundled CommonJS entry into a real platform SEA.
+ * @param {object} options - SEA inputs.
+ * @param {string} options.bundlePath - Bundled JavaScript entry.
+ * @param {string} options.seaRoot - Owned build directory.
+ * @returns {Promise<string>} - Injected executable path.
+ */
+async function injectSea({ bundlePath, seaRoot }) {
+  const blobPath = path.join(seaRoot, 'provider-free.blob');
+  const configPath = path.join(seaRoot, 'sea-config.json');
+  const injectedPath = path.join(
+    seaRoot,
+    process.platform === 'win32'
+      ? 'provider-free-sea.exe'
+      : 'provider-free-sea',
+  );
+  writeFileSync(
+    configPath,
+    `${JSON.stringify(
+      {
+        main: bundlePath,
+        output: blobPath,
+        disableExperimentalSEAWarning: true,
+        useSnapshot: false,
+        useCodeCache: false,
+        execArgv: [],
+        execArgvExtension: 'cli',
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  runCommand(
+    process.execPath,
+    ['--no-warnings', '--experimental-sea-config', configPath],
+    { cwd: seaRoot },
+  );
+  copyFileSync(process.execPath, injectedPath);
+  chmodSync(injectedPath, 0o700);
+  if (process.platform === 'darwin') {
+    const removal = spawnSync(
+      'codesign',
+      ['--remove-signature', injectedPath],
+      {
+        encoding: 'utf8',
+      },
+    );
+    if (
+      removal.status !== 0 &&
+      !String(removal.stderr || '').includes('code object is not signed at all')
+    ) {
+      throw new Error(`codesign signature removal failed: ${removal.stderr}`);
+    }
+  }
+  await inject(injectedPath, 'NODE_SEA_BLOB', readFileSync(blobPath), {
+    sentinelFuse: Buffer.from(
+      'Tk9ERV9TRUFfRlVTRV9mY2U2ODBhYjJjYzQ2N2I2ZTA3MmI4YjVkZjE5OTZiMg==',
+      'base64',
+    ).toString(),
+    ...(process.platform === 'darwin' ? { machoSegmentName: 'NODE_SEA' } : {}),
+  });
+  if (process.platform === 'darwin') {
+    runCommand('codesign', ['--sign', '-', '--force', injectedPath], {
+      cwd: seaRoot,
+    });
+  }
+  return injectedPath;
+}
+
+/**
+ * Prove a provider-free generated SEA is sealed against a companion appearing
+ * later beside the relocated executable and fails before runtime preparation.
+ * @param {object} options - Proof inputs.
+ * @param {string} options.coreConsumerDirectory - Clean core-only consumer.
+ * @param {string} options.installedCoreRoot - Installed core package root.
+ * @param {string} options.expectedProviderMessage - Exact public diagnostic.
+ * @param {string} options.root - Parent-owned temporary root.
+ * @returns {Promise<number>} - Relocated executable bytes.
+ */
+export async function verifyRelocatedProviderFreeSea(options) {
+  const seaRoot = path.join(options.root, 'provider-free-sea');
+  const relocatedRoot = path.join(options.root, 'provider-free-sea-relocated');
+  mkdirSync(seaRoot, { recursive: true, mode: 0o700 });
+  mkdirSync(relocatedRoot, { recursive: true, mode: 0o700 });
+  const mutationMarker = path.join(relocatedRoot, 'runtime-prepared');
+  const fakeImportMarker = path.join(relocatedRoot, 'fake-provider-imported');
+  const fakeProbeMarker = path.join(relocatedRoot, 'fake-provider-probe');
+  const operatorPath = path.join(seaRoot, 'operator.js');
+  const bundlePath = path.join(seaRoot, 'provider-free-entry.cjs');
+  writeFileSync(
+    operatorPath,
+    "export default async function operatorCli() { throw new Error('operator dispatch must not run'); }\n",
+  );
+
+  const packagedEntryPath = path.join(
+    options.installedCoreRoot,
+    'src/core/resources/builds/packaged-app-entry.js',
+  );
+  const source = `
+import runtimeOperatorCli from ${JSON.stringify(operatorPath)};
+import { writeFileSync } from 'node:fs';
+import { runPackagedApp } from ${JSON.stringify(packagedEntryPath)};
+const ledgerServiceCmd = {};
+(async () => {
+  await runPackagedApp({
+    argv: [
+      'node',
+      'provider-free-sea',
+      'wharfie',
+      'deployment',
+      'inspect',
+      'wdi1_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      '--region',
+      'us-east-1',
+    ],
+    prepareRuntime: async () => writeFileSync(${JSON.stringify(mutationMarker)}, 'prepared'),
+    runtimeModules: {
+      operatorCli: runtimeOperatorCli,
+      'ledger-service': ledgerServiceCmd,
+    },
+  });
+})();
+`;
+  const installedWrapper = await import(
+    `${pathToFileURL(path.join(options.installedCoreRoot, 'src/core/lib/esbuild.js')).href}?provider-free-sea`
+  );
+  const prepared = await installedWrapper.withEmbeddedAwsProvider({
+    stdin: { contents: source, resolveDir: seaRoot, sourcefile: 'index.js' },
+  });
+  assert.match(
+    prepared.stdin.contents,
+    /sealWharfieAwsProviderUnavailable\(\)/u,
+  );
+  assert.doesNotMatch(prepared.stdin.contents, /wharfieEmbeddedAwsProvider/u);
+  await build({
+    ...prepared,
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    outfile: bundlePath,
+    target: `node${process.versions.node}`,
+    logLevel: 'silent',
+  });
+  const injectedPath = await injectSea({ bundlePath, seaRoot });
+  const relocatedPath = path.join(relocatedRoot, path.basename(injectedPath));
+  copyFileSync(injectedPath, relocatedPath);
+  chmodSync(relocatedPath, 0o700);
+
+  const fakeProviderRoot = path.join(
+    relocatedRoot,
+    'node_modules',
+    '@wharfie',
+    'aws',
+  );
+  mkdirSync(fakeProviderRoot, { recursive: true, mode: 0o700 });
+  writeFileSync(
+    path.join(fakeProviderRoot, 'package.json'),
+    `${JSON.stringify({
+      name: '@wharfie/aws',
+      version: '0.0.15',
+      type: 'module',
+      exports: './index.js',
+    })}\n`,
+  );
+  writeFileSync(
+    path.join(fakeProviderRoot, 'index.js'),
+    [
+      "import { writeFileSync } from 'node:fs';",
+      'if (process.env.WHARFIE_FAKE_PROVIDER_MARKER) {',
+      "  writeFileSync(process.env.WHARFIE_FAKE_PROVIDER_MARKER, 'imported');",
+      '}',
+      "throw new Error('fake external provider must never load');",
+      '',
+    ].join('\n'),
+  );
+
+  const probe = spawnSync(
+    process.execPath,
+    ['--input-type=module', '--eval', "await import('@wharfie/aws')"],
+    {
+      cwd: relocatedRoot,
+      encoding: 'utf8',
+      env: { WHARFIE_FAKE_PROVIDER_MARKER: fakeProbeMarker },
+    },
+  );
+  assert.notEqual(probe.status, 0, 'fake provider probe must throw');
+  assert.equal(
+    existsSync(fakeProbeMarker),
+    true,
+    'fake provider must be discoverable beside the relocated SEA',
+  );
+
+  renameSync(
+    options.coreConsumerDirectory,
+    path.join(options.root, 'core-consumer-hidden'),
+  );
+  assert.equal(existsSync(options.coreConsumerDirectory), false);
+  const result = spawnSync(relocatedPath, [], {
+    cwd: relocatedRoot,
+    encoding: 'utf8',
+    env: {
+      PATH: '',
+      HOME: path.join(relocatedRoot, 'home'),
+      XDG_CACHE_HOME: path.join(relocatedRoot, 'cache'),
+      XDG_CONFIG_HOME: path.join(relocatedRoot, 'config'),
+      XDG_DATA_HOME: path.join(relocatedRoot, 'data'),
+      XDG_STATE_HOME: path.join(relocatedRoot, 'state'),
+      WHARFIE_FAKE_PROVIDER_MARKER: fakeImportMarker,
+    },
+    timeout: 60_000,
+  });
+  if (result.error) throw result.error;
+  assert.equal(result.status, 1);
+  assert.equal(result.stdout, '');
+  assert.equal(result.stderr.trim(), options.expectedProviderMessage);
+  assert.equal(existsSync(fakeImportMarker), false);
+  assert.equal(existsSync(mutationMarker), false);
+  return statSync(relocatedPath).size;
+}
+
+export default verifyRelocatedProviderFreeSea;

--- a/src/cli/cmds/deployment.js
+++ b/src/cli/cmds/deployment.js
@@ -8,6 +8,7 @@ import {
   inspectAwsDeployment,
   reconcileAwsStagedDeployment,
 } from '../../core/runtime/deployment-aws-lifecycle.js';
+import { requireAwsProvider } from '../../core/runtime/aws-provider-module.js';
 import {
   createDeploymentCommand,
   snapshotDeploymentOperationOverrides,
@@ -33,6 +34,19 @@ function createSelectedSeaRequest(input) {
 }
 
 /**
+ * Require the fixed provider before an AWS operation can package, stage, or
+ * contact a provider.
+ * @param {Function} operation - Existing operation implementation.
+ * @returns {(input: Record<string, any>) => Promise<any>} - Guarded operation.
+ */
+function withAwsProvider(operation) {
+  return async (input) => {
+    await requireAwsProvider();
+    return operation(input);
+  };
+}
+
+/**
  * Create a fresh source deployment parent.
  * @param {{operations?: Partial<Record<'prepare'|'apply'|'applyPrepared'|'inspect'|'reconcile'|'destroy', Function>>, output?: Partial<import('../../core/runtime/operator/deployment-command.js').DeploymentCommandOutput>, processRef?: import('../../core/runtime/operator/deployment-command.js').DeploymentCommandProcess, readJsonObjectFile?: typeof import('../../core/runtime/operator/json-document-file.js').readOperatorJsonObjectFile}} [options] - Test and host seams.
  * @returns {import('commander').Command} - Source deployment command.
@@ -44,16 +58,20 @@ export function createSourceDeploymentCommand(options = {}) {
     operations: {
       prepare:
         supplied.prepare ??
-        ((/** @type {Record<string, any>} */ input) =>
-          prepareAwsSelectedSeaPlan(createSelectedSeaRequest(input))),
+        withAwsProvider((/** @type {Record<string, any>} */ input) =>
+          prepareAwsSelectedSeaPlan(createSelectedSeaRequest(input)),
+        ),
       apply:
         supplied.apply ??
-        ((/** @type {Record<string, any>} */ input) =>
-          applyAwsSelectedSea(createSelectedSeaRequest(input))),
-      applyPrepared: supplied.applyPrepared ?? applyAwsPreparedStagedPlan,
-      inspect: supplied.inspect ?? inspectAwsDeployment,
-      reconcile: supplied.reconcile ?? reconcileAwsStagedDeployment,
-      destroy: supplied.destroy ?? destroyAwsDeployment,
+        withAwsProvider((/** @type {Record<string, any>} */ input) =>
+          applyAwsSelectedSea(createSelectedSeaRequest(input)),
+        ),
+      applyPrepared:
+        supplied.applyPrepared ?? withAwsProvider(applyAwsPreparedStagedPlan),
+      inspect: supplied.inspect ?? withAwsProvider(inspectAwsDeployment),
+      reconcile:
+        supplied.reconcile ?? withAwsProvider(reconcileAwsStagedDeployment),
+      destroy: supplied.destroy ?? withAwsProvider(destroyAwsDeployment),
     },
     ...(options.output === undefined ? {} : { output: options.output }),
     ...(options.processRef === undefined

--- a/src/cli/entry.js
+++ b/src/cli/entry.js
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 
 import paths from '../core/lib/paths.js';
 import { WHARFIE_VERSION } from '../core/lib/version.js';
+import { requireAwsProvider } from '../core/runtime/aws-provider-module.js';
 
 import { createSourceOpsCommand } from './cmds/ops.js';
 import { createSourceAppCommand } from './cmds/app.js';
@@ -10,7 +11,23 @@ import { createSourceDeploymentCommand } from './cmds/deployment.js';
 /**
  * @typedef {object} CreateProgramOptions
  * @property {{ config: string, createWharfiePaths: () => Promise<void> }} [pathsModule] - Wharfie path helpers.
+ * @property {() => Promise<unknown>} [requireProvider] - Ensure the fixed AWS deployment provider is installed.
  */
+
+/**
+ * Determine whether a command belongs to the deployment command family.
+ * @param {import('commander').Command} command - Command selected by Commander.
+ * @returns {boolean} - True for deployment and each deployment subcommand.
+ */
+function isDeploymentCommand(command) {
+  /** @type {import('commander').Command | null} */
+  let current = command;
+  while (current) {
+    if (current.name() === 'deployment') return true;
+    current = current.parent;
+  }
+  return false;
+}
 
 /**
  * Build the Wharfie CLI commander program.
@@ -18,7 +35,7 @@ import { createSourceDeploymentCommand } from './cmds/deployment.js';
  * @returns {import('commander').Command} - Configured Wharfie command.
  */
 export function createProgram(options = {}) {
-  const { pathsModule = paths } = options;
+  const { pathsModule = paths, requireProvider = requireAwsProvider } = options;
 
   const program = new Command();
 
@@ -31,7 +48,10 @@ export function createProgram(options = {}) {
   program.addCommand(createSourceOpsCommand());
   program.addCommand(createSourceDeploymentCommand());
 
-  program.hook('preAction', async () => {
+  program.hook('preAction', async (_thisCommand, actionCommand) => {
+    if (isDeploymentCommand(actionCommand)) {
+      await requireProvider();
+    }
     await pathsModule.createWharfiePaths();
     process.env.CONFIG_DIR = pathsModule.config;
   });

--- a/src/core/lib/aws/base.js
+++ b/src/core/lib/aws/base.js
@@ -1,5 +1,3 @@
-import { ConfiguredRetryStrategy } from '@smithy/util-retry';
-
 /**
  * @typedef BaseAWSConfig
  * @property {number} [maxAttempts] - Maximum SDK attempts.
@@ -12,10 +10,16 @@ import { ConfiguredRetryStrategy } from '@smithy/util-retry';
  */
 class BaseAWS {
   /**
-   * @param {BaseAWSConfig} [options] - Retry configuration.
-   * @returns {{ retryStrategy: ConfiguredRetryStrategy }} - AWS SDK client configuration.
+   * @param {BaseAWSConfig} options - Retry configuration.
+   * @param {import('../../runtime/aws-provider-module.js').AwsSdkBindings} bindings - Fixed provider bindings.
+   * @returns {{ retryStrategy: any }} - AWS SDK client configuration.
    */
-  static config(options = {}) {
+  static config(options = {}, bindings) {
+    const ConfiguredRetryStrategy =
+      bindings?.utilRetry?.ConfiguredRetryStrategy;
+    if (typeof ConfiguredRetryStrategy !== 'function') {
+      throw new TypeError('AWS provider retry binding is invalid.');
+    }
     const configuredAttempts = Number(options.maxAttempts);
     const maxAttempts =
       Number.isSafeInteger(configuredAttempts) && configuredAttempts > 0
@@ -23,8 +27,10 @@ class BaseAWS {
         : 20;
 
     return {
-      retryStrategy: new ConfiguredRetryStrategy(maxAttempts, (attempt) =>
-        Math.floor(Math.random() * Math.min(20, Math.pow(2, attempt))),
+      retryStrategy: new ConfiguredRetryStrategy(
+        maxAttempts,
+        (/** @type {number} */ attempt) =>
+          Math.floor(Math.random() * Math.min(20, Math.pow(2, attempt))),
       ),
     };
   }

--- a/src/core/lib/config/db.js
+++ b/src/core/lib/config/db.js
@@ -288,15 +288,29 @@ function mkTempDir(prefix) {
 }
 
 /**
+ * Create the fixed provider-backed DynamoDB adapter only after the explicit
+ * companion package has loaded.
+ * @param {Record<string, any>} options - DynamoDB adapter options.
+ * @returns {Promise<import('../db/base.js').DBClient>} - Provider-backed client.
+ */
+async function createDynamoDBClient(options) {
+  const [{ default: createDynamoDB }, { loadAwsProviderBindings }] =
+    await Promise.all([
+      import('../db/adapters/dynamodb.js'),
+      import('../../runtime/aws-provider-module.js'),
+    ]);
+  const bindings = await loadAwsProviderBindings();
+  return createDynamoDB(options, bindings);
+}
+
+/**
  * Create a new DB client based on the resolved general adapter.
  * @param {DBAdapterName} [adapterName] - adapterName.
  * @returns {Promise<import('../db/base.js').DBClient>} - Result.
  */
 export async function createDBClient(adapterName = resolveDBAdapterName()) {
   if (adapterName === 'dynamodb') {
-    const { default: createDynamoDB } =
-      await import('../db/adapters/dynamodb.js');
-    return createDynamoDB({ region: process.env.AWS_REGION });
+    return createDynamoDBClient({ region: process.env.AWS_REGION });
   }
 
   if (adapterName === 'lmdb') {
@@ -327,9 +341,7 @@ export async function createControlDBClient(
   options = {},
 ) {
   if (adapterName === 'dynamodb') {
-    const { default: createDynamoDB } =
-      await import('../db/adapters/dynamodb.js');
-    return createDynamoDB({
+    return createDynamoDBClient({
       region: process.env.AWS_REGION,
       readOnly: options.readOnly === true,
     });
@@ -404,9 +416,7 @@ export async function createApplicationStateDBClient(
   const readOnly = options.readOnly === true;
 
   if (normalizedAdapter === 'dynamodb') {
-    const { default: createDynamoDB } =
-      await import('../db/adapters/dynamodb.js');
-    return createDynamoDB({
+    return createDynamoDBClient({
       region: process.env.AWS_REGION,
       readOnly,
     });
@@ -433,9 +443,7 @@ export async function createStateDBClient(
   adapterName = resolveStateAdapterName(),
 ) {
   if (adapterName === 'dynamodb') {
-    const { default: createDynamoDB } =
-      await import('../db/adapters/dynamodb.js');
-    return createDynamoDB({ region: process.env.AWS_REGION });
+    return createDynamoDBClient({ region: process.env.AWS_REGION });
   }
 
   if (adapterName === 'lmdb') {

--- a/src/core/lib/db/adapters/dynamodb.js
+++ b/src/core/lib/db/adapters/dynamodb.js
@@ -1,11 +1,3 @@
-import { DynamoDBDocument } from '@aws-sdk/lib-dynamodb';
-import {
-  DynamoDB,
-  ProvisionedThroughputExceededException,
-  ResourceNotFoundException,
-  ReturnValue,
-} from '@aws-sdk/client-dynamodb';
-import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import BaseAWS from '../../aws/base.js';
 import {
   CONDITION_TYPE,
@@ -40,21 +32,33 @@ const MAX_TRANSACTION_CONFLICT_ATTEMPTS = 5;
  * - `marshallOptions.removeUndefinedValues` is enabled, so undefined properties are removed.
  * - SDK retry behavior is also enabled via `maxAttempts`, but this wrapper adds targeted retries
  *   for bursty throughput / eventual-consistency table creation races on a couple operations.
- * @param {CreateDynamoDBOptions} [options] - options.
+ * @param {CreateDynamoDBOptions} options - options.
+ * @param {import('../../../runtime/aws-provider-module.js').AwsSdkBindings} bindings - Fixed provider bindings.
  * @returns {import('../base.js').DBClient} - Result.
  */
-export default function createDynamoDB({
-  region = process.env.AWS_REGION,
-  readOnly = false,
-  credentials = fromNodeProviderChain(),
-} = {}) {
+export default function createDynamoDB(
+  { region = process.env.AWS_REGION, readOnly = false, credentials } = {},
+  bindings,
+) {
+  const { DynamoDBDocument } = bindings.libDynamoDB;
+  const {
+    DynamoDB,
+    ProvisionedThroughputExceededException,
+    ResourceNotFoundException,
+    ReturnValue,
+  } = bindings.clientDynamoDB;
+  const { fromNodeProviderChain } = bindings.credentialProviders;
+  const resolvedCredentials = credentials ?? fromNodeProviderChain();
   const docClient = DynamoDBDocument.from(
     new DynamoDB({
-      ...BaseAWS.config({
-        maxAttempts: Number(process.env?.DYNAMO_MAX_RETRIES || 30),
-      }),
+      ...BaseAWS.config(
+        {
+          maxAttempts: Number(process.env?.DYNAMO_MAX_RETRIES || 30),
+        },
+        bindings,
+      ),
       region,
-      credentials,
+      credentials: resolvedCredentials,
     }),
     { marshallOptions: { removeUndefinedValues: true } },
   );

--- a/src/core/lib/esbuild.js
+++ b/src/core/lib/esbuild.js
@@ -1,14 +1,210 @@
+import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  AWS_PROVIDER_PACKAGE_NAME,
+  AWS_PROVIDER_PACKAGE_VERSION,
+  AwsProviderUnavailableError,
+  validateAwsProviderModule,
+} from '../runtime/aws-provider-module.js';
+
 const require = createRequire(import.meta.url);
+const AWS_PROVIDER_LOADER_PATH = fileURLToPath(
+  new URL('../runtime/aws-provider-module.js', import.meta.url),
+);
+const AWS_PROVIDER_BOUNDARY_MARKER =
+  '/* wharfie:fixed-aws-provider-boundary:v1 */';
+const PACKAGED_APP_ENTRY_MARKERS = Object.freeze([
+  'import runtimeOperatorCli from',
+  'await runPackagedApp({',
+  "'ledger-service': ledgerServiceCmd",
+]);
+
+/**
+ * @param {unknown} cause - Provider resolution or import failure.
+ * @returns {AwsProviderUnavailableError} - Stable incompatible-provider error.
+ */
+function incompatibleProvider(cause) {
+  if (
+    cause instanceof AwsProviderUnavailableError &&
+    cause.reason === 'incompatible'
+  ) {
+    return cause;
+  }
+  return new AwsProviderUnavailableError({ cause, reason: 'incompatible' });
+}
+
+/**
+ * @param {unknown} cause - `require.resolve` failure.
+ * @returns {boolean} - Whether the fixed companion itself is absent.
+ */
+function isMissingProviderPackageJson(cause) {
+  if (
+    cause === null ||
+    typeof cause !== 'object' ||
+    /** @type {{code?: unknown}} */ (cause).code !== 'MODULE_NOT_FOUND'
+  ) {
+    return false;
+  }
+  const message =
+    typeof (/** @type {{message?: unknown}} */ (cause).message) === 'string'
+      ? /** @type {{message: string}} */ (cause).message
+      : '';
+  return /^Cannot find module ['"]@wharfie\/aws\/package\.json['"]/u.test(
+    message,
+  );
+}
+
+/**
+ * Resolve and bind the fixed companion's package identity before importing it.
+ * The exported provider version is validated separately after import.
+ * @param {{requireRef?: typeof require, readPackageJson?: (packageJsonPath: string) => string}} [dependencies] - Focused test seams.
+ * @returns {Readonly<{entrypoint: string, packageJsonPath: string, packageRoot: string}> | undefined} - Exact companion resolution, or undefined only when absent.
+ */
+function resolveAwsProviderEmbedding(dependencies = {}) {
+  const requireRef = dependencies.requireRef ?? require;
+  const readPackageJson =
+    dependencies.readPackageJson ??
+    ((packageJsonPath) => readFileSync(packageJsonPath, 'utf8'));
+  let packageJsonPath;
+  try {
+    packageJsonPath = requireRef.resolve(
+      `${AWS_PROVIDER_PACKAGE_NAME}/package.json`,
+    );
+  } catch (cause) {
+    if (isMissingProviderPackageJson(cause)) return undefined;
+    throw incompatibleProvider(cause);
+  }
+
+  try {
+    if (
+      typeof packageJsonPath !== 'string' ||
+      !path.isAbsolute(packageJsonPath) ||
+      path.basename(packageJsonPath) !== 'package.json'
+    ) {
+      throw new Error('AWS companion package.json resolution is invalid.');
+    }
+    const metadata = JSON.parse(readPackageJson(packageJsonPath));
+    if (
+      metadata === null ||
+      typeof metadata !== 'object' ||
+      Array.isArray(metadata) ||
+      metadata.name !== AWS_PROVIDER_PACKAGE_NAME ||
+      metadata.version !== AWS_PROVIDER_PACKAGE_VERSION
+    ) {
+      throw new Error('AWS companion package identity is incompatible.');
+    }
+
+    const packageRoot = path.dirname(packageJsonPath);
+    const entrypoint = requireRef.resolve(AWS_PROVIDER_PACKAGE_NAME);
+    const relativeEntrypoint = path.relative(packageRoot, entrypoint);
+    if (
+      typeof entrypoint !== 'string' ||
+      !path.isAbsolute(entrypoint) ||
+      relativeEntrypoint === '' ||
+      relativeEntrypoint === '..' ||
+      relativeEntrypoint.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativeEntrypoint)
+    ) {
+      throw new Error('AWS companion entrypoint escaped its package root.');
+    }
+    return Object.freeze({ entrypoint, packageJsonPath, packageRoot });
+  } catch (cause) {
+    throw incompatibleProvider(cause);
+  }
+}
+
+/**
+ * Add the fixed packaged-app provider boundary. The error boundary is present
+ * in every generated app. The AWS SDK graph is added only when the one exact
+ * optional companion resolves beside core and passes package plus export
+ * validation. Already-prepared input is returned unchanged so evidence capture
+ * may prepare the entry before the ordinary build wrapper sees it.
+ * @param {import('esbuild').BuildOptions} args - Candidate build options.
+ * @param {{resolveProvider?: typeof resolveAwsProviderEmbedding, importProvider?: (entrypoint: string) => Promise<unknown>}} [dependencies] - Focused test seams.
+ * @returns {Promise<import('esbuild').BuildOptions>} - Exact build options.
+ */
+async function withEmbeddedAwsProvider(args, dependencies = {}) {
+  const contents = args.stdin?.contents;
+  if (
+    typeof contents === 'string' &&
+    contents.startsWith(`${AWS_PROVIDER_BOUNDARY_MARKER}\n`)
+  ) {
+    return args;
+  }
+  if (
+    typeof contents !== 'string' ||
+    !PACKAGED_APP_ENTRY_MARKERS.every((marker) => contents.includes(marker))
+  ) {
+    return args;
+  }
+
+  let providerResolution;
+  try {
+    providerResolution = (
+      dependencies.resolveProvider ?? resolveAwsProviderEmbedding
+    )();
+  } catch (cause) {
+    throw incompatibleProvider(cause);
+  }
+
+  const boundaryImports = [
+    `import { AwsProviderUnavailableError as WharfieAwsProviderUnavailableError${
+      providerResolution
+        ? ', registerAwsProviderModule as registerWharfieEmbeddedAwsProvider'
+        : ', sealAwsProviderUnavailable as sealWharfieAwsProviderUnavailable'
+    } } from ${JSON.stringify(AWS_PROVIDER_LOADER_PATH)};`,
+  ];
+  if (providerResolution) {
+    let providerNamespace;
+    try {
+      providerNamespace = await (
+        dependencies.importProvider ??
+        ((entrypoint) => import(pathToFileURL(entrypoint).href))
+      )(providerResolution.entrypoint);
+      validateAwsProviderModule(providerNamespace);
+    } catch (cause) {
+      throw incompatibleProvider(cause);
+    }
+    boundaryImports.push(
+      `import * as wharfieEmbeddedAwsProvider from ${JSON.stringify(providerResolution.entrypoint)};`,
+      'registerWharfieEmbeddedAwsProvider(wharfieEmbeddedAwsProvider);',
+    );
+  } else {
+    boundaryImports.push('sealWharfieAwsProviderUnavailable();');
+  }
+
+  const guardedContents = contents.replace(
+    /\}\)\(\);\s*$/u,
+    `})().catch((error) => {
+      console.error(error instanceof WharfieAwsProviderUnavailableError ? error.message : error);
+      process.exitCode = 1;
+    });`,
+  );
+  if (guardedContents === contents) {
+    throw new Error(
+      'Generated packaged-app entry is missing its terminal async invocation.',
+    );
+  }
+
+  return {
+    ...args,
+    stdin: {
+      ...args.stdin,
+      contents: `${AWS_PROVIDER_BOUNDARY_MARKER}\n${boundaryImports.join('\n')}\n${guardedContents}`,
+    },
+  };
+}
 
 /**
  * @param {import('esbuild').BuildOptions} args - args.
  * @returns {Promise<import('esbuild').BuildResult>} - Result.
  */
-function build(args) {
+async function build(args) {
   const esbuild = require('esbuild');
-  // Your build logic here
-  return esbuild.build(args);
+  return esbuild.build(await withEmbeddedAwsProvider(args));
 }
 
-export { build };
+export { build, resolveAwsProviderEmbedding, withEmbeddedAwsProvider };

--- a/src/core/resources/builds/actor-system-cli/control_cmds/deployment.js
+++ b/src/core/resources/builds/actor-system-cli/control_cmds/deployment.js
@@ -6,10 +6,23 @@ import {
   prepareAwsRunningSeaPlan,
   reconcileAwsRunningSeaDeployment,
 } from '../../../../runtime/deployment-aws-lifecycle.js';
+import { requireAwsProvider } from '../../../../runtime/aws-provider-module.js';
 import {
   createDeploymentCommand,
   snapshotDeploymentOperationOverrides,
 } from '../../../../runtime/operator/deployment-command.js';
+
+/**
+ * Require the fixed provider before a packaged AWS operation can mutate state.
+ * @param {Function} operation - Existing operation implementation.
+ * @returns {(input: Record<string, any>) => Promise<any>} - Guarded operation.
+ */
+function withAwsProvider(operation) {
+  return async (input) => {
+    await requireAwsProvider();
+    return operation(input);
+  };
+}
 
 /**
  * Create a fresh deployment parent for the SEA's reserved operator namespace.
@@ -22,12 +35,15 @@ export function createPackagedDeploymentCommand(options = {}) {
   const supplied = snapshotDeploymentOperationOverrides(options.operations);
   return createDeploymentCommand({
     operations: {
-      prepare: supplied.prepare ?? prepareAwsRunningSeaPlan,
-      apply: supplied.apply ?? applyAwsRunningSea,
-      applyPrepared: supplied.applyPrepared ?? applyAwsPreparedRunningSeaPlan,
-      inspect: supplied.inspect ?? inspectAwsDeployment,
-      reconcile: supplied.reconcile ?? reconcileAwsRunningSeaDeployment,
-      destroy: supplied.destroy ?? destroyAwsDeployment,
+      prepare: supplied.prepare ?? withAwsProvider(prepareAwsRunningSeaPlan),
+      apply: supplied.apply ?? withAwsProvider(applyAwsRunningSea),
+      applyPrepared:
+        supplied.applyPrepared ??
+        withAwsProvider(applyAwsPreparedRunningSeaPlan),
+      inspect: supplied.inspect ?? withAwsProvider(inspectAwsDeployment),
+      reconcile:
+        supplied.reconcile ?? withAwsProvider(reconcileAwsRunningSeaDeployment),
+      destroy: supplied.destroy ?? withAwsProvider(destroyAwsDeployment),
     },
     ...(options.output === undefined ? {} : { output: options.output }),
     ...(options.processRef === undefined

--- a/src/core/resources/builds/packaged-app-entry.js
+++ b/src/core/resources/builds/packaged-app-entry.js
@@ -1,8 +1,18 @@
+import { requireAwsProvider as defaultRequireAwsProvider } from '../../runtime/aws-provider-module.js';
+
 /**
  * The one top-level word reserved by packaged applications for Wharfie-owned
  * operator commands. All other argv belongs to the application.
  */
 export const OPERATOR_NAMESPACE = 'wharfie';
+
+const AWS_DEPLOYMENT_OPERATIONS = new Set([
+  'plan',
+  'apply',
+  'inspect',
+  'reconcile',
+  'destroy',
+]);
 
 /**
  * @param {string | undefined} value - value.
@@ -161,6 +171,23 @@ export function getOperatorArgv(argv) {
 }
 
 /**
+ * Detect a real AWS deployment leaf before packaged runtime preparation. Help,
+ * an omitted leaf, and unknown commands stay provider-free so Commander can
+ * explain the surface without an installed companion.
+ * @param {string[]} argv - Packaged application argv.
+ * @returns {boolean} - Whether argv selects one of the five AWS operations.
+ */
+export function isAwsDeploymentOperationInvocation(argv) {
+  const operatorArgs = argv.slice(3);
+  return (
+    operatorArgs[0] === 'deployment' &&
+    AWS_DEPLOYMENT_OPERATIONS.has(operatorArgs[1]) &&
+    !operatorArgs.includes('--help') &&
+    !operatorArgs.includes('-h')
+  );
+}
+
+/**
  * @param {Record<string, any>} runtimeModules - runtimeModules.
  * @param {{ argv?: string[] }} [options] - options.
  * @returns {Promise<void>} - Result.
@@ -191,7 +218,7 @@ export async function runRuntimeBootstrap(runtimeModules, options = {}) {
 }
 
 /**
- * @param {{ developerCliModule?: Record<string, any> | null, cliModule?: Record<string, any> | null, loadDeveloperCliModule?: function(): Promise<Record<string, any> | null> | Record<string, any> | null, cliExportName?: string, runtimeModules?: Record<string, any>, prepareRuntime?: function(): Promise<void> | void, argv?: string[] }} [options] - options.
+ * @param {{ developerCliModule?: Record<string, any> | null, cliModule?: Record<string, any> | null, loadDeveloperCliModule?: function(): Promise<Record<string, any> | null> | Record<string, any> | null, cliExportName?: string, runtimeModules?: Record<string, any>, prepareRuntime?: function(): Promise<void> | void, requireAwsProvider?: function(): Promise<void>, argv?: string[] }} [options] - options.
  * @returns {Promise<void>} - Result.
  */
 export async function runPackagedApp(options = {}) {
@@ -201,6 +228,10 @@ export async function runPackagedApp(options = {}) {
     typeof options.prepareRuntime === 'function'
       ? options.prepareRuntime
       : async () => {};
+  const requireAwsProvider =
+    typeof options.requireAwsProvider === 'function'
+      ? options.requireAwsProvider
+      : defaultRequireAwsProvider;
 
   if (getDispatchMode() === 'runtime') {
     await prepareRuntime();
@@ -215,6 +246,7 @@ export async function runPackagedApp(options = {}) {
       );
     }
 
+    if (isAwsDeploymentOperationInvocation(argv)) await requireAwsProvider();
     await prepareRuntime();
     await runDeveloperCli(
       { default: runtimeModules.operatorCli },

--- a/src/core/resources/builds/sea-build.js
+++ b/src/core/resources/builds/sea-build.js
@@ -8,7 +8,7 @@ import {
   existsSync,
   writeFileSync,
 } from 'node:fs';
-import { build as _build } from '../../lib/esbuild.js';
+import { build as _build, withEmbeddedAwsProvider } from '../../lib/esbuild.js';
 import paths from '../../lib/paths.js';
 import { runCmd, execFile } from '../../lib/cmd.js';
 import { inject } from 'postject';
@@ -694,9 +694,20 @@ class SeaBuild extends BaseResource {
     try {
       await promises.mkdir(tmpBuildDir, { mode: 0o700, recursive: true });
       await promises.chmod(tmpBuildDir, 0o700);
-      const entryCode = this.get('entryCode');
-      if (typeof entryCode !== 'string') {
+      const rawEntryCode = this.get('entryCode');
+      if (typeof rawEntryCode !== 'string') {
         throw new TypeError('SEA build entryCode must resolve to a string.');
+      }
+      const preparedBuildOptions = await withEmbeddedAwsProvider({
+        stdin: {
+          contents: rawEntryCode,
+          resolveDir: this.get('resolveDir'),
+          sourcefile: 'index.js',
+        },
+      });
+      const entryCode = preparedBuildOptions.stdin?.contents;
+      if (typeof entryCode !== 'string') {
+        throw new TypeError('SEA build prepared entryCode must be a string.');
       }
       const entryCodeBytes = Buffer.from(entryCode, 'utf8');
       const entryCodeEvidence = {

--- a/src/core/runtime/aws-provider-module.js
+++ b/src/core/runtime/aws-provider-module.js
@@ -1,0 +1,316 @@
+/**
+ * @typedef {Readonly<{
+ *   clientDynamoDB: typeof import('@aws-sdk/client-dynamodb'),
+ *   clientEC2: typeof import('@aws-sdk/client-ec2'),
+ *   clientIAM: typeof import('@aws-sdk/client-iam'),
+ *   clientS3: typeof import('@aws-sdk/client-s3'),
+ *   clientSSM: typeof import('@aws-sdk/client-ssm'),
+ *   clientSTS: typeof import('@aws-sdk/client-sts'),
+ *   credentialProviders: typeof import('@aws-sdk/credential-providers'),
+ *   libDynamoDB: typeof import('@aws-sdk/lib-dynamodb'),
+ *   utilRetry: typeof import('@smithy/util-retry'),
+ * }>} AwsSdkBindings
+ */
+
+import { WHARFIE_VERSION } from '../lib/version.js';
+
+export const AWS_PROVIDER_PACKAGE_NAME = '@wharfie/aws';
+export const AWS_PROVIDER_CONTRACT_VERSION = 1;
+export const AWS_PROVIDER_PACKAGE_VERSION = WHARFIE_VERSION;
+
+const CORE_PACKAGE_NAME = '@wharfie/wharfie';
+const PACKAGE_VERSION_SEPARATOR = '@';
+
+const INSTALL_MESSAGE = `AWS deployment support is not installed. Install '${AWS_PROVIDER_PACKAGE_NAME}@${AWS_PROVIDER_PACKAGE_VERSION}' next to '@wharfie/wharfie@${WHARFIE_VERSION}' and retry.`;
+const INCOMPATIBLE_MESSAGE = `AWS deployment support is incompatible. Install matching '${AWS_PROVIDER_PACKAGE_NAME}@${AWS_PROVIDER_PACKAGE_VERSION}' and '@wharfie/wharfie@${WHARFIE_VERSION}' packages and retry.`;
+const NOT_EMBEDDED_MESSAGE =
+  "AWS deployment support was not embedded. Install matching '" +
+  AWS_PROVIDER_PACKAGE_NAME +
+  '@' +
+  AWS_PROVIDER_PACKAGE_VERSION +
+  "' beside '" +
+  CORE_PACKAGE_NAME +
+  PACKAGE_VERSION_SEPARATOR +
+  WHARFIE_VERSION +
+  "' in the builder, rebuild the application, and retry.";
+const BINDING_KEYS = Object.freeze([
+  'clientDynamoDB',
+  'clientEC2',
+  'clientIAM',
+  'clientS3',
+  'clientSSM',
+  'clientSTS',
+  'credentialProviders',
+  'libDynamoDB',
+  'utilRetry',
+]);
+const REQUIRED_CALLABLES = Object.freeze({
+  clientDynamoDB: Object.freeze([
+    'DynamoDB',
+    'DynamoDBClient',
+    'ProvisionedThroughputExceededException',
+    'ResourceNotFoundException',
+  ]),
+  clientEC2: Object.freeze([
+    'AssociateRouteTableCommand',
+    'AttachInternetGatewayCommand',
+    'AttachVolumeCommand',
+    'CreateInternetGatewayCommand',
+    'CreateRouteCommand',
+    'CreateRouteTableCommand',
+    'CreateSecurityGroupCommand',
+    'CreateSubnetCommand',
+    'CreateVpcCommand',
+    'CreateVolumeCommand',
+    'DeleteInternetGatewayCommand',
+    'DeleteRouteCommand',
+    'DeleteRouteTableCommand',
+    'DeleteSecurityGroupCommand',
+    'DeleteSubnetCommand',
+    'DeleteVpcCommand',
+    'DescribeAvailabilityZonesCommand',
+    'DescribeImagesCommand',
+    'DescribeInstanceAttributeCommand',
+    'DescribeInstanceCreditSpecificationsCommand',
+    'DescribeInstancesCommand',
+    'DescribeInternetGatewaysCommand',
+    'DescribeInstanceTypeOfferingsCommand',
+    'DescribeRouteTablesCommand',
+    'DescribeSecurityGroupsCommand',
+    'DescribeSubnetsCommand',
+    'DescribeVpcAttributeCommand',
+    'DescribeVpcsCommand',
+    'DescribeVolumesCommand',
+    'DisassociateRouteTableCommand',
+    'DetachInternetGatewayCommand',
+    'DetachVolumeCommand',
+    'EC2Client',
+    'GetEbsDefaultKmsKeyIdCommand',
+    'ModifyInstanceAttributeCommand',
+    'RunInstancesCommand',
+    'StartInstancesCommand',
+    'TerminateInstancesCommand',
+  ]),
+  clientIAM: Object.freeze([
+    'AddRoleToInstanceProfileCommand',
+    'CreateInstanceProfileCommand',
+    'CreateRoleCommand',
+    'DeleteInstanceProfileCommand',
+    'DeleteRoleCommand',
+    'DeleteRolePolicyCommand',
+    'GetInstanceProfileCommand',
+    'GetRoleCommand',
+    'GetRolePolicyCommand',
+    'IAMClient',
+    'ListAttachedRolePoliciesCommand',
+    'ListInstanceProfilesForRoleCommand',
+    'ListInstanceProfileTagsCommand',
+    'ListRolePoliciesCommand',
+    'ListRoleTagsCommand',
+    'PutRolePolicyCommand',
+    'RemoveRoleFromInstanceProfileCommand',
+  ]),
+  clientS3: Object.freeze(['GetObjectCommand', 'S3', 'S3Client']),
+  clientSSM: Object.freeze(['GetParameterCommand', 'SSMClient']),
+  clientSTS: Object.freeze(['GetCallerIdentityCommand', 'STSClient']),
+  credentialProviders: Object.freeze(['fromNodeProviderChain']),
+  libDynamoDB: Object.freeze([
+    'DynamoDBDocument',
+    'DynamoDBDocumentClient',
+    'GetCommand',
+  ]),
+  utilRetry: Object.freeze(['ConfiguredRetryStrategy']),
+});
+const REQUIRED_STATIC_CALLABLES = Object.freeze([
+  Object.freeze(['libDynamoDB', 'DynamoDBDocument', 'from']),
+  Object.freeze(['libDynamoDB', 'DynamoDBDocumentClient', 'from']),
+]);
+
+/** AWS deployment was selected without its explicit provider package. */
+export class AwsProviderUnavailableError extends Error {
+  /** @param {{cause?: unknown, reason?: 'missing'|'incompatible'|'not-embedded'}} [options] - Stable public classification and optional private cause. */
+  constructor(options = {}) {
+    const reason = options.reason ?? 'missing';
+    super(
+      reason === 'incompatible'
+        ? INCOMPATIBLE_MESSAGE
+        : reason === 'not-embedded'
+          ? NOT_EMBEDDED_MESSAGE
+          : INSTALL_MESSAGE,
+      {
+        ...(options.cause === undefined ? {} : { cause: options.cause }),
+      },
+    );
+    this.name = 'AwsProviderUnavailableError';
+    this.code =
+      reason === 'incompatible'
+        ? 'WHARFIE_AWS_PROVIDER_INCOMPATIBLE'
+        : reason === 'not-embedded'
+          ? 'WHARFIE_AWS_PROVIDER_NOT_EMBEDDED'
+          : 'WHARFIE_AWS_PROVIDER_UNAVAILABLE';
+    this.reason = reason;
+  }
+}
+
+/**
+ * @param {unknown} value - Candidate provider namespace or SDK binding.
+ * @returns {value is Record<string, any>} - True only for a non-array object.
+ */
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Validate the one versioned companion-package surface.
+ * @param {unknown} namespace - Imported `@wharfie/aws` module.
+ * @returns {AwsSdkBindings} - Exact SDK bindings.
+ */
+export function validateAwsProviderModule(namespace) {
+  if (
+    !isObject(namespace) ||
+    namespace.WHARFIE_AWS_PROVIDER_PACKAGE_VERSION !==
+      AWS_PROVIDER_PACKAGE_VERSION ||
+    namespace.WHARFIE_AWS_PROVIDER_CONTRACT_VERSION !==
+      AWS_PROVIDER_CONTRACT_VERSION ||
+    typeof namespace.getAwsSdkBindings !== 'function'
+  ) {
+    throw new AwsProviderUnavailableError({ reason: 'incompatible' });
+  }
+  let bindings;
+  try {
+    bindings = namespace.getAwsSdkBindings();
+  } catch (cause) {
+    throw new AwsProviderUnavailableError({
+      cause,
+      reason: 'incompatible',
+    });
+  }
+  if (
+    !isObject(bindings) ||
+    !Object.isFrozen(bindings) ||
+    Reflect.ownKeys(bindings).length !== BINDING_KEYS.length ||
+    BINDING_KEYS.some((key) => !isObject(bindings[key])) ||
+    Object.entries(REQUIRED_CALLABLES).some(([bindingKey, exports]) =>
+      exports.some(
+        (exportName) =>
+          typeof bindings[bindingKey]?.[exportName] !== 'function',
+      ),
+    ) ||
+    REQUIRED_STATIC_CALLABLES.some(
+      ([bindingKey, exportName, staticName]) =>
+        typeof bindings[bindingKey]?.[exportName]?.[staticName] !== 'function',
+    ) ||
+    !isObject(bindings.clientDynamoDB.ReturnValue) ||
+    bindings.clientDynamoDB.ReturnValue.NONE !== 'NONE'
+  ) {
+    throw new AwsProviderUnavailableError({ reason: 'incompatible' });
+  }
+  return /** @type {AwsSdkBindings} */ (bindings);
+}
+
+/** @type {Promise<AwsSdkBindings> | undefined} */
+let defaultLoad;
+/** @type {AwsSdkBindings | undefined} */
+let registeredBindings;
+let providerUnavailableSealed = false;
+
+/**
+ * Register the one fixed provider namespace already embedded by a generated
+ * SEA entry. Registration is deliberately specific to AWS and may not replace
+ * a previously validated binding surface.
+ * @param {unknown} namespace - Statically embedded `@wharfie/aws` namespace.
+ * @returns {AwsSdkBindings} - Registered validated SDK bindings.
+ */
+export function registerAwsProviderModule(namespace) {
+  if (providerUnavailableSealed) {
+    throw new AwsProviderUnavailableError({ reason: 'not-embedded' });
+  }
+  const bindings = validateAwsProviderModule(namespace);
+  if (registeredBindings && registeredBindings !== bindings) {
+    throw new AwsProviderUnavailableError({ reason: 'incompatible' });
+  }
+  registeredBindings = bindings;
+  defaultLoad = Promise.resolve(bindings);
+  return bindings;
+}
+
+/**
+ * Permanently seal one generated provider-free application. Source CLI modules
+ * never call this; a sealed SEA cannot discover a later external companion.
+ * @returns {void}
+ */
+export function sealAwsProviderUnavailable() {
+  if (registeredBindings || defaultLoad) {
+    throw new AwsProviderUnavailableError({ reason: 'incompatible' });
+  }
+  providerUnavailableSealed = true;
+}
+
+/**
+ * Read the already validated binding surface for synchronous host construction.
+ * @returns {AwsSdkBindings} - Registered validated SDK bindings.
+ */
+export function getRegisteredAwsProviderBindings() {
+  if (!registeredBindings) {
+    throw new AwsProviderUnavailableError({
+      reason: providerUnavailableSealed ? 'not-embedded' : 'missing',
+    });
+  }
+  return registeredBindings;
+}
+
+/**
+ * @param {unknown} cause - Dynamic-import failure.
+ * @returns {boolean} - Whether the fixed provider package itself is absent.
+ */
+function isMissingProviderPackage(cause) {
+  if (!isObject(cause) || cause.code !== 'ERR_MODULE_NOT_FOUND') return false;
+  const message = typeof cause.message === 'string' ? cause.message : '';
+  return /^Cannot find package ['"]@wharfie\/aws['"] imported from /u.test(
+    message,
+  );
+}
+
+/**
+ * Convert dynamic-import failures into the stable fixed-provider boundary.
+ * @param {unknown} cause - Provider import failure.
+ * @returns {AwsProviderUnavailableError} - Stable missing or incompatible error.
+ */
+export function classifyAwsProviderImportFailure(cause) {
+  if (cause instanceof AwsProviderUnavailableError) return cause;
+  return new AwsProviderUnavailableError({
+    cause,
+    reason: isMissingProviderPackage(cause) ? 'missing' : 'incompatible',
+  });
+}
+
+/**
+ * Load only Wharfie's fixed AWS companion package. The non-literal import is
+ * deliberate: provider-free SEA builds must not absorb the optional SDK graph.
+ * @returns {Promise<AwsSdkBindings>} - Fixed SDK bindings.
+ */
+export function loadAwsProviderBindings() {
+  if (providerUnavailableSealed) {
+    return Promise.reject(
+      new AwsProviderUnavailableError({ reason: 'not-embedded' }),
+    );
+  }
+  if (registeredBindings) return Promise.resolve(registeredBindings);
+  if (!defaultLoad) {
+    const specifier = AWS_PROVIDER_PACKAGE_NAME;
+    defaultLoad = import(specifier)
+      .then(registerAwsProviderModule)
+      .catch((cause) => {
+        throw classifyAwsProviderImportFailure(cause);
+      });
+  }
+  return /** @type {Promise<AwsSdkBindings>} */ (defaultLoad);
+}
+
+/**
+ * Prove the explicit provider is available before starting an AWS operation.
+ * @returns {Promise<void>} - Resolves only for the fixed compatible provider.
+ */
+export async function requireAwsProvider() {
+  await loadAwsProviderBindings();
+}

--- a/src/core/runtime/deployment-aws-authority.js
+++ b/src/core/runtime/deployment-aws-authority.js
@@ -1,73 +1,16 @@
 /* eslint-disable jsdoc/require-param, jsdoc/require-returns, jsdoc/require-returns-description -- Compact internal boundary helpers keep their complete types inline. */
 
-import { DynamoDB } from '@aws-sdk/client-dynamodb';
-import {
-  AssociateRouteTableCommand,
-  AttachInternetGatewayCommand,
-  AttachVolumeCommand,
-  CreateInternetGatewayCommand,
-  CreateRouteCommand,
-  CreateRouteTableCommand,
-  CreateSecurityGroupCommand,
-  CreateSubnetCommand,
-  CreateVpcCommand,
-  CreateVolumeCommand,
-  DeleteInternetGatewayCommand,
-  DeleteRouteCommand,
-  DeleteRouteTableCommand,
-  DeleteSecurityGroupCommand,
-  DeleteSubnetCommand,
-  DeleteVpcCommand,
-  DescribeAvailabilityZonesCommand,
-  DescribeImagesCommand,
-  DescribeInstanceCreditSpecificationsCommand,
-  DescribeInstanceAttributeCommand,
-  DescribeInstancesCommand,
-  DescribeInternetGatewaysCommand,
-  DescribeInstanceTypeOfferingsCommand,
-  DescribeRouteTablesCommand,
-  DescribeSecurityGroupsCommand,
-  DescribeSubnetsCommand,
-  DescribeVpcAttributeCommand,
-  DescribeVpcsCommand,
-  DescribeVolumesCommand,
-  DisassociateRouteTableCommand,
-  DetachInternetGatewayCommand,
-  DetachVolumeCommand,
-  EC2Client,
-  GetEbsDefaultKmsKeyIdCommand,
-  ModifyInstanceAttributeCommand,
-  RunInstancesCommand,
-  StartInstancesCommand,
-  TerminateInstancesCommand,
-} from '@aws-sdk/client-ec2';
-import {
-  AddRoleToInstanceProfileCommand,
-  CreateInstanceProfileCommand,
-  CreateRoleCommand,
-  DeleteInstanceProfileCommand,
-  DeleteRoleCommand,
-  DeleteRolePolicyCommand,
-  GetInstanceProfileCommand,
-  GetRoleCommand,
-  GetRolePolicyCommand,
-  IAMClient,
-  ListAttachedRolePoliciesCommand,
-  ListInstanceProfilesForRoleCommand,
-  ListInstanceProfileTagsCommand,
-  ListRolePoliciesCommand,
-  ListRoleTagsCommand,
-  PutRolePolicyCommand,
-  RemoveRoleFromInstanceProfileCommand,
-} from '@aws-sdk/client-iam';
-import { S3 } from '@aws-sdk/client-s3';
-import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
-import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
-import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
-
 import BaseAWS from '../lib/aws/base.js';
 import createDynamoDBAdapter from '../lib/db/adapters/dynamodb.js';
 import { createAwsProviderScope } from './deployment-provider-scope.js';
+import { loadAwsProviderBindings } from './aws-provider-module.js';
+
+/** @typedef {import('@aws-sdk/client-dynamodb').DynamoDB} DynamoDB */
+/** @typedef {import('@aws-sdk/client-ec2').EC2Client} EC2Client */
+/** @typedef {import('@aws-sdk/client-iam').IAMClient} IAMClient */
+/** @typedef {import('@aws-sdk/client-s3').S3} S3 */
+/** @typedef {import('@aws-sdk/client-ssm').SSMClient} SSMClient */
+/** @typedef {import('@aws-sdk/client-sts').STSClient} STSClient */
 
 const AWS_REGION_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)+$/;
 const AWS_ACCOUNT_ID_PATTERN = /^[0-9]{12}$/;
@@ -767,6 +710,71 @@ function scopeFromCallerIdentity(value, region) {
  */
 export async function createAwsDeploymentAuthority(options) {
   const region = readCanonicalRegion(options);
+  const bindings = await loadAwsProviderBindings();
+  const { DynamoDB } = bindings.clientDynamoDB;
+  const {
+    AssociateRouteTableCommand,
+    AttachInternetGatewayCommand,
+    AttachVolumeCommand,
+    CreateInternetGatewayCommand,
+    CreateRouteCommand,
+    CreateRouteTableCommand,
+    CreateSecurityGroupCommand,
+    CreateSubnetCommand,
+    CreateVpcCommand,
+    CreateVolumeCommand,
+    DeleteInternetGatewayCommand,
+    DeleteRouteCommand,
+    DeleteRouteTableCommand,
+    DeleteSecurityGroupCommand,
+    DeleteSubnetCommand,
+    DeleteVpcCommand,
+    DescribeAvailabilityZonesCommand,
+    DescribeImagesCommand,
+    DescribeInstanceCreditSpecificationsCommand,
+    DescribeInstanceAttributeCommand,
+    DescribeInstancesCommand,
+    DescribeInternetGatewaysCommand,
+    DescribeInstanceTypeOfferingsCommand,
+    DescribeRouteTablesCommand,
+    DescribeSecurityGroupsCommand,
+    DescribeSubnetsCommand,
+    DescribeVpcAttributeCommand,
+    DescribeVpcsCommand,
+    DescribeVolumesCommand,
+    DisassociateRouteTableCommand,
+    DetachInternetGatewayCommand,
+    DetachVolumeCommand,
+    EC2Client,
+    GetEbsDefaultKmsKeyIdCommand,
+    ModifyInstanceAttributeCommand,
+    RunInstancesCommand,
+    StartInstancesCommand,
+    TerminateInstancesCommand,
+  } = bindings.clientEC2;
+  const {
+    AddRoleToInstanceProfileCommand,
+    CreateInstanceProfileCommand,
+    CreateRoleCommand,
+    DeleteInstanceProfileCommand,
+    DeleteRoleCommand,
+    DeleteRolePolicyCommand,
+    GetInstanceProfileCommand,
+    GetRoleCommand,
+    GetRolePolicyCommand,
+    IAMClient,
+    ListAttachedRolePoliciesCommand,
+    ListInstanceProfilesForRoleCommand,
+    ListInstanceProfileTagsCommand,
+    ListRolePoliciesCommand,
+    ListRoleTagsCommand,
+    PutRolePolicyCommand,
+    RemoveRoleFromInstanceProfileCommand,
+  } = bindings.clientIAM;
+  const { S3 } = bindings.clientS3;
+  const { GetParameterCommand, SSMClient } = bindings.clientSSM;
+  const { GetCallerIdentityCommand, STSClient } = bindings.clientSTS;
+  const { fromNodeProviderChain } = bindings.credentialProviders;
   let resolvedCredentials;
   try {
     const provider = fromNodeProviderChain({ clientConfig: { region } });
@@ -786,7 +794,7 @@ export async function createAwsDeploymentAuthority(options) {
   let sts;
   try {
     sts = new STSClient({
-      ...BaseAWS.config(),
+      ...BaseAWS.config({}, bindings),
       region,
       credentials,
     });
@@ -844,11 +852,14 @@ export async function createAwsDeploymentAuthority(options) {
       throw new TypeError('AWS deployment DynamoDB options are invalid.');
     }
     try {
-      return createDynamoDBAdapter({
-        region,
-        credentials,
-        readOnly: dbOptions.readOnly ?? false,
-      });
+      return createDynamoDBAdapter(
+        {
+          region,
+          credentials,
+          readOnly: dbOptions.readOnly ?? false,
+        },
+        bindings,
+      );
     } catch {
       throw new Error(DYNAMODB_CREATION_ERROR);
     }
@@ -861,7 +872,7 @@ export async function createAwsDeploymentAuthority(options) {
     let client;
     try {
       client = new DynamoDB({
-        ...BaseAWS.config(),
+        ...BaseAWS.config({}, bindings),
         region,
         credentials,
       });
@@ -914,7 +925,7 @@ export async function createAwsDeploymentAuthority(options) {
     let client;
     try {
       client = new S3({
-        ...BaseAWS.config(),
+        ...BaseAWS.config({}, bindings),
         region,
         credentials,
       });
@@ -1025,7 +1036,7 @@ export async function createAwsDeploymentAuthority(options) {
         // Conditional copy and exact-version deletion settle only through the
         // driver's explicit readback. Hidden SDK retries must not multiply one
         // authorized effect.
-        ...BaseAWS.config({ maxAttempts: 1 }),
+        ...BaseAWS.config({ maxAttempts: 1 }, bindings),
         region,
         credentials,
       });
@@ -1093,12 +1104,12 @@ export async function createAwsDeploymentAuthority(options) {
     let ec2;
     try {
       ssm = new SSMClient({
-        ...BaseAWS.config(),
+        ...BaseAWS.config({}, bindings),
         region,
         credentials,
       });
       ec2 = new EC2Client({
-        ...BaseAWS.config(),
+        ...BaseAWS.config({}, bindings),
         region,
         credentials,
       });
@@ -1186,7 +1197,7 @@ export async function createAwsDeploymentAuthority(options) {
     let client;
     try {
       client = new EC2Client({
-        ...BaseAWS.config(),
+        ...BaseAWS.config({}, bindings),
         region,
         credentials,
       });
@@ -1241,7 +1252,7 @@ export async function createAwsDeploymentAuthority(options) {
       client = new EC2Client({
         // Node mutations use explicit provider recovery identities. Keep SDK
         // transport retries from hiding an ambiguous launch or termination.
-        ...BaseAWS.config({ maxAttempts: 1 }),
+        ...BaseAWS.config({ maxAttempts: 1 }, bindings),
         region,
         credentials,
       });
@@ -1315,7 +1326,7 @@ export async function createAwsDeploymentAuthority(options) {
         // Attachment mutations have no provider idempotency token. Perform one
         // SDK attempt, then let the driver recover solely from exact dual
         // instance/volume readback.
-        ...BaseAWS.config({ maxAttempts: 1 }),
+        ...BaseAWS.config({ maxAttempts: 1 }, bindings),
         region,
         credentials,
       });
@@ -1382,7 +1393,7 @@ export async function createAwsDeploymentAuthority(options) {
         // Keep SDK transport retries from multiplying one authorized effect.
         // A driver may supply its own provider token where supported, but every
         // driver owns explicit recovery through exact readback.
-        ...BaseAWS.config({ maxAttempts: 1 }),
+        ...BaseAWS.config({ maxAttempts: 1 }, bindings),
         region,
         credentials,
       });
@@ -1500,12 +1511,12 @@ export async function createAwsDeploymentAuthority(options) {
         // IAM mutations do not carry provider idempotency tokens. Recovery is
         // explicit exact readback, so transport retries must not duplicate one
         // authorized effect.
-        ...BaseAWS.config({ maxAttempts: 1 }),
+        ...BaseAWS.config({ maxAttempts: 1 }, bindings),
         region,
         credentials,
       });
       ec2Client = new EC2Client({
-        ...BaseAWS.config({ maxAttempts: 1 }),
+        ...BaseAWS.config({ maxAttempts: 1 }, bindings),
         region,
         credentials,
       });

--- a/src/core/runtime/deployment-aws-host-client-family.js
+++ b/src/core/runtime/deployment-aws-host-client-family.js
@@ -1,9 +1,6 @@
 /* eslint-disable jsdoc/valid-types, jsdoc/require-param, jsdoc/require-param-description, jsdoc/require-returns, jsdoc/require-returns-description -- This boundary owns one exact host-only SDK lifetime behind the V67 and V70 adapters. */
 
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
-import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
+import { getRegisteredAwsProviderBindings } from './aws-provider-module.js';
 
 import BaseAWS from '../lib/aws/base.js';
 import { createAwsSingleNodeHostActivationAuthorityAdapter } from './deployment-aws-host-activation-authority.js';
@@ -17,6 +14,11 @@ import {
   assertDeploymentInstanceId,
   validateProviderScope,
 } from './deployment-provider-scope.js';
+
+/** @typedef {import('@aws-sdk/client-sts').STSClient} AwsSTSClient */
+/** @typedef {import('@aws-sdk/client-dynamodb').DynamoDBClient} AwsDynamoDBClient */
+/** @typedef {import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient} AwsDynamoDBDocumentClient */
+/** @typedef {import('@aws-sdk/client-s3').S3Client} AwsS3Client */
 
 const OPEN_OPTIONS_KEYS = new Set(['providerScope', 'deploymentInstanceId']);
 const SUPPORTED_PARTITION = 'aws';
@@ -167,18 +169,23 @@ function discardCapability(capability, receiver) {
  */
 export function openAwsSingleNodeHostClientFamily(options) {
   const { providerScope, deploymentInstanceId } = validateOpenOptions(options);
+  const awsBindings = getRegisteredAwsProviderBindings();
+  const { DynamoDBClient } = awsBindings.clientDynamoDB;
+  const { DynamoDBDocumentClient, GetCommand } = awsBindings.libDynamoDB;
+  const { GetObjectCommand, S3Client } = awsBindings.clientS3;
+  const { GetCallerIdentityCommand, STSClient } = awsBindings.clientSTS;
   const lifetimeAbortController = new AbortController();
   /** @type {Set<Promise<unknown>>} */
   const activeSends = new Set();
   /** @type {Set<Readonly<{abort: () => void}>>} */
   const activeS3Bodies = new Set();
-  /** @type {STSClient|undefined} */
+  /** @type {AwsSTSClient|undefined} */
   let sts;
-  /** @type {DynamoDBClient|undefined} */
+  /** @type {AwsDynamoDBClient|undefined} */
   let dynamo;
-  /** @type {DynamoDBDocumentClient|undefined} */
+  /** @type {AwsDynamoDBDocumentClient|undefined} */
   let dynamoDocument;
-  /** @type {S3Client|undefined} */
+  /** @type {AwsS3Client|undefined} */
   let s3;
   /** @type {Function|undefined} */
   let destroySts;
@@ -239,7 +246,7 @@ export function openAwsSingleNodeHostClientFamily(options) {
       throw new TypeError(INITIALIZATION_ERROR);
     }
     sts = new STSClient({
-      ...BaseAWS.config({ maxAttempts: 1 }),
+      ...BaseAWS.config({ maxAttempts: 1 }, awsBindings),
       maxAttempts: 1,
       region: providerScope.region,
       endpoint: `https://sts.${providerScope.region}.amazonaws.com`,
@@ -256,7 +263,7 @@ export function openAwsSingleNodeHostClientFamily(options) {
     }
 
     dynamo = new DynamoDBClient({
-      ...BaseAWS.config({ maxAttempts: 1 }),
+      ...BaseAWS.config({ maxAttempts: 1 }, awsBindings),
       maxAttempts: 1,
       region: providerScope.region,
       endpoint: `https://dynamodb.${providerScope.region}.amazonaws.com`,
@@ -286,7 +293,7 @@ export function openAwsSingleNodeHostClientFamily(options) {
     }
 
     s3 = new S3Client({
-      ...BaseAWS.config({ maxAttempts: 1 }),
+      ...BaseAWS.config({ maxAttempts: 1 }, awsBindings),
       maxAttempts: 1,
       region: providerScope.region,
       endpoint: `https://s3.${providerScope.region}.amazonaws.com`,
@@ -977,21 +984,21 @@ export function openAwsSingleNodeHostClientFamily(options) {
           Promise.resolve().then(() =>
             Reflect.apply(
               /** @type {Function} */ (destroyS3),
-              /** @type {S3Client} */ (s3),
+              /** @type {AwsS3Client} */ (s3),
               [],
             ),
           ),
           Promise.resolve().then(() =>
             Reflect.apply(
               /** @type {Function} */ (destroySts),
-              /** @type {STSClient} */ (sts),
+              /** @type {AwsSTSClient} */ (sts),
               [],
             ),
           ),
           Promise.resolve().then(() =>
             Reflect.apply(
               /** @type {Function} */ (destroyDynamo),
-              /** @type {DynamoDBClient} */ (dynamo),
+              /** @type {AwsDynamoDBClient} */ (dynamo),
               [],
             ),
           ),

--- a/test/cli/entry-provider-boundary.test.js
+++ b/test/cli/entry-provider-boundary.test.js
@@ -1,0 +1,55 @@
+/* eslint-env jest */
+
+import path from 'node:path';
+
+import { createProgram } from '../../src/cli/entry.js';
+
+const DEPLOYMENT_INSTANCE_ID = `wdi1_${'A'.repeat(43)}`;
+
+describe('CLI provider boundary', () => {
+  test.each([
+    [
+      'plan',
+      [
+        'plan',
+        'demo',
+        '--profile',
+        '/provider-guard/not-read.json',
+        '--control-policy',
+        'bootstrap',
+      ],
+    ],
+    ['apply', ['apply', 'demo', '--profile', '/provider-guard/not-read.json']],
+    ['inspect', ['inspect', DEPLOYMENT_INSTANCE_ID, '--region', 'us-east-1']],
+    [
+      'reconcile',
+      ['reconcile', DEPLOYMENT_INSTANCE_ID, '--region', 'us-east-1'],
+    ],
+    ['destroy', ['destroy', DEPLOYMENT_INSTANCE_ID, '--region', 'us-east-1']],
+  ])(
+    'requires the AWS provider before paths or the %s operation',
+    async (_operation, operationArgv) => {
+      /** @type {string[]} */
+      const order = [];
+      const providerError = new Error('provider missing');
+      const program = createProgram({
+        pathsModule: {
+          config: path.join(process.cwd(), '.wharfie-test-config'),
+          createWharfiePaths: async () => {
+            order.push('paths');
+          },
+        },
+        requireProvider: async () => {
+          order.push('provider');
+          throw providerError;
+        },
+      });
+
+      await expect(
+        program.parseAsync(['node', 'wharfie', 'deployment', ...operationArgv]),
+      ).rejects.toBe(providerError);
+
+      expect(order).toEqual(['provider']);
+    },
+  );
+});

--- a/test/db/dynamodb-read-only.test.js
+++ b/test/db/dynamodb-read-only.test.js
@@ -3,6 +3,7 @@
 
 import { describe, expect, it, jest } from '@jest/globals';
 
+import { createAwsProviderModule } from '../helpers/aws-provider.js';
 import { createFakeDocClient } from '../helpers/db-adapters.js';
 
 describe('dynamodb read-only observer mode', () => {
@@ -19,10 +20,18 @@ describe('dynamodb read-only observer mode', () => {
       TableName: 'runs',
       Item: { pk: 'service', sk: 'run/b', status: 'ready' },
     });
+    const DynamoDBDocument = Object.assign(jest.fn(), {
+      from: () => fakeDocClient,
+    });
     jest.unstable_mockModule('@aws-sdk/lib-dynamodb', () => ({
-      DynamoDBDocument: { from: () => fakeDocClient },
+      DynamoDBDocument,
     }));
 
+    const { registerAwsProviderModule } =
+      await import('../../src/core/runtime/aws-provider-module.js');
+    registerAwsProviderModule(
+      createAwsProviderModule({ libDynamoDB: { DynamoDBDocument } }),
+    );
     const { createControlDBClient } =
       await import('../../src/core/lib/config/db.js');
     const db = await createControlDBClient('dynamodb', { readOnly: true });

--- a/test/helpers/aws-provider.js
+++ b/test/helpers/aws-provider.js
@@ -1,0 +1,34 @@
+import * as actualProvider from '@wharfie/aws';
+
+const ACTUAL_BINDINGS = actualProvider.getAwsSdkBindings();
+
+/**
+ * Build a complete fixed provider test namespace while replacing only the SDK
+ * capabilities a focused test observes.
+ * @param {Partial<Record<keyof typeof ACTUAL_BINDINGS, Record<string, any>>>} [overrides] - Per-namespace test doubles.
+ * @returns {Readonly<Record<string, any>>} - Complete provider namespace.
+ */
+export function createAwsProviderModule(overrides = {}) {
+  const bindings = Object.freeze(
+    Object.fromEntries(
+      Object.entries(ACTUAL_BINDINGS).map(([key, namespace]) => {
+        const bindingKey = /** @type {keyof typeof ACTUAL_BINDINGS} */ (key);
+        return [
+          bindingKey,
+          Object.hasOwn(overrides, bindingKey)
+            ? Object.freeze({ ...namespace, ...overrides[bindingKey] })
+            : namespace,
+        ];
+      }),
+    ),
+  );
+  return Object.freeze({
+    WHARFIE_AWS_PROVIDER_PACKAGE_VERSION:
+      actualProvider.WHARFIE_AWS_PROVIDER_PACKAGE_VERSION,
+    WHARFIE_AWS_PROVIDER_CONTRACT_VERSION:
+      actualProvider.WHARFIE_AWS_PROVIDER_CONTRACT_VERSION,
+    getAwsSdkBindings: () => bindings,
+  });
+}
+
+export default createAwsProviderModule;

--- a/test/helpers/db-adapters.js
+++ b/test/helpers/db-adapters.js
@@ -5,6 +5,8 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { createAwsProviderModule } from './aws-provider.js';
+
 /**
  * @typedef {import('../../src/core/lib/db/base.js').DBClient} DBClient
  */
@@ -505,12 +507,27 @@ export async function createMockedDynamoDB(options = {}) {
   jest.resetModules();
   const fakeDocClient = createFakeDocClient(options);
 
+  const DynamoDBDocument = Object.assign(jest.fn(), {
+    from: () => fakeDocClient,
+  });
   jest.unstable_mockModule('@aws-sdk/lib-dynamodb', () => ({
-    DynamoDBDocument: { from: () => fakeDocClient },
+    DynamoDBDocument,
   }));
 
-  const { default: createDynamoDB } = await import(DYNAMO_ADAPTER_IMPORT);
-  const db = createDynamoDB({ region: 'us-east-1' });
+  const [
+    { default: createDynamoDB },
+    { loadAwsProviderBindings, registerAwsProviderModule },
+  ] = await Promise.all([
+    import(DYNAMO_ADAPTER_IMPORT),
+    import('../../src/core/runtime/aws-provider-module.js'),
+  ]);
+  registerAwsProviderModule(
+    createAwsProviderModule({ libDynamoDB: { DynamoDBDocument } }),
+  );
+  const db = createDynamoDB(
+    { region: 'us-east-1' },
+    await loadAwsProviderBindings(),
+  );
   return { db, fakeDocClient };
 }
 

--- a/test/runtime/aws-provider-embedding.test.js
+++ b/test/runtime/aws-provider-embedding.test.js
@@ -1,0 +1,137 @@
+/* eslint-env jest */
+/* eslint-disable jsdoc/require-jsdoc */
+
+import { describe, expect, it, jest } from '@jest/globals';
+import path from 'node:path';
+
+import {
+  resolveAwsProviderEmbedding,
+  withEmbeddedAwsProvider,
+} from '../../src/core/lib/esbuild.js';
+
+const INCOMPATIBLE_MESSAGE =
+  "AWS deployment support is incompatible. Install matching '@wharfie/aws@0.0.15' and '@wharfie/wharfie@0.0.15' packages and retry.";
+const GENERATED_ENTRY = `
+import runtimeOperatorCli from './operator.js';
+const ledgerServiceCmd = {};
+async function runPackagedApp() {}
+(async () => {
+  await runPackagedApp({
+    runtimeModules: {
+      operatorCli: runtimeOperatorCli,
+      'ledger-service': ledgerServiceCmd,
+    },
+  });
+})();
+`;
+
+/** @param {Record<string, string>} resolutions */
+function requireRef(resolutions) {
+  return /** @type {NodeRequire} */ (
+    /** @type {unknown} */ ({
+      resolve: jest.fn(
+        /** @param {string} specifier */ (specifier) => {
+          const resolved = resolutions[specifier];
+          if (resolved) return resolved;
+          throw Object.assign(new Error(`Cannot find module '${specifier}'`), {
+            code: 'MODULE_NOT_FOUND',
+          });
+        },
+      ),
+    })
+  );
+}
+
+describe('AWS provider SEA embedding boundary', () => {
+  it('binds the actual companion package identity and root', () => {
+    const resolved = resolveAwsProviderEmbedding();
+
+    expect(resolved).toBeDefined();
+    expect(resolved?.packageJsonPath).toBe(
+      path.join(resolved?.packageRoot || '', 'package.json'),
+    );
+    expect(
+      path.relative(resolved?.packageRoot || '', resolved?.entrypoint || ''),
+    ).not.toMatch(/^\.\.(?:[/\\]|$)/u);
+  });
+
+  it.each([
+    [
+      'wrong package name',
+      { name: '@wharfie/not-aws', version: '0.0.15' },
+      '/tmp/wharfie-provider/src/index.js',
+    ],
+    [
+      'wrong package version',
+      { name: '@wharfie/aws', version: '0.0.14' },
+      '/tmp/wharfie-provider/src/index.js',
+    ],
+    [
+      'entrypoint outside package root',
+      { name: '@wharfie/aws', version: '0.0.15' },
+      '/tmp/other-provider/index.js',
+    ],
+  ])(
+    'rejects %s before importing provider code',
+    (_label, metadata, entrypoint) => {
+      const packageJsonPath = '/tmp/wharfie-provider/package.json';
+
+      expect(() =>
+        resolveAwsProviderEmbedding({
+          requireRef: requireRef({
+            '@wharfie/aws': entrypoint,
+            '@wharfie/aws/package.json': packageJsonPath,
+          }),
+          readPackageJson: () => JSON.stringify(metadata),
+        }),
+      ).toThrow(
+        expect.objectContaining({
+          code: 'WHARFIE_AWS_PROVIDER_INCOMPATIBLE',
+          reason: 'incompatible',
+          message: INCOMPATIBLE_MESSAGE,
+        }),
+      );
+    },
+  );
+
+  it('maps an installed companion import failure to the stable incompatible error', async () => {
+    const transitiveFailure = Object.assign(
+      new Error(
+        "Cannot find package '@aws-sdk/client-sts' imported from /tmp/provider/node_modules/@wharfie/aws/src/index.js",
+      ),
+      { code: 'ERR_MODULE_NOT_FOUND' },
+    );
+
+    await expect(
+      withEmbeddedAwsProvider(
+        { stdin: { contents: GENERATED_ENTRY, resolveDir: process.cwd() } },
+        {
+          resolveProvider: () =>
+            Object.freeze({
+              entrypoint: '/tmp/wharfie-provider/src/index.js',
+              packageJsonPath: '/tmp/wharfie-provider/package.json',
+              packageRoot: '/tmp/wharfie-provider',
+            }),
+          importProvider: async () => {
+            throw transitiveFailure;
+          },
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: 'WHARFIE_AWS_PROVIDER_INCOMPATIBLE',
+      reason: 'incompatible',
+      message: INCOMPATIBLE_MESSAGE,
+      cause: transitiveFailure,
+    });
+  });
+
+  it('prepares the provider entry idempotently', async () => {
+    const prepared = await withEmbeddedAwsProvider({
+      stdin: { contents: GENERATED_ENTRY, resolveDir: process.cwd() },
+    });
+    const preparedAgain = await withEmbeddedAwsProvider(prepared);
+
+    expect(prepared.stdin?.contents).toContain('wharfieEmbeddedAwsProvider');
+    expect(preparedAgain).toBe(prepared);
+  });
+});

--- a/test/runtime/aws-provider-module.test.js
+++ b/test/runtime/aws-provider-module.test.js
@@ -1,0 +1,164 @@
+/* eslint-env jest */
+
+import * as providerNamespace from '@wharfie/aws';
+
+import {
+  AWS_PROVIDER_CONTRACT_VERSION,
+  AWS_PROVIDER_PACKAGE_VERSION,
+  AwsProviderUnavailableError,
+  classifyAwsProviderImportFailure,
+  getRegisteredAwsProviderBindings,
+  registerAwsProviderModule,
+  validateAwsProviderModule,
+} from '../../src/core/runtime/aws-provider-module.js';
+
+const INCOMPATIBLE_MESSAGE =
+  "AWS deployment support is incompatible. Install matching '@wharfie/aws@0.0.15' and '@wharfie/wharfie@0.0.15' packages and retry.";
+const MISSING_MESSAGE =
+  "AWS deployment support is not installed. Install '@wharfie/aws@0.0.15' next to '@wharfie/wharfie@0.0.15' and retry.";
+
+/** @returns {ReturnType<typeof providerNamespace.getAwsSdkBindings>} */
+function actualBindings() {
+  return providerNamespace.getAwsSdkBindings();
+}
+
+/** @param {Record<string, any>} replacements @returns {Record<string, any>} */
+function providerWith(replacements = {}) {
+  return {
+    WHARFIE_AWS_PROVIDER_PACKAGE_VERSION: AWS_PROVIDER_PACKAGE_VERSION,
+    WHARFIE_AWS_PROVIDER_CONTRACT_VERSION: AWS_PROVIDER_CONTRACT_VERSION,
+    getAwsSdkBindings: actualBindings,
+    ...replacements,
+  };
+}
+
+/** @param {string} message @returns {Error & {code: string}} */
+function moduleNotFound(message) {
+  return Object.assign(new Error(message), { code: 'ERR_MODULE_NOT_FOUND' });
+}
+
+describe('AWS provider module boundary', () => {
+  test('accepts and registers the exact fixed provider surface', () => {
+    const bindings = actualBindings();
+
+    expect(validateAwsProviderModule(providerNamespace)).toBe(bindings);
+    expect(registerAwsProviderModule(providerNamespace)).toBe(bindings);
+    expect(getRegisteredAwsProviderBindings()).toBe(bindings);
+  });
+
+  test.each([
+    ['missing namespace', undefined],
+    [
+      'wrong package version',
+      providerWith({ WHARFIE_AWS_PROVIDER_PACKAGE_VERSION: '0.0.14' }),
+    ],
+    [
+      'wrong contract',
+      providerWith({ WHARFIE_AWS_PROVIDER_CONTRACT_VERSION: 2 }),
+    ],
+    [
+      'mutable bindings',
+      providerWith({
+        getAwsSdkBindings: () => ({ ...actualBindings() }),
+      }),
+    ],
+    [
+      'extra binding',
+      providerWith({
+        getAwsSdkBindings: () =>
+          Object.freeze({ ...actualBindings(), arbitraryProviderHook: {} }),
+      }),
+    ],
+    [
+      'missing required constructor',
+      providerWith({
+        getAwsSdkBindings: () =>
+          Object.freeze({
+            ...actualBindings(),
+            clientSTS: Object.freeze({
+              ...actualBindings().clientSTS,
+              STSClient: undefined,
+            }),
+          }),
+      }),
+    ],
+    [
+      'invalid ReturnValue.NONE',
+      providerWith({
+        getAwsSdkBindings: () =>
+          Object.freeze({
+            ...actualBindings(),
+            clientDynamoDB: Object.freeze({
+              ...actualBindings().clientDynamoDB,
+              ReturnValue: Object.freeze({
+                ...actualBindings().clientDynamoDB.ReturnValue,
+                NONE: 'NOT_NONE',
+              }),
+            }),
+          }),
+      }),
+    ],
+    [
+      'missing DynamoDBDocument.from',
+      providerWith({
+        getAwsSdkBindings: () =>
+          Object.freeze({
+            ...actualBindings(),
+            libDynamoDB: Object.freeze({
+              ...actualBindings().libDynamoDB,
+              DynamoDBDocument: function DynamoDBDocument() {},
+            }),
+          }),
+      }),
+    ],
+    [
+      'missing DynamoDBDocumentClient.from',
+      providerWith({
+        getAwsSdkBindings: () =>
+          Object.freeze({
+            ...actualBindings(),
+            libDynamoDB: Object.freeze({
+              ...actualBindings().libDynamoDB,
+              DynamoDBDocumentClient: function DynamoDBDocumentClient() {},
+            }),
+          }),
+      }),
+    ],
+  ])('rejects %s before registration', (_label, namespace) => {
+    expect(() => validateAwsProviderModule(namespace)).toThrow(
+      expect.objectContaining({
+        name: 'AwsProviderUnavailableError',
+        code: 'WHARFIE_AWS_PROVIDER_INCOMPATIBLE',
+        reason: 'incompatible',
+        message: INCOMPATIBLE_MESSAGE,
+      }),
+    );
+    expect(() => validateAwsProviderModule(namespace)).toThrow(
+      AwsProviderUnavailableError,
+    );
+  });
+
+  test('classifies only an exact missing companion target as absent', () => {
+    const missing = classifyAwsProviderImportFailure(
+      moduleNotFound(
+        "Cannot find package '@wharfie/aws' imported from /consumer/loader.js",
+      ),
+    );
+    const missingTransitive = classifyAwsProviderImportFailure(
+      moduleNotFound(
+        "Cannot find package '@aws-sdk/client-sts' imported from /consumer/node_modules/@wharfie/aws/src/index.js",
+      ),
+    );
+
+    expect(missing).toMatchObject({
+      code: 'WHARFIE_AWS_PROVIDER_UNAVAILABLE',
+      reason: 'missing',
+      message: MISSING_MESSAGE,
+    });
+    expect(missingTransitive).toMatchObject({
+      code: 'WHARFIE_AWS_PROVIDER_INCOMPATIBLE',
+      reason: 'incompatible',
+      message: INCOMPATIBLE_MESSAGE,
+    });
+  });
+});

--- a/test/runtime/aws-provider-seal.test.js
+++ b/test/runtime/aws-provider-seal.test.js
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+
+import * as providerNamespace from '@wharfie/aws';
+import { describe, expect, it, jest } from '@jest/globals';
+
+const BOUNDARY_IMPORT = '../../src/core/runtime/aws-provider-module.js';
+const NOT_EMBEDDED_MESSAGE =
+  "AWS deployment support was not embedded. Install matching '@wharfie/aws@0.0.15' beside '@wharfie/wharfie@0.0.15' in the builder, rebuild the application, and retry.";
+
+describe('sealed provider-free AWS boundary', () => {
+  it('cannot discover or register a companion after sealing', async () => {
+    jest.resetModules();
+    const boundary = await import(`${BOUNDARY_IMPORT}?sealed-provider-free`);
+
+    expect(boundary.sealAwsProviderUnavailable()).toBeUndefined();
+    expect(boundary.sealAwsProviderUnavailable()).toBeUndefined();
+    await expect(boundary.loadAwsProviderBindings()).rejects.toMatchObject({
+      code: 'WHARFIE_AWS_PROVIDER_NOT_EMBEDDED',
+      reason: 'not-embedded',
+      message: NOT_EMBEDDED_MESSAGE,
+    });
+    expect(() => boundary.registerAwsProviderModule(providerNamespace)).toThrow(
+      expect.objectContaining({
+        code: 'WHARFIE_AWS_PROVIDER_NOT_EMBEDDED',
+        reason: 'not-embedded',
+        message: NOT_EMBEDDED_MESSAGE,
+      }),
+    );
+  });
+
+  it('does not allow a registered provider to become unavailable', async () => {
+    jest.resetModules();
+    const boundary = await import(`${BOUNDARY_IMPORT}?registered-provider`);
+
+    boundary.registerAwsProviderModule(providerNamespace);
+    expect(() => boundary.sealAwsProviderUnavailable()).toThrow(
+      expect.objectContaining({
+        code: 'WHARFIE_AWS_PROVIDER_INCOMPATIBLE',
+        reason: 'incompatible',
+      }),
+    );
+  });
+});

--- a/test/runtime/deployment-aws-authority.test.js
+++ b/test/runtime/deployment-aws-authority.test.js
@@ -1,4 +1,8 @@
+/* eslint-disable n/no-extraneous-import -- Dynamic SDK imports load the exact mocked companion bindings exercised by this test. */
+
 import { describe, expect, it, jest } from '@jest/globals';
+
+import { createAwsProviderModule } from '../helpers/aws-provider.js';
 
 const AUTHORITY_IMPORT = '../../src/core/runtime/deployment-aws-authority.js';
 
@@ -810,8 +814,44 @@ async function loadHarness({
     destroy: documentDestroy,
   };
   jest.unstable_mockModule('@aws-sdk/lib-dynamodb', () => ({
-    DynamoDBDocument: { from: jest.fn(() => documentClient) },
+    DynamoDBDocument: Object.assign(jest.fn(), {
+      from: jest.fn(() => documentClient),
+    }),
   }));
+
+  const [
+    clientDynamoDB,
+    clientEC2,
+    clientIAM,
+    clientS3,
+    clientSSM,
+    clientSTS,
+    credentialProviders,
+    libDynamoDB,
+    { registerAwsProviderModule },
+  ] = await Promise.all([
+    import('@aws-sdk/client-dynamodb'),
+    import('@aws-sdk/client-ec2'),
+    import('@aws-sdk/client-iam'),
+    import('@aws-sdk/client-s3'),
+    import('@aws-sdk/client-ssm'),
+    import('@aws-sdk/client-sts'),
+    import('@aws-sdk/credential-providers'),
+    import('@aws-sdk/lib-dynamodb'),
+    import('../../src/core/runtime/aws-provider-module.js'),
+  ]);
+  registerAwsProviderModule(
+    createAwsProviderModule({
+      clientDynamoDB,
+      clientEC2,
+      clientIAM,
+      clientS3,
+      clientSSM,
+      clientSTS,
+      credentialProviders,
+      libDynamoDB,
+    }),
+  );
 
   const authorityModule = await import(AUTHORITY_IMPORT);
   return {

--- a/test/runtime/deployment-aws-host-client-family.test.js
+++ b/test/runtime/deployment-aws-host-client-family.test.js
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { EventEmitter } from 'node:events';
 import { Readable } from 'node:stream';
 
+import { createAwsProviderModule } from '../helpers/aws-provider.js';
+
 import { getAwsSingleNodeHostActivationIntentId } from '../../src/core/runtime/deployment-aws-host-activation.js';
 import { createAwsSingleNodeHostActivationRequest } from '../../src/core/runtime/deployment-aws-host-agent-contract.js';
 import { createAwsSingleNodeHostActivationAuthorityRecord } from '../../src/core/runtime/deployment-aws-host-activation-authority-contract.js';
@@ -46,6 +48,9 @@ const documentClientFrom = jest.fn();
 const S3Client = jest.fn();
 /** @type {jest.Mock<(input: AnyRecord) => AnyRecord>} */
 const GetObjectCommand = jest.fn();
+const DynamoDBDocumentClient = Object.assign(jest.fn(), {
+  from: documentClientFrom,
+});
 
 /** @type {AnyRecord[]} */
 let rawClients;
@@ -108,13 +113,24 @@ jest.unstable_mockModule('@aws-sdk/client-dynamodb', () => ({
   DynamoDBClient,
 }));
 jest.unstable_mockModule('@aws-sdk/lib-dynamodb', () => ({
-  DynamoDBDocumentClient: Object.freeze({ from: documentClientFrom }),
+  DynamoDBDocumentClient,
   GetCommand,
 }));
 jest.unstable_mockModule('@aws-sdk/client-s3', () => ({
   GetObjectCommand,
   S3Client,
 }));
+
+const { registerAwsProviderModule } =
+  await import('../../src/core/runtime/aws-provider-module.js');
+registerAwsProviderModule(
+  createAwsProviderModule({
+    clientDynamoDB: { DynamoDBClient },
+    clientS3: { GetObjectCommand, S3Client },
+    clientSTS: { GetCallerIdentityCommand, STSClient },
+    libDynamoDB: { DynamoDBDocumentClient, GetCommand },
+  }),
+);
 
 const {
   AwsSingleNodeHostArtifactReadError,

--- a/test/runtime/packaged-app-provider-boundary.test.js
+++ b/test/runtime/packaged-app-provider-boundary.test.js
@@ -1,0 +1,73 @@
+/* eslint-env jest */
+/* eslint-disable jsdoc/require-jsdoc */
+
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { runPackagedApp } from '../../src/core/resources/builds/packaged-app-entry.js';
+
+const originalEnvironment = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnvironment };
+  jest.restoreAllMocks();
+});
+
+describe('packaged AWS provider admission', () => {
+  it.each(['plan', 'apply', 'inspect', 'reconcile', 'destroy'])(
+    'fails deployment %s before runtime preparation or dispatch',
+    async (operation) => {
+      const providerError = new Error('provider unavailable');
+      const requireAwsProvider = jest.fn(async () => {
+        throw providerError;
+      });
+      const prepareRuntime = jest.fn(async () => undefined);
+      const dispatch = jest.fn(async () => undefined);
+      delete process.env.WHARFIE_RUNTIME_COMMAND;
+
+      await expect(
+        runPackagedApp({
+          argv: ['node', 'wharfie-app', 'wharfie', 'deployment', operation],
+          prepareRuntime,
+          requireAwsProvider,
+          runtimeModules: { operatorCli: dispatch },
+        }),
+      ).rejects.toBe(providerError);
+
+      expect(requireAwsProvider).toHaveBeenCalledTimes(1);
+      expect(prepareRuntime).not.toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ['parent help', ['deployment', '--help']],
+    ['leaf help', ['deployment', 'inspect', '--help']],
+    ['short leaf help', ['deployment', 'inspect', '-h']],
+    ['omitted leaf', ['deployment']],
+  ])('keeps packaged deployment %s provider-free', async (_label, args) => {
+    const requireAwsProvider = jest.fn(async () => {
+      throw new Error('help must not load the provider');
+    });
+    const prepareRuntime = jest.fn(async () => undefined);
+    const dispatch = jest.fn(
+      /** @param {string[]} _argv @param {unknown} _context */ async (
+        _argv,
+        _context,
+      ) => undefined,
+    );
+    delete process.env.WHARFIE_RUNTIME_COMMAND;
+
+    await runPackagedApp({
+      argv: ['node', 'wharfie-app', 'wharfie', ...args],
+      prepareRuntime,
+      requireAwsProvider,
+      runtimeModules: { operatorCli: dispatch },
+    });
+
+    expect(requireAwsProvider).not.toHaveBeenCalled();
+    expect(prepareRuntime).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(['node', 'wharfie-app', ...args], {
+      loadDeveloperCliModule: undefined,
+    });
+  });
+});

--- a/test/runtime/resources/sea-build.test.js
+++ b/test/runtime/resources/sea-build.test.js
@@ -299,7 +299,7 @@ describe('SeaBuild', () => {
     }
   });
 
-  it('resolves entryCode once and uses the same captured string for bundling and evidence', async () => {
+  it('resolves entryCode once and records the provider-prepared string handed to bundling', async () => {
     jest.unstable_mockModule(CHILD_PROCESS_IMPORT, () => ({
       execFile: jest.fn(),
       spawn: jest.fn(),
@@ -318,7 +318,19 @@ describe('SeaBuild', () => {
       path.join(os.tmpdir(), 'wharfie-sea-entry-capture-'),
     );
     const sourceBinary = path.join(tmpRoot, 'source-node');
-    const capturedEntry = 'process.stdout.write("captured");\n';
+    const capturedEntry = [
+      'import runtimeOperatorCli from \x27./operator.js\x27;',
+      'const ledgerServiceCmd = {};',
+      'async function runPackagedApp() {}',
+      '(async () => {',
+      '  await runPackagedApp({',
+      '    runtimeModules: {',
+      '      operatorCli: runtimeOperatorCli,',
+      '      \x27ledger-service\x27: ledgerServiceCmd,',
+      '    },',
+      '  });',
+      '})();',
+    ].join('\n');
     const resolveEntryCode = jest.fn(() => capturedEntry);
     await fsp.writeFile(sourceBinary, 'node-binary', 'utf8');
     SeaBuild.BUILD_DIR = path.join(tmpRoot, 'builds');
@@ -347,8 +359,18 @@ describe('SeaBuild', () => {
       const evidence = build.getSuccessfulBuildEvidence(artifactBytes);
 
       expect(resolveEntryCode).toHaveBeenCalledTimes(1);
-      expect(esbuild).toHaveBeenCalledWith(expect.any(String), capturedEntry);
-      expect(evidence.entryCode).toEqual(evidenceFor(capturedEntry));
+      const transformedEntry = esbuild.mock.calls[0]?.[1];
+      if (typeof transformedEntry !== 'string') {
+        throw new TypeError('Expected the prepared entry handed to esbuild.');
+      }
+      expect(transformedEntry).not.toBe(capturedEntry);
+      expect(transformedEntry).toContain('wharfieEmbeddedAwsProvider');
+      expect(transformedEntry).toContain('registerWharfieEmbeddedAwsProvider');
+      expect(esbuild).toHaveBeenCalledWith(
+        expect.any(String),
+        transformedEntry,
+      );
+      expect(evidence.entryCode).toEqual(evidenceFor(transformedEntry));
     } finally {
       SeaBuild.BUILD_DIR = originalBuildDir;
       SeaBuild.BINARIES_DIR = originalBinariesDir;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "src/core/**/*.js",
     "src/cli/**/*.js",
     "examples/**/*.js",
+    "packages/aws/**/*.js",
     "scripts/aws-host-retained-storage-host-preflight.js",
     "scripts/aws-host-retained-storage-host-preflight-sea-artifact-record.js",
     "scripts/aws-host-retained-storage-host-preflight-sea-build.js",
@@ -38,6 +39,8 @@
     "scripts/sea-inspector.js",
     "scripts/verify-package-contents.js",
     "scripts/verify-magnetic-first-run.js",
+    "scripts/verify-provider-boundary.js",
+    "scripts/verify-provider-free-sea.js",
     "types/**/*.d.ts"
   ],
   "exclude": [


### PR DESCRIPTION
Closes #141

## Outcome

- moves the AWS SDK and Smithy graph into the exact-version `@wharfie/aws` companion
- keeps source and packaged deployment behavior behind one narrow, versioned AWS boundary
- seals provider-free application SEAs at build time, so a later sibling package cannot change the artifact's capability
- fails every deployment leaf before local preparation or provider mutation when AWS support is unavailable
- records and enforces the canonical hello-world install footprint in CI
- preserves the compact starter, durable terminate/resume path, and retained output

## First-run footprint

The original provider-loaded path was approximately 205 packages / 139 MiB. The clean hosted-Linux canonical starter now installs:

- 160 dependency package directories
- 83,315,429 logical file bytes (~79.5 MiB)
- zero `@aws-sdk/*` or `@smithy/*` packages

CI enforces budgets of 170 packages and 85 MiB logical bytes.

## Evidence

- all four checked-JS/type configurations pass
- 6 focused suites / 53 provider-boundary tests pass
- package tarball verification passes (310 files)
- independent real-SEA audits passed for both sealed provider-free and embedded-provider relocation
- exact Node 24.13.1/npm 11.12.0 lock installation succeeds
- the clean registry-backed provider and magnetic scripts are mandatory hosted CI gates
